### PR TITLE
Multi-core upload

### DIFF
--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -528,7 +528,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
         // called.
         @Override
         protected void initialize() {
-            requestMtu(515)
+            requestMtu(498)
                     .with((device, mtu) -> mMaxPacketLength = Math.max(mtu - 3, mMaxPacketLength))
                     .fail((device, status) -> {
                         log(Log.INFO, "Failed to negotiate MTU, disconnecting,");

--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -305,7 +305,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                         public void send(@NonNull byte[] data) {
                             if (mLoggingEnabled) {
                                 try {
-                                    log(Log.VERBOSE, "Sending (" + payload.length + " bytes) "
+                                    log(Log.INFO, "Sending (" + payload.length + " bytes) "
                                             + McuMgrHeader.fromBytes(payload).toString() + " CBOR "
                                             + CBOR.toString(payload, McuMgrHeader.HEADER_LENGTH));
                                 } catch (Exception e) {
@@ -544,7 +544,6 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
         // Registered as a callback for all notifications from the SMP characteristic.
         // Forwards the merged data packets to the protocol layer to be matched to a request.
         private final DataReceivedCallback mAsyncNotificationCallback = new DataReceivedCallback() {
-
             @Override
             public void onDataReceived(@NonNull BluetoothDevice device, @NonNull Data data) {
                 byte[] bytes = data.getValue();

--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -391,7 +391,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                             break;
                     }
                 })
-        .retry(3, 100)
+        .retry(3, 500)
         .enqueue();
     }
 
@@ -404,7 +404,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
             return;
         }
         connect(mDevice)
-                .retry(3, 100)
+                .retry(3, 500)
                 .done(device -> {
                     notifyConnected();
                     if (callback == null) {
@@ -476,7 +476,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                 McuMgrBleTransport.super.requestConnectionPriority(priority).enqueue();
             } // else ignore... :(
         })
-        .retry(3, 100)
+        .retry(3, 500)
         .enqueue();
     }
 

--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/callback/SmpProtocolSession.kt
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/callback/SmpProtocolSession.kt
@@ -83,9 +83,7 @@ internal class SmpProtocolSession(
      * Consumes messages off the tx channel until the channel is closed.
      */
     private suspend fun writer() {
-
         txChannel.consumeEach { outgoing ->
-
             // Set sequence number in outgoing data
             val sequenceNumber = sequenceCounter.getAndRotate()
             outgoing.data.setSequenceNumber(sequenceNumber)
@@ -98,7 +96,7 @@ internal class SmpProtocolSession(
             outgoing.transaction.send(handler, outgoing.data)
 
             scope.launch {
-                delay(10000)
+                delay(30000)
                 val transaction = getAndSetTransaction(sequenceNumber, null)
                 transaction?.onFailure(handler, TransactionTimeoutException(sequenceNumber))
             }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
@@ -254,7 +254,7 @@ public abstract class McuManager {
      * @param callback the response callback.
      * @param <T>      the response type.
      */
-    public <T extends McuMgrResponse> void send(@NotNull byte[] data, @NotNull Class<T> respType,
+    public <T extends McuMgrResponse> void send(byte @NotNull [] data, @NotNull Class<T> respType,
                                                 @NotNull McuMgrCallback<T> callback) {
         mTransporter.send(data, respType, callback);
     }
@@ -269,7 +269,7 @@ public abstract class McuManager {
      * @throws McuMgrException when an error occurs while sending the data.
      */
     @NotNull
-    public <T extends McuMgrResponse> T send(@NotNull byte[] data, @NotNull Class<T> respType)
+    public <T extends McuMgrResponse> T send(byte @NotNull [] data, @NotNull Class<T> respType)
             throws McuMgrException {
         return mTransporter.send(data, respType);
     }
@@ -287,10 +287,9 @@ public abstract class McuManager {
      * @return The packet data.
      * @throws McuMgrException if the payload map could not be serialized into CBOR. See cause.
      */
-    @NotNull
-    public static byte[] buildPacket(@NotNull McuMgrScheme scheme, int op, int flags, int groupId,
-                                     int sequenceNum, int commandId,
-                                     @Nullable Map<String, Object> payloadMap)
+    public static byte @NotNull [] buildPacket(@NotNull McuMgrScheme scheme, int op, int flags, int groupId,
+                                               int sequenceNum, int commandId,
+                                               @Nullable Map<String, Object> payloadMap)
             throws McuMgrException {
         byte[] packet;
         try {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/McuMgrErrorCode.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/McuMgrErrorCode.java
@@ -58,7 +58,7 @@ public enum McuMgrErrorCode {
     NOT_SUPPORTED(8),
     PER_USER(256);
 
-    private int mCode;
+    private final int mCode;
 
     McuMgrErrorCode(int code) {
         mCode = code;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/McuMgrHeader.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/McuMgrHeader.java
@@ -39,8 +39,7 @@ public class McuMgrHeader {
         mCommandId = commandId;
     }
 
-    @NotNull
-    public byte[] toBytes() {
+    public byte @NotNull [] toBytes() {
         return build(mOp, mFlags, mLen, mGroupId, mSequenceNum, mCommandId);
     }
 
@@ -108,7 +107,7 @@ public class McuMgrHeader {
      * @throws IllegalArgumentException when the byte array length is less than 8 bytes
      */
     @NotNull
-    public static McuMgrHeader fromBytes(@NotNull byte[] header) {
+    public static McuMgrHeader fromBytes(byte @NotNull [] header) {
         if (header.length < HEADER_LENGTH) {
             throw new IllegalArgumentException("Failed to parse mcumgr header from bytes; too short - length=" + header.length);
         }
@@ -135,8 +134,7 @@ public class McuMgrHeader {
      * @param id       the sub-command ID for certain groups.
      * @return The built newt manager header.
      */
-    @NotNull
-    public static byte[] build(int op, int flags, int len, int group, int sequence, int id) {
+    public static byte @NotNull [] build(int op, int flags, int len, int group, int sequence, int id) {
         return new byte[]{
                 (byte) op,
                 (byte) flags,

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/McuMgrTransport.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/McuMgrTransport.java
@@ -86,7 +86,7 @@ public interface McuMgrTransport {
      * @throws McuMgrException thrown on error. Set the cause of the error if caused by a different
      *                         type of exception.
      */
-    @NotNull <T extends McuMgrResponse> T send(@NotNull byte[] payload, @NotNull Class<T> responseType)
+    @NotNull <T extends McuMgrResponse> T send(byte @NotNull [] payload, @NotNull Class<T> responseType)
             throws McuMgrException;
 
     /**
@@ -99,7 +99,7 @@ public interface McuMgrTransport {
      * @param callback     the callback to call on response or error.
      * @param <T>          the response type.
      */
-    <T extends McuMgrResponse> void send(@NotNull byte[] payload, @NotNull Class<T> responseType,
+    <T extends McuMgrResponse> void send(byte @NotNull [] payload, @NotNull Class<T> responseType,
                                          @NotNull McuMgrCallback<T> callback);
 
     /**

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/crash/CoreDump.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/crash/CoreDump.java
@@ -18,8 +18,8 @@ public class CoreDump {
     protected static final int TLV_TYPE_MEM   = 2;
     protected static final int TLV_TYPE_REG   = 3;
 
-    private CoreDumpHeader mHeader;
-    private CoreDumpTlv mTlv;
+    private final CoreDumpHeader mHeader;
+    private final CoreDumpTlv mTlv;
 
     public CoreDump(@NotNull CoreDumpHeader header, @NotNull CoreDumpTlv tlv) {
         mHeader = header;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/crash/CoreDump.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/crash/CoreDump.java
@@ -34,7 +34,7 @@ public class CoreDump {
      * @throws IOException if the core dump is invalid.
      */
     @NotNull
-    public static CoreDump fromBytes(@NotNull byte[] data) throws IOException {
+    public static CoreDump fromBytes(byte @NotNull [] data) throws IOException {
         CoreDumpHeader header = CoreDumpHeader.fromBytes(data);
         CoreDumpTlv tlv = CoreDumpTlv.fromBytes(data);
         return new CoreDump(header, tlv);
@@ -45,8 +45,7 @@ public class CoreDump {
      *
      * @return the image hash, or null if not found in the TLV.
      */
-    @Nullable
-    public byte[] getImageHash() {
+    public byte @Nullable [] getImageHash() {
         CoreDumpTlvEntry entry = mTlv.getEntryOfType(TLV_TYPE_IMAGE);
         if (entry == null) {
             return null;
@@ -59,8 +58,7 @@ public class CoreDump {
      *
      * @return the registers, or null if not found in the TLV.
      */
-    @Nullable
-    public byte[] getRegisters() {
+    public byte @Nullable [] getRegisters() {
         CoreDumpTlvEntry entry = mTlv.getEntryOfType(TLV_TYPE_REG);
         if (entry == null) {
             return null;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/crash/CoreDumpHeader.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/crash/CoreDumpHeader.java
@@ -16,8 +16,8 @@ public class CoreDumpHeader {
 
     private static final int OFFSET = 0;
 
-    private int mMagic;
-    private int mSize;
+    private final int mMagic;
+    private final int mSize;
 
     public CoreDumpHeader(int magic, int size) {
         mMagic = magic;
@@ -31,7 +31,7 @@ public class CoreDumpHeader {
      * @throws IOException If the magic number was invalid.
      */
     @NotNull
-    public static CoreDumpHeader fromBytes(@NotNull byte[] data) throws IOException {
+    public static CoreDumpHeader fromBytes(byte @NotNull [] data) throws IOException {
         return fromBytes(data, OFFSET);
     }
 
@@ -43,7 +43,7 @@ public class CoreDumpHeader {
      * @throws IOException If the magic number was invalid.
      */
     @NotNull
-    public static CoreDumpHeader fromBytes(@NotNull byte[] data, int offset) throws IOException {
+    public static CoreDumpHeader fromBytes(byte @NotNull [] data, int offset) throws IOException {
         int magic = ByteUtil.byteArrayToUnsignedInt(data, offset, Endian.LITTLE, 4);
         if (magic != CoreDump.MAGIC) {
             throw new IOException("Illegal magic number: actual=" +

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/crash/CoreDumpTlv.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/crash/CoreDumpTlv.java
@@ -29,7 +29,7 @@ public class CoreDumpTlv {
      * @throws IOException If parsing TLV entries encountered an error.
      */
     @NotNull
-    public static CoreDumpTlv fromBytes(@NotNull byte[] data) throws IOException {
+    public static CoreDumpTlv fromBytes(byte @NotNull [] data) throws IOException {
         return fromBytes(data, OFFSET);
     }
 
@@ -41,7 +41,7 @@ public class CoreDumpTlv {
      * @throws IOException If parsing TLV entries encountered an error.
      */
     @NotNull
-    public static CoreDumpTlv fromBytes(@NotNull byte[] data, int offset) throws IOException {
+    public static CoreDumpTlv fromBytes(byte @NotNull [] data, int offset) throws IOException {
         List<CoreDumpTlvEntry> entries = new ArrayList<>();
         while (offset < data.length) {
             CoreDumpTlvEntry entry = CoreDumpTlvEntry.fromBytes(data, offset);

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/crash/CoreDumpTlv.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/crash/CoreDumpTlv.java
@@ -16,7 +16,7 @@ public class CoreDumpTlv {
     private static final int OFFSET = 8;
 
     @NotNull
-    private List<CoreDumpTlvEntry> mEntries;
+    private final List<CoreDumpTlvEntry> mEntries;
 
     public CoreDumpTlv(@NotNull List<CoreDumpTlvEntry> entries) {
         mEntries = entries;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/crash/CoreDumpTlvEntry.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/crash/CoreDumpTlvEntry.java
@@ -24,11 +24,9 @@ public class CoreDumpTlvEntry {
     private final int mType;      // uint8_t
     private final int mLength;    // uint16_t
     private final long mOff;      // uint32_t
+    private final byte @NotNull [] mValue;
 
-    @NotNull
-    private final byte[] mValue;
-
-    public CoreDumpTlvEntry(int type, int length, long off, @NotNull byte[] value) {
+    public CoreDumpTlvEntry(int type, int length, long off, byte @NotNull [] value) {
         mType = type;
         mLength = length;
         mOff = off;
@@ -47,8 +45,7 @@ public class CoreDumpTlvEntry {
         return mOff;
     }
 
-    @NotNull
-    public byte[] getValue() {
+    public byte @NotNull [] getValue() {
         return mValue;
     }
 
@@ -57,7 +54,7 @@ public class CoreDumpTlvEntry {
     }
 
     @NotNull
-    public static CoreDumpTlvEntry fromBytes(@NotNull byte[] data, int offset) throws IOException {
+    public static CoreDumpTlvEntry fromBytes(byte @NotNull [] data, int offset) throws IOException {
         if (offset + MIN_SIZE > data.length) {
             throw new IOException("Insufficient data. TLV entry requires at least 8 bytes. " +
                     "(length=" + data.length +

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/crash/CoreDumpTlvEntry.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/crash/CoreDumpTlvEntry.java
@@ -21,12 +21,12 @@ public class CoreDumpTlvEntry {
 
     private static final int MIN_SIZE = 8;
 
-    private int mType;      // uint8_t
-    private int mLength;    // uint16_t
-    private long mOff;      // uint32_t
+    private final int mType;      // uint8_t
+    private final int mLength;    // uint16_t
+    private final long mOff;      // uint32_t
 
     @NotNull
-    private byte[] mValue;
+    private final byte[] mValue;
 
     public CoreDumpTlvEntry(int type, int length, long off, @NotNull byte[] value) {
         mType = type;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
@@ -295,6 +295,13 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
     /**
      * A window capacity > 1 enables a faster image upload implementation which allows
      * {@code windowCapacity} concurrent upload requests.
+     * <p>
+     * <b>Note: </b>This feature is in alpha mode and causes problems if the target device is not
+     * compatible. Also, pause and resume will throw an exception when window upload is used.
+     * Packets are sent one after another, without waiting for a notification confirming number
+     * of bytes received. As each packet is identified by SEQ number, the received notifications
+     * should match those SEQ. If the notifications report current offset, not one sent with given
+     * SEQ, the reported progress jumps back and forth. In that case use default window capacity 1.
      *
      * @param windowCapacity the maximum number of concurrent upload requests at any time.
      */
@@ -353,7 +360,7 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
             .setEstimatedSwapTime(mEstimatedSwapTime)
             .setWindowCapacity(mWindowCapacity)
             .build();
-        mPerformer.start(mMode, mcuMgrImages, settings);
+        mPerformer.start(settings, mMode, mcuMgrImages);
     }
 
     //******************************************************************

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
@@ -282,7 +282,7 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      * The manager will try to connect to the SMP server on the new firmware and confirm
      * the upload.
      */
-    public synchronized void start(@NotNull byte[] imageData) throws McuMgrException {
+    public synchronized void start(byte @NotNull [] imageData) throws McuMgrException {
         if (mState != State.NONE) {
             LOG.info("Firmware upgrade is already in progress");
             return;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
@@ -2,31 +2,21 @@ package io.runtime.mcumgr.dfu;
 
 import android.os.Handler;
 import android.os.Looper;
-import android.os.SystemClock;
+import android.util.Pair;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Executor;
 
-import io.runtime.mcumgr.McuMgrCallback;
-import io.runtime.mcumgr.McuMgrScheme;
 import io.runtime.mcumgr.McuMgrTransport;
-import io.runtime.mcumgr.exception.McuMgrErrorException;
 import io.runtime.mcumgr.exception.McuMgrException;
-import io.runtime.mcumgr.exception.McuMgrTimeoutException;
 import io.runtime.mcumgr.image.McuMgrImage;
-import io.runtime.mcumgr.managers.DefaultManager;
-import io.runtime.mcumgr.managers.ImageManager;
-import io.runtime.mcumgr.response.McuMgrResponse;
-import io.runtime.mcumgr.response.img.McuMgrImageStateResponse;
-import io.runtime.mcumgr.transfer.TransferController;
-import io.runtime.mcumgr.transfer.UploadCallback;
-
-import static io.runtime.mcumgr.transfer.ImageUploaderKt.windowUpload;
 
 // TODO Add retries for each step
 
@@ -50,6 +40,23 @@ import static io.runtime.mcumgr.transfer.ImageUploaderKt.windowUpload;
 public class FirmwareUpgradeManager implements FirmwareUpgradeController {
 
     private final static Logger LOG = LoggerFactory.getLogger(FirmwareUpgradeManager.class);
+
+    //******************************************************************
+    // Firmware Upgrade State
+    //******************************************************************
+
+    public enum State {
+        NONE, VALIDATE, UPLOAD, TEST, RESET, CONFIRM, SUCCESS;
+
+        public boolean isInProgress() {
+            return this == VALIDATE || this == UPLOAD || this == TEST ||
+                    this == RESET || this == CONFIRM;
+        }
+    }
+
+    //******************************************************************
+    // Firmware Upgrade Mode
+    //******************************************************************
 
     public enum Mode {
         /**
@@ -80,20 +87,70 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
         TEST_AND_CONFIRM
     }
 
-    /**
-     * Performs the image upload, test, and confirmation steps.
-     */
-    private final ImageManager mImageManager;
+    //******************************************************************
+    // Firmware Upgrade Mode
+    //******************************************************************
 
-    /**
-     * Performs the reset command.
-     */
-    private final DefaultManager mDefaultManager;
+    public static class Settings {
+        @NotNull
+        public final McuMgrTransport transport;
 
-    /**
-     * Upload controller used to pause, resume, and cancel upload. Set when the upload is started.
-     */
-    private TransferController mUploadController;
+        /**
+         * Estimated time required for swapping images, in milliseconds.
+         * If the mode is set to {@link FirmwareUpgradeManager.Mode#TEST_AND_CONFIRM}, the manager will try to reconnect after
+         * this time. 0 by default.
+         */
+        public final int estimatedSwapTime;
+
+        /**
+         * The upload window capacity for faster image uploads. A capacity greater than 1 will enable
+         * using the faster window upload implementation.
+         */
+        public final int windowCapacity;
+
+        private Settings(@NotNull final McuMgrTransport transport,
+                         final int estimatedSwapTime,
+                         final int windowCapacity) {
+            this.transport = transport;
+            this.estimatedSwapTime = estimatedSwapTime;
+            this.windowCapacity = windowCapacity;
+        }
+
+        public static class Builder {
+            @NotNull
+            private final McuMgrTransport transport;
+            private int estimatedSwapTime = 0;
+            private int windowCapacity = 1;
+
+            public Builder(@NotNull final McuMgrTransport transport) {
+                this.transport = transport;
+            }
+
+            public Builder setEstimatedSwapTime(final int time) {
+                this.estimatedSwapTime = Math.max(0, time);
+                return this;
+            }
+
+            public Builder setWindowCapacity(final int windowCapacity) {
+                this.windowCapacity = Math.max(0, windowCapacity);
+                return this;
+            }
+
+            public Settings build() {
+                return new Settings(transport, estimatedSwapTime, windowCapacity);
+            }
+        }
+    }
+
+    //******************************************************************
+    // Properties
+    //******************************************************************
+
+    @NotNull
+    private final FirmwareUpgradePerformer mPerformer;
+
+    @NotNull
+    private final McuMgrTransport mTransport;
 
     /**
      * Firmware upgrade callback passed into the constructor or set before the upload has started.
@@ -101,29 +158,9 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
     private FirmwareUpgradeCallback mCallback;
 
     /**
-     * Image data to upload.
-     */
-    private byte[] mImageData;
-
-    /**
-     * Hash of the image data.
-     */
-    private byte[] mHash;
-
-    /**
      * The manager mode. By default the {@link Mode#TEST_AND_CONFIRM} mode is set.
      */
     private Mode mMode = Mode.TEST_AND_CONFIRM;
-
-    /**
-     * State of the firmware upgrade.
-     */
-    private State mState;
-
-    /**
-     * Paused flag.
-     */
-    private boolean mPaused = false;
 
     /**
      * Flag for setting callbacks to run on the main UI thread.
@@ -138,18 +175,14 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
     private int mEstimatedSwapTime = 0;
 
     /**
-     * The timestamp at which the response to Reset command was received.
-     * Assuming that the target device has reset just after sending this response,
-     * the time difference between this moment and receiving disconnection event may be deducted
-     * from the {@link #mEstimatedSwapTime}.
-     */
-    private long mResetResponseTime;
-
-    /**
      * The upload window capacity for faster image uploads. A capacity greater than 1 will enable
      * using the faster window upload implementation.
      */
     private int mWindowCapacity = 1;
+
+    //******************************************************************
+    // Firmware Upgrade Manager API
+    //******************************************************************
 
     /**
      * Construct a firmware upgrade manager. If using this constructor, the callback must be set
@@ -158,7 +191,7 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      *
      * @param transport the transporter to use.
      */
-    public FirmwareUpgradeManager(@NotNull McuMgrTransport transport) {
+    public FirmwareUpgradeManager(@NotNull final McuMgrTransport transport) {
         this(transport, null);
     }
 
@@ -168,12 +201,26 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      * @param transport the transporter to use.
      * @param callback  the callback.
      */
-    public FirmwareUpgradeManager(@NotNull McuMgrTransport transport,
-                                  @Nullable FirmwareUpgradeCallback callback) {
-        mState = State.NONE;
-        mImageManager = new ImageManager(transport);
-        mDefaultManager = new DefaultManager(transport);
+    public FirmwareUpgradeManager(@NotNull final McuMgrTransport transport,
+                                  @Nullable final FirmwareUpgradeCallback callback) {
+        mTransport = transport;
         mCallback = callback;
+        mPerformer = new FirmwareUpgradePerformer(mInternalCallback);
+    }
+
+    /**
+     * Construct a firmware upgrade manager.
+     *
+     * @param settings the upgrade settings.
+     * @param callback the callback.
+     */
+    public FirmwareUpgradeManager(@NotNull final Settings settings,
+                                  @Nullable final FirmwareUpgradeCallback callback) {
+        mTransport = settings.transport;
+        mCallback = callback;
+        mEstimatedSwapTime = settings.estimatedSwapTime;
+        mWindowCapacity = settings.windowCapacity;
+        mPerformer = new FirmwareUpgradePerformer(mInternalCallback);
     }
 
     /**
@@ -183,26 +230,16 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      */
     @NotNull
     public McuMgrTransport getTransporter() {
-        return mImageManager.getTransporter();
+        return mTransport;
     }
 
     /**
-     * Get the transporter's scheme.
+     * Get the current {@link State} of the firmware upgrade.
      *
-     * @return The transporter's scheme.
+     * @return The current state.
      */
-    @NotNull
-    public McuMgrScheme getScheme() {
-        return mImageManager.getScheme();
-    }
-
-    /**
-     * Returns the upload MTU. MTU must be between 20 and 1024.
-     *
-     * @return The MTY.
-     */
-    public synchronized int getMtu() {
-        return mImageManager.getMtu();
+    public State getState() {
+        return mPerformer.getState();
     }
 
     /**
@@ -210,7 +247,7 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      *
      * @param uiThreadCallbacks true if all callbacks should run on the UI thread.
      */
-    public void setCallbackOnUiThread(boolean uiThreadCallbacks) {
+    public void setCallbackOnUiThread(final boolean uiThreadCallbacks) {
         mUiThreadCallbacks = uiThreadCallbacks;
     }
 
@@ -219,7 +256,7 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      *
      * @param callback the callback for receiving status change events.
      */
-    public void setFirmwareUpgradeCallback(@Nullable FirmwareUpgradeCallback callback) {
+    public void setFirmwareUpgradeCallback(@Nullable final FirmwareUpgradeCallback callback) {
         mCallback = callback;
     }
 
@@ -232,8 +269,8 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      * @see Mode#CONFIRM_ONLY CONFIRM_ONLY
      * @see Mode#TEST_AND_CONFIRM TEST_AND_CONFIRM
      */
-    public void setMode(@NotNull Mode mode) {
-        if (mState != State.NONE) {
+    public void setMode(@NotNull final Mode mode) {
+        if (mPerformer.isBusy()) {
             LOG.info("Firmware upgrade is already in progress");
             return;
         }
@@ -247,17 +284,12 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      *
      * @param swapTime estimated time required for swapping images, in milliseconds. 0 by default.
      */
-    public void setEstimatedSwapTime(int swapTime) {
+    public void setEstimatedSwapTime(final int swapTime) {
+        if (mPerformer.isBusy()) {
+            LOG.info("Firmware upgrade is already in progress");
+            return;
+        }
         mEstimatedSwapTime = Math.max(swapTime, 0);
-    }
-
-    /**
-     * Set the MTU of the image upload.
-     *
-     * @param mtu the mtu (Maximum Transfer Unit).
-     */
-    public void setUploadMtu(int mtu) {
-        mImageManager.setUploadMtu(mtu);
     }
 
     /**
@@ -266,9 +298,13 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      *
      * @param windowCapacity the maximum number of concurrent upload requests at any time.
      */
-    public void setWindowUploadCapacity(int windowCapacity) {
+    public void setWindowUploadCapacity(final int windowCapacity) {
         if (windowCapacity <= 0) {
             throw new IllegalArgumentException("window capacity must be > 0");
+        }
+        if (mPerformer.isBusy()) {
+            LOG.info("Firmware upgrade is already in progress");
+            return;
         }
         mWindowCapacity = windowCapacity;
     }
@@ -277,23 +313,47 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      * Start the upgrade.
      * <p>
      * The specified image file will be sent to the target using the
-     * given transport, then verified using test command. If test successful, the reset
-     * command will be sent. The device should boot with the new firmware.
-     * The manager will try to connect to the SMP server on the new firmware and confirm
-     * the upload.
+     * given transport, then depending on the mode, verified using "test" command or confirmed
+     * using "confirm" command. If successful, the reset command will be sent. The device should
+     * boot with the new firmware.  The manager will try to connect to the SMP server on the new
+     * firmware and confirm the new images if they were not confirmed before, or they didn't confirm
+     * automatically.
      */
-    public synchronized void start(byte @NotNull [] imageData) throws McuMgrException {
-        if (mState != State.NONE) {
+    public synchronized void start(final byte @NotNull [] imageData) throws McuMgrException {
+        final Pair<Integer, byte[]> image = new Pair<>(0, imageData);
+        start(Collections.singletonList(image));
+    }
+
+    /**
+     * Start the upgrade for multi-core devices. Each image is paired with image partition identifier.
+     * E.g. image 0 is the main, application core. Image 1 is the next core, e.g network core, etc.
+     * <p>
+     * The specified image files will be sent to the target to image partitions identified
+     * by the Integer parameter paired with each image using the transport specified for the manager,
+     * then, depending on the mode, verified using "test" command or confirmed using "confirm"
+     * command. If successful, the reset command will be sent. The device should boot with the
+     * new firmware.  The manager will try to connect to the SMP server on the new firmware and
+     * confirm the new images if they were not confirmed before, or they didn't confirm
+     * automatically.
+     */
+    public synchronized void start(@NotNull final List<Pair<Integer, byte[]>> images) throws McuMgrException {
+        if (mPerformer.isBusy()) {
             LOG.info("Firmware upgrade is already in progress");
             return;
         }
-        // Set image and validate
-        mImageData = imageData;
-        mHash = McuMgrImage.getHash(imageData);
+        // Store images to be sent.
+        final List<Pair<Integer, McuMgrImage>> mcuMgrImages = new ArrayList<>(images.size());
+        for (final Pair<Integer, byte[]> image: images) {
+            mcuMgrImages.add(new Pair<>(image.first, McuMgrImage.fromBytes(image.second)));
+        }
 
-        // Begin the upload
+        // Start upgrade.
         mInternalCallback.onUpgradeStarted(this);
-        validate();
+        final Settings settings = new Settings.Builder(mTransport)
+            .setEstimatedSwapTime(mEstimatedSwapTime)
+            .setWindowCapacity(mWindowCapacity)
+            .build();
+        mPerformer.start(mMode, mcuMgrImages, settings);
     }
 
     //******************************************************************
@@ -302,563 +362,28 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
 
     @Override
     public synchronized void cancel() {
-        if (mState == State.VALIDATE) {
-            mState = State.NONE;
-            mPaused = false;
-        } else if (mState == State.UPLOAD) {
-            mUploadController.cancel();
-            mPaused = false;
-        }
+        mPerformer.cancel();
     }
 
     @Override
     public synchronized void pause() {
-        if (mState.isInProgress()) {
-            mPaused = true;
-            if (mState == State.UPLOAD) {
-                mUploadController.pause();
-            }
-        }
+        mPerformer.pause();
     }
 
     @Override
     public synchronized void resume() {
-        if (mPaused) {
-            mPaused = false;
-            currentState();
-        }
+        mPerformer.resume();
     }
 
     @Override
     public synchronized boolean isPaused() {
-        return mPaused;
+        return mPerformer.isPaused();
     }
 
     @Override
     public synchronized boolean isInProgress() {
-        return mState.isInProgress() && !isPaused();
+        return mPerformer.isBusy() && !isPaused();
     }
-
-    //******************************************************************
-    // Implementation
-    //******************************************************************
-
-    private synchronized void setState(State newState) {
-        State prevState = mState;
-        mState = newState;
-        if (newState != prevState) {
-            LOG.trace("Moving from state {} to state {}", prevState.name(), newState.name());
-            mInternalCallback.onStateChanged(prevState, newState);
-        }
-    }
-
-    private synchronized void validate() {
-        setState(State.VALIDATE);
-        if (!mPaused) {
-            mImageManager.list(mImageValidateCallback);
-        }
-    }
-
-    private synchronized void upload() {
-        setState(State.UPLOAD);
-        if (!mPaused) {
-            if (mWindowCapacity > 1) {
-                mUploadController = windowUpload(mImageManager, mImageData, mWindowCapacity,
-                        mImageUploadCallback);
-            } else {
-                mUploadController = mImageManager.imageUpload(mImageData, mImageUploadCallback);
-            }
-        }
-    }
-
-    private synchronized void test() {
-        setState(State.TEST);
-        if (!mPaused) {
-            mImageManager.test(mHash, mTestCallback);
-        }
-    }
-
-    private synchronized void confirm() {
-        setState(State.CONFIRM);
-        if (!mPaused) {
-            mImageManager.confirm(mHash, mConfirmCallback);
-        }
-    }
-
-    private synchronized void verify() {
-        setState(State.CONFIRM);
-        if (!mPaused) {
-            mImageManager.confirm(null, mConfirmCallback);
-        }
-    }
-
-    private synchronized void reset() {
-        setState(State.RESET);
-        if (!mPaused) {
-            mDefaultManager.getTransporter().addObserver(mResetObserver);
-            mDefaultManager.reset(mResetCallback);
-        }
-    }
-
-    private synchronized void success() {
-        mState = State.NONE;
-        mPaused = false;
-        mInternalCallback.onUpgradeCompleted();
-    }
-
-    private synchronized void fail(McuMgrException error) {
-        State failedState = mState;
-        mState = State.NONE;
-        mPaused = false;
-        mInternalCallback.onUpgradeFailed(failedState, error);
-    }
-
-    private synchronized void cancelled(State state) {
-        LOG.trace("Upgrade cancelled");
-        mState = State.NONE;
-        mPaused = false;
-        mInternalCallback.onUpgradeCanceled(state);
-    }
-
-    //******************************************************************
-    // McuManagerCallbacks
-    //******************************************************************
-
-    /**
-     * State: VALIDATE.
-     * Callback for the list command.
-     */
-    private final McuMgrCallback<McuMgrImageStateResponse> mImageValidateCallback = new McuMgrCallback<McuMgrImageStateResponse>() {
-        @Override
-        public void onResponse(@NotNull final McuMgrImageStateResponse response) {
-            LOG.trace("Validation response: {}", response.toString());
-
-            // Check for an error return code
-            if (!response.isSuccess()) {
-                fail(new McuMgrErrorException(response.getReturnCode()));
-                return;
-            }
-
-            if (mState == State.NONE) {
-                cancelled(State.VALIDATE);
-                return;
-            }
-
-            McuMgrImageStateResponse.ImageSlot[] images = response.images;
-            if (images == null) {
-                LOG.error("Missing images information: {}", response.toString());
-                fail(new McuMgrException("Missing images information"));
-                return;
-            }
-
-            // Check if the new firmware is different than the active one.
-            if (images.length > 0 && Arrays.equals(mHash, images[0].hash)) {
-                if (images[0].confirmed) {
-                    // The new firmware is already active and confirmed.
-                    // No need to do anything.
-                    success();
-                } else {
-                    // The new firmware is in test mode.
-                    switch (mMode) {
-                        case CONFIRM_ONLY:
-                        case TEST_AND_CONFIRM:
-                            // We have to confirm it.
-                            confirm();
-                            break;
-                        case TEST_ONLY:
-                            // Nothing to be done.
-                            success();
-                            break;
-                    }
-                }
-                return;
-            }
-
-            // If the image in slot 1 is confirmed, we wont be able to erase or upload the image.
-            // Therefore we must confirm the image in slot 0 and revalidate the image state.
-            if (images.length > 1 && images[1].confirmed) {
-                mImageManager.confirm(images[0].hash, new McuMgrCallback<McuMgrImageStateResponse>() {
-                    @Override
-                    public void onResponse(@NotNull McuMgrImageStateResponse response) {
-                        if (!response.isSuccess()) {
-                            fail(new McuMgrErrorException(response.getReturnCode()));
-                            return;
-                        }
-                        validate();
-                    }
-
-                    @Override
-                    public void onError(@NotNull McuMgrException error) {
-                        fail(error);
-                    }
-                });
-                return;
-            }
-
-            // If the image in slot 1 is pending, we won't be able to erase, upload or test the
-            // image. Therefore, We must reset the device and revalidate the new image state.
-            if (images.length > 1 && images[1].pending) {
-                // Send reset command without changing state.
-                mDefaultManager.getTransporter().addObserver(mResetObserver);
-                mDefaultManager.reset(mResetCallback);
-                return;
-            }
-
-            // Check if the new firmware was already sent.
-            if (images.length > 1 && Arrays.equals(mHash, images[1].hash)) {
-                // Firmware is identical to one on slot 1. No need to send anything.
-
-                // If the test or confirm commands were not sent, proceed with next state.
-                if (!images[1].pending) {
-                    switch (mMode) {
-                        case TEST_AND_CONFIRM:
-                        case TEST_ONLY:
-                            test();
-                            break;
-                        case CONFIRM_ONLY:
-                            confirm();
-                            break;
-                    }
-                    return;
-                }
-
-                // If image was already confirmed, reset (if confirm was planned), or fail.
-                if (images[1].permanent) {
-                    switch (mMode) {
-                        case CONFIRM_ONLY:
-                        case TEST_AND_CONFIRM:
-                            // If confirm command was sent, just reset.
-                            reset();
-                            break;
-                        case TEST_ONLY:
-                            fail(new McuMgrException("Image already confirmed. Can't be tested."));
-                            break;
-                    }
-                    return;
-                }
-
-                // If image was not confirmed, but test command was sent, confirm or reset.
-                switch (mMode) {
-                    case CONFIRM_ONLY:
-                        confirm();
-                        break;
-                    case TEST_AND_CONFIRM:
-                    case TEST_ONLY:
-                        reset();
-                        break;
-                }
-                return;
-            }
-
-            // Validation successful, begin image upload.
-            upload();
-        }
-
-        @Override
-        public void onError(@NotNull McuMgrException e) {
-            fail(e);
-        }
-    };
-
-    /**
-     * State: TEST.
-     * Callback for the test command.
-     */
-    private final McuMgrCallback<McuMgrImageStateResponse> mTestCallback = new McuMgrCallback<McuMgrImageStateResponse>() {
-        @Override
-        public void onResponse(@NotNull McuMgrImageStateResponse response) {
-            LOG.trace("Test response: {}", response.toString());
-            // Check for an error return code
-            if (!response.isSuccess()) {
-                fail(new McuMgrErrorException(response.getReturnCode()));
-                return;
-            }
-            if (response.images.length != 2) {
-                fail(new McuMgrException("Test response does not contain enough info"));
-                return;
-            }
-            if (!response.images[1].pending) {
-                fail(new McuMgrException("Tested image is not in a pending state."));
-                return;
-            }
-            // Test image success, begin device reset.
-            reset();
-        }
-
-        @Override
-        public void onError(@NotNull McuMgrException e) {
-            fail(e);
-        }
-    };
-
-    /**
-     * State: RESET.
-     * Observer for the transport disconnection.
-     */
-    private final McuMgrTransport.ConnectionObserver mResetObserver = new McuMgrTransport.ConnectionObserver() {
-        @Override
-        public void onConnected() {
-            // Do nothing
-        }
-
-        @Override
-        public void onDisconnected() {
-            mDefaultManager.getTransporter().removeObserver(mResetObserver);
-
-            LOG.info("Device disconnected");
-            Runnable reconnect = () -> mDefaultManager.getTransporter().connect(mReconnectCallback);
-            // Calculate the delay needed before verification.
-            // It may have taken 20 sec before the phone realized that it's
-            // disconnected. No need to wait more, perhaps?
-            long now = SystemClock.elapsedRealtime();
-            long timeSinceReset = now - mResetResponseTime;
-            long remainingTime = mEstimatedSwapTime - timeSinceReset;
-
-            if (remainingTime > 0) {
-                LOG.trace("Waiting for estimated swap time {}ms", mEstimatedSwapTime);
-                new Handler(Looper.getMainLooper()).postDelayed(reconnect, remainingTime);
-            } else {
-                reconnect.run();
-            }
-        }
-    };
-
-    /**
-     * State: RESET.
-     * Callback for reconnecting to the device.
-     */
-    private final McuMgrTransport.ConnectionCallback mReconnectCallback = new McuMgrTransport.ConnectionCallback() {
-
-        @Override
-        public void onConnected() {
-            LOG.info("Reconnect successful");
-            continueUpgrade();
-        }
-
-        @Override
-        public void onDeferred() {
-            LOG.info("Reconnect deferred");
-            continueUpgrade();
-        }
-
-        @Override
-        public void onError(@NotNull Throwable t) {
-            LOG.error("Reconnect failed");
-            fail(new McuMgrException(t));
-        }
-
-        public void continueUpgrade() {
-            switch (mState) {
-                case NONE:
-                    // Upload cancelled in state validate.
-                    cancelled(State.VALIDATE);
-                    break;
-                case VALIDATE:
-                    // If the reset occurred in the validate state, we must re-validate as
-                    // multiple resets may be required.
-                    validate();
-                    break;
-                case RESET:
-                    switch (mMode) {
-                        case TEST_AND_CONFIRM:
-                            // The device reconnected after testing.
-                            verify();
-                            break;
-                        case TEST_ONLY:
-                        case CONFIRM_ONLY:
-                            // The device has been tested or confirmed.
-                            success();
-                            break;
-                    }
-            }
-        }
-    };
-
-    /**
-     * State: RESET.
-     * Callback for the reset command.
-     */
-    private final McuMgrCallback<McuMgrResponse> mResetCallback = new McuMgrCallback<McuMgrResponse>() {
-        @Override
-        public void onResponse(@NotNull McuMgrResponse response) {
-            // Check for an error return code
-            if (!response.isSuccess()) {
-                fail(new McuMgrErrorException(response.getReturnCode()));
-                return;
-            }
-            mResetResponseTime = SystemClock.elapsedRealtime();
-            LOG.trace("Reset request success. Waiting for disconnect...");
-        }
-
-        @Override
-        public void onError(@NotNull McuMgrException e) {
-            fail(e);
-        }
-    };
-
-    /**
-     * State: CONFIRM.
-     * Callback for the confirm command.
-     */
-    private final McuMgrCallback<McuMgrImageStateResponse> mConfirmCallback = new McuMgrCallback<McuMgrImageStateResponse>() {
-        private final static int MAX_ATTEMPTS = 2;
-        private int mAttempts = 0;
-
-        @Override
-        public void onResponse(@NotNull McuMgrImageStateResponse response) {
-            // Reset retry counter
-            mAttempts = 0;
-
-            LOG.trace("Confirm response: {}", response.toString());
-            // Check for an error return code
-            if (!response.isSuccess()) {
-                fail(new McuMgrErrorException(response.getReturnCode()));
-                return;
-            }
-            if (response.images.length == 0) {
-                fail(new McuMgrException("Confirm response does not contain enough info"));
-                return;
-            }
-            // Handle the response based on mode.
-            switch (mMode) {
-                case CONFIRM_ONLY:
-                    // Check that an image exists in slot 1
-                    if (response.images.length != 2) {
-                        fail(new McuMgrException("Confirm response does not contain enough info"));
-                        return;
-                    }
-                    // Check that the upgrade image has been confirmed
-                    if (!response.images[1].pending) {
-                        fail(new McuMgrException("Image is not in a confirmed state."));
-                        return;
-                    }
-                    // Reset the device, we don't want to do anything more.
-                    reset();
-                    break;
-                case TEST_AND_CONFIRM:
-                    // Check that the upgrade image has successfully booted
-                    if (!Arrays.equals(mHash, response.images[0].hash)) {
-                        fail(new McuMgrException("Device failed to boot into new image"));
-                        return;
-                    }
-                    // Check that the upgrade image has been confirmed
-                    if (!response.images[0].confirmed) {
-                        fail(new McuMgrException("Image is not in a confirmed state."));
-                        return;
-                    }
-                    // The device has been tested and confirmed.
-                    success();
-                    break;
-            }
-        }
-
-        @Override
-        public void onError(@NotNull McuMgrException e) {
-            // The confirm request might have been sent after the device was rebooted
-            // and the images were swapped. Swapping images, depending on the hardware,
-            // make take a long time, during which the phone may throw 133 error as a
-            // timeout. In such case we should try again.
-            if (e instanceof McuMgrTimeoutException) {
-                if (mAttempts++ < MAX_ATTEMPTS) {
-                    // Try again
-                    LOG.warn("Connection timeout. Retrying...");
-                    verify();
-                    return;
-                }
-            }
-            fail(e);
-        }
-    };
-
-    //******************************************************************
-    // Firmware Upgrade State
-    //******************************************************************
-
-    public enum State {
-        NONE, VALIDATE, UPLOAD, TEST, RESET, CONFIRM, SUCCESS;
-
-        public boolean isInProgress() {
-            return this == VALIDATE || this == UPLOAD || this == TEST ||
-                    this == RESET || this == CONFIRM;
-        }
-    }
-
-    /**
-     * Get the current {@link State} of the firmware upgrade.
-     *
-     * @return The current state.
-     */
-    public State getState() {
-        return mState;
-    }
-
-    /**
-     * Called by {@link FirmwareUpgradeManager#resume} to run the current state.
-     */
-    private synchronized void currentState() {
-        if (mPaused) {
-            return;
-        }
-        switch (mState) {
-            case NONE:
-                return;
-            case VALIDATE:
-                validate();
-                break;
-            case UPLOAD:
-                mUploadController.resume();
-                break;
-            case TEST:
-                test();
-                break;
-            case RESET:
-                reset();
-                break;
-            case CONFIRM:
-                confirm();
-                break;
-        }
-    }
-
-    //******************************************************************
-    // Image Upload Callback
-    //******************************************************************
-
-    /**
-     * Image upload callback. Forwards upload callbacks to the FirmwareUpgradeCallback.
-     */
-
-    private final UploadCallback mImageUploadCallback = new UploadCallback() {
-
-        @Override
-        public void onUploadProgressChanged(int current, int total, long timestamp) {
-            mInternalCallback.onUploadProgressChanged(current, total, timestamp);
-        }
-
-        @Override
-        public void onUploadFailed(@NotNull McuMgrException error) {
-            fail(error);
-        }
-
-        @Override
-        public void onUploadCanceled() {
-            cancelled(State.UPLOAD);
-        }
-
-        @Override
-        public void onUploadCompleted() {
-            // When upload is complete, send test on confirm commands, depending on the mode.
-            switch (mMode) {
-                case TEST_ONLY:
-                case TEST_AND_CONFIRM:
-                    test();
-                    break;
-                case CONFIRM_ONLY:
-                    confirm();
-                    break;
-            }
-        }
-    };
 
     //******************************************************************
     // Internal Callback forwarder

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradePerformer.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradePerformer.java
@@ -1,0 +1,164 @@
+package io.runtime.mcumgr.dfu;
+
+import android.util.Pair;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+import io.runtime.mcumgr.dfu.task.FirmwareUpgradeTask;
+import io.runtime.mcumgr.dfu.task.PerformDfu;
+import io.runtime.mcumgr.exception.McuMgrException;
+import io.runtime.mcumgr.image.McuMgrImage;
+import io.runtime.mcumgr.task.Task;
+import io.runtime.mcumgr.task.TaskPerformer;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Mode;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
+
+class FirmwareUpgradePerformer implements TaskPerformer<Settings> {
+	private final static Logger LOG = LoggerFactory.getLogger(FirmwareUpgradePerformer.class);
+
+	/**
+	 * Firmware upgrade callback passed into the constructor or set before the upload has started.
+	 */
+	@NotNull
+	private final FirmwareUpgradeCallback callback;
+
+	/**
+	 * The queue of tasks to be performed during the update. The content of the queue
+	 * depends on the images given in {@link FirmwareUpgradeManager#start(List)} and the state of the device,
+	 * which is determined by validation step before the upload begins.
+	 */
+	@NotNull
+	private final Queue<FirmwareUpgradeTask> taskQueue = new PriorityQueue<>();
+
+	/**
+	 * The currently performed task.
+	 */
+	@Nullable
+	private FirmwareUpgradeTask currentTask;
+
+	@Nullable
+	private Settings settings;
+
+	private boolean paused;
+	private boolean cancelled;
+
+	FirmwareUpgradePerformer(@NotNull final FirmwareUpgradeCallback callback) {
+		this.callback = callback;
+	}
+
+	State getState() {
+		final FirmwareUpgradeTask task = currentTask;
+		if (task == null)
+			return State.NONE;
+		return task.getState();
+	}
+
+	void start(@NotNull final Mode mode,
+			   @NotNull final List<Pair<Integer, McuMgrImage>> images,
+			   @NotNull final Settings settings) {
+		this.settings = settings;
+		enqueue(new PerformDfu(mode, images));
+		onTaskCompleted();
+	}
+
+	synchronized void pause() {
+		final FirmwareUpgradeTask task = currentTask;
+		if (paused || task == null)
+			return;
+		paused = true;
+		task.pause();
+	}
+
+	synchronized void resume() {
+		final Task<Settings> task = currentTask;
+		if (!paused || task == null || settings == null)
+			return;
+		paused = false;
+		task.start(settings, this);
+	}
+
+	synchronized void cancel() {
+		final Task<Settings> task = currentTask;
+		if (!cancelled || task == null)
+			return;
+		cancelled = true;
+		paused = false;
+		task.cancel();
+	}
+
+	synchronized boolean isPaused() {
+		return paused;
+	}
+
+	boolean isBusy() {
+		return currentTask != null;
+	}
+
+	@Override
+	public void enqueue(@NotNull final Task<Settings> task) {
+		taskQueue.add((FirmwareUpgradeTask) task);
+	}
+
+	@Override
+	public void onTaskCompleted() {
+		final FirmwareUpgradeTask completedTask = currentTask;
+		final FirmwareUpgradeManager.State prevState = completedTask != null ?
+				completedTask.getState() : FirmwareUpgradeManager.State.NONE;
+
+		// Has the process been cancelled?
+		if (cancelled) {
+			cleanUp();
+			callback.onUpgradeCanceled(prevState);
+			return;
+		}
+
+		// Poll the next task. If there's nothing, we're done.
+		final FirmwareUpgradeTask nextTask = currentTask = taskQueue.poll();
+		if (nextTask == null) {
+			callback.onUpgradeCompleted();
+			return;
+		}
+
+		// Notify observer about changing the state.
+		final FirmwareUpgradeManager.State newState = nextTask.getState();
+		if (newState != prevState) {
+			LOG.trace("Moving from state {} to state {}", prevState.name(), newState.name());
+			callback.onStateChanged(prevState, newState);
+		}
+
+		// Should we pause a bit?
+		if (paused) {
+			return;
+		}
+
+		// Run the next task.
+		assert settings != null;
+		nextTask.start(settings,this);
+	}
+
+	@Override
+	public void onTaskFailed(@NotNull final McuMgrException error) {
+		final FirmwareUpgradeTask task = currentTask;
+		if (task == null)
+			return;
+		cleanUp();
+		callback.onUpgradeFailed(task.getState(), error);
+	}
+
+	private void cleanUp() {
+		taskQueue.clear();
+		currentTask = null;
+		paused = false;
+		cancelled = false;
+		settings = null;
+	}
+
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradePerformer.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradePerformer.java
@@ -8,20 +8,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.PriorityQueue;
-import java.util.Queue;
 
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Mode;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
 import io.runtime.mcumgr.dfu.task.FirmwareUpgradeTask;
 import io.runtime.mcumgr.dfu.task.PerformDfu;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.image.McuMgrImage;
 import io.runtime.mcumgr.task.Task;
 import io.runtime.mcumgr.task.TaskPerformer;
-import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Mode;
-import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
-import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
 
-class FirmwareUpgradePerformer implements TaskPerformer<Settings> {
+public class FirmwareUpgradePerformer extends TaskPerformer<Settings, State> {
 	private final static Logger LOG = LoggerFactory.getLogger(FirmwareUpgradePerformer.class);
 
 	/**
@@ -30,135 +28,58 @@ class FirmwareUpgradePerformer implements TaskPerformer<Settings> {
 	@NotNull
 	private final FirmwareUpgradeCallback callback;
 
-	/**
-	 * The queue of tasks to be performed during the update. The content of the queue
-	 * depends on the images given in {@link FirmwareUpgradeManager#start(List)} and the state of the device,
-	 * which is determined by validation step before the upload begins.
-	 */
-	@NotNull
-	private final Queue<FirmwareUpgradeTask> taskQueue = new PriorityQueue<>();
-
-	/**
-	 * The currently performed task.
-	 */
-	@Nullable
-	private FirmwareUpgradeTask currentTask;
-
-	@Nullable
-	private Settings settings;
-
-	private boolean paused;
-	private boolean cancelled;
-
 	FirmwareUpgradePerformer(@NotNull final FirmwareUpgradeCallback callback) {
 		this.callback = callback;
 	}
 
 	State getState() {
-		final FirmwareUpgradeTask task = currentTask;
+		final FirmwareUpgradeTask task = (FirmwareUpgradeTask) getCurrentTask();
 		if (task == null)
 			return State.NONE;
 		return task.getState();
 	}
 
-	void start(@NotNull final Mode mode,
-			   @NotNull final List<Pair<Integer, McuMgrImage>> images,
-			   @NotNull final Settings settings) {
-		this.settings = settings;
-		enqueue(new PerformDfu(mode, images));
-		onTaskCompleted();
-	}
-
-	synchronized void pause() {
-		final FirmwareUpgradeTask task = currentTask;
-		if (paused || task == null)
-			return;
-		paused = true;
-		task.pause();
-	}
-
-	synchronized void resume() {
-		final Task<Settings> task = currentTask;
-		if (!paused || task == null || settings == null)
-			return;
-		paused = false;
-		task.start(settings, this);
-	}
-
-	synchronized void cancel() {
-		final Task<Settings> task = currentTask;
-		if (!cancelled || task == null)
-			return;
-		cancelled = true;
-		paused = false;
-		task.cancel();
-	}
-
-	synchronized boolean isPaused() {
-		return paused;
-	}
-
-	boolean isBusy() {
-		return currentTask != null;
+	void start(@NotNull final Settings settings,
+			   @NotNull final Mode mode,
+			   @NotNull final List<Pair<Integer, McuMgrImage>> images) {
+		LOG.trace("Starting DFU, mode: {}", mode.name());
+		super.start(settings, new PerformDfu(mode, images));
 	}
 
 	@Override
-	public void enqueue(@NotNull final Task<Settings> task) {
-		taskQueue.add((FirmwareUpgradeTask) task);
-	}
-
-	@Override
-	public void onTaskCompleted() {
-		final FirmwareUpgradeTask completedTask = currentTask;
-		final FirmwareUpgradeManager.State prevState = completedTask != null ?
-				completedTask.getState() : FirmwareUpgradeManager.State.NONE;
-
-		// Has the process been cancelled?
-		if (cancelled) {
-			cleanUp();
-			callback.onUpgradeCanceled(prevState);
+	public void onTaskStarted(final @Nullable Task<Settings, State> previousTask,
+							  final @NotNull Task<Settings, State> nextTask) {
+		if (previousTask == null)
 			return;
-		}
-
-		// Poll the next task. If there's nothing, we're done.
-		final FirmwareUpgradeTask nextTask = currentTask = taskQueue.poll();
-		if (nextTask == null) {
-			callback.onUpgradeCompleted();
-			return;
-		}
 
 		// Notify observer about changing the state.
-		final FirmwareUpgradeManager.State newState = nextTask.getState();
-		if (newState != prevState) {
-			LOG.trace("Moving from state {} to state {}", prevState.name(), newState.name());
-			callback.onStateChanged(prevState, newState);
+		final State oldState = previousTask.getState();
+		final State newState = nextTask.getState();
+		if (oldState != null && newState != null && newState != oldState) {
+			LOG.trace("Moving from state {} to state {}", oldState.name(), newState.name());
+			callback.onStateChanged(oldState, newState);
 		}
-
-		// Should we pause a bit?
-		if (paused) {
-			return;
-		}
-
-		// Run the next task.
-		assert settings != null;
-		nextTask.start(settings,this);
 	}
 
 	@Override
-	public void onTaskFailed(@NotNull final McuMgrException error) {
-		final FirmwareUpgradeTask task = currentTask;
-		if (task == null)
-			return;
-		cleanUp();
+	public void onCompleted(final @NotNull Task<Settings, State> task) {
+		callback.onUpgradeCompleted();
+	}
+
+	@Override
+	public void onTaskProgressChanged(final @NotNull Task<Settings, State> task,
+									  final int current, final int total, final long timestamp) {
+		callback.onUploadProgressChanged(current, total, timestamp);
+	}
+
+	@Override
+	public void onCancelled(final @NotNull Task<Settings, State> task) {
+		callback.onUpgradeCanceled(task.getState());
+	}
+
+	@Override
+	public void onTaskFailed(final @NotNull Task<Settings, State> task,
+							 final @NotNull McuMgrException error) {
 		callback.onUpgradeFailed(task.getState(), error);
 	}
-
-	private void cleanUp() {
-		taskQueue.clear();
-		currentTask = null;
-		paused = false;
-		cancelled = false;
-		settings = null;
-	}
-
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Confirm.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Confirm.java
@@ -1,0 +1,110 @@
+package io.runtime.mcumgr.dfu.task;
+
+import android.util.Log;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
+import io.runtime.mcumgr.task.TaskPerformer;
+
+class Confirm extends FirmwareUpgradeTask {
+	private final byte @NotNull [] hash;
+
+	Confirm(final byte @NotNull [] hash) {
+		this.hash = hash;
+	}
+
+	@Override
+	@NotNull
+	public FirmwareUpgradeManager.State getState() {
+		return FirmwareUpgradeManager.State.CONFIRM;
+	}
+
+	@Override
+	public int getPriority() {
+		return PRIORITY_CONFIRM_AFTER_UPLOAD;
+	}
+
+	@Override
+	public void start(@NotNull final FirmwareUpgradeManager.Settings settings,
+					  @NotNull final TaskPerformer<FirmwareUpgradeManager.Settings> performer) {
+		Log.d("AAA", "Confirm " + Arrays.toString(hash));
+		performer.onTaskCompleted();
+	}
+
+//	/**
+//	 * State: CONFIRM.
+//	 * Callback for the confirm command.
+//	 */
+//	private final McuMgrCallback<McuMgrImageStateResponse> mConfirmCallback = new McuMgrCallback<McuMgrImageStateResponse>() {
+//		private final static int MAX_ATTEMPTS = 2;
+//		private int mAttempts = 0;
+//
+//		@Override
+//		public void onResponse(@NotNull McuMgrImageStateResponse response) {
+//			// Reset retry counter
+//			mAttempts = 0;
+//
+//			LOG.trace("Confirm response: {}", response.toString());
+//			// Check for an error return code
+//			if (!response.isSuccess()) {
+//				fail(new McuMgrErrorException(response.getReturnCode()));
+//				return;
+//			}
+//			if (response.images.length == 0) {
+//				fail(new McuMgrException("Confirm response does not contain enough info"));
+//				return;
+//			}
+//			// Handle the response based on mode.
+//			switch (mMode) {
+//				case CONFIRM_ONLY:
+//					// Check that an image exists in slot 1
+//					if (response.images.length != 2) {
+//						fail(new McuMgrException("Confirm response does not contain enough info"));
+//						return;
+//					}
+//					// Check that the upgrade image has been confirmed
+//					if (!response.images[1].pending) {
+//						fail(new McuMgrException("Image is not in a confirmed state."));
+//						return;
+//					}
+//					// Reset the device, we don't want to do anything more.
+//					reset();
+//					break;
+//				case TEST_AND_CONFIRM:
+//					// Check that the upgrade image has successfully booted
+//					if (!Arrays.equals(mHash, response.images[0].hash)) {
+//						fail(new McuMgrException("Device failed to boot into new image"));
+//						return;
+//					}
+//					// Check that the upgrade image has been confirmed
+//					if (!response.images[0].confirmed) {
+//						fail(new McuMgrException("Image is not in a confirmed state."));
+//						return;
+//					}
+//					// The device has been tested and confirmed.
+//					success();
+//					break;
+//			}
+//		}
+//
+//		@Override
+//		public void onError(@NotNull McuMgrException e) {
+//			// The confirm request might have been sent after the device was rebooted
+//			// and the images were swapped. Swapping images, depending on the hardware,
+//			// make take a long time, during which the phone may throw 133 error as a
+//			// timeout. In such case we should try again.
+//			if (e instanceof McuMgrTimeoutException) {
+//				if (mAttempts++ < MAX_ATTEMPTS) {
+//					// Try again
+//					LOG.warn("Connection timeout. Retrying...");
+//					verify();
+//					return;
+//				}
+//			}
+//			fail(e);
+//		}
+//	};
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/ConfirmAfterReset.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/ConfirmAfterReset.java
@@ -1,0 +1,15 @@
+package io.runtime.mcumgr.dfu.task;
+
+import org.jetbrains.annotations.NotNull;
+
+class ConfirmAfterReset extends Confirm {
+
+	ConfirmAfterReset(final byte @NotNull [] hash) {
+		super(hash);
+	}
+
+	@Override
+	public int getPriority() {
+		return PRIORITY_CONFIRM_AFTER_RESET;
+	}
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/FirmwareUpgradeTask.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/FirmwareUpgradeTask.java
@@ -1,0 +1,25 @@
+package io.runtime.mcumgr.dfu.task;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
+import io.runtime.mcumgr.task.Task;
+
+public abstract class FirmwareUpgradeTask extends Task<Settings> {
+	final static int PRIORITY_VALIDATE = 0;
+	final static int PRIORITY_RESET_INITIAL = 1;
+	final static int PRIORITY_UPLOAD = 2;
+	final static int PRIORITY_TEST_AFTER_UPLOAD = PRIORITY_UPLOAD + 1;
+	final static int PRIORITY_CONFIRM_AFTER_UPLOAD = PRIORITY_UPLOAD + 1;
+	final static int PRIORITY_RESET = 10;
+	final static int PRIORITY_CONFIRM_AFTER_RESET = PRIORITY_RESET + 1;
+
+	/**
+	 * Returns the state that will be reported to the callback.
+	 * @return The state in which the manager is in.
+	 */
+	@NotNull
+	public abstract State getState();
+
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/FirmwareUpgradeTask.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/FirmwareUpgradeTask.java
@@ -1,12 +1,10 @@
 package io.runtime.mcumgr.dfu.task;
 
-import org.jetbrains.annotations.NotNull;
-
-import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
 import io.runtime.mcumgr.task.Task;
 
-public abstract class FirmwareUpgradeTask extends Task<Settings> {
+public abstract class FirmwareUpgradeTask extends Task<Settings, State> {
 	final static int PRIORITY_VALIDATE = 0;
 	final static int PRIORITY_RESET_INITIAL = 1;
 	final static int PRIORITY_UPLOAD = 2;
@@ -14,12 +12,4 @@ public abstract class FirmwareUpgradeTask extends Task<Settings> {
 	final static int PRIORITY_CONFIRM_AFTER_UPLOAD = PRIORITY_UPLOAD + 1;
 	final static int PRIORITY_RESET = 10;
 	final static int PRIORITY_CONFIRM_AFTER_RESET = PRIORITY_RESET + 1;
-
-	/**
-	 * Returns the state that will be reported to the callback.
-	 * @return The state in which the manager is in.
-	 */
-	@NotNull
-	public abstract State getState();
-
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/PerformDfu.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/PerformDfu.java
@@ -10,8 +10,12 @@ import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
 import io.runtime.mcumgr.image.McuMgrImage;
-import io.runtime.mcumgr.task.TaskPerformer;
+import io.runtime.mcumgr.task.TaskManager;
 
+/**
+ * This task performs the DFU. Given images will be sent to the target device, and tested and
+ * confirmed, depending on the given mode.
+ */
 public class PerformDfu extends FirmwareUpgradeTask {
 
 	@NotNull
@@ -37,9 +41,8 @@ public class PerformDfu extends FirmwareUpgradeTask {
 	}
 
 	@Override
-	public void start(final @NotNull Settings settings,
-					  final @NotNull TaskPerformer<Settings> performer) {
+	public void start(final @NotNull TaskManager<Settings, State> performer) {
 		performer.enqueue(new Validate(mode, images));
-		performer.onTaskCompleted();
+		performer.onTaskCompleted(this);
 	}
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/PerformDfu.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/PerformDfu.java
@@ -1,0 +1,45 @@
+package io.runtime.mcumgr.dfu.task;
+
+import android.util.Pair;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
+import io.runtime.mcumgr.image.McuMgrImage;
+import io.runtime.mcumgr.task.TaskPerformer;
+
+public class PerformDfu extends FirmwareUpgradeTask {
+
+	@NotNull
+	private final List<Pair<Integer, McuMgrImage>> images;
+	@NotNull
+	private final FirmwareUpgradeManager.Mode mode;
+
+	public PerformDfu(final @NotNull FirmwareUpgradeManager.Mode mode,
+					  final @NotNull List<Pair<Integer, McuMgrImage>> images) {
+		this.mode = mode;
+		this.images = images;
+	}
+
+	@NotNull
+	@Override
+	public State getState() {
+		return State.VALIDATE;
+	}
+
+	@Override
+	public int getPriority() {
+		return 0;
+	}
+
+	@Override
+	public void start(final @NotNull Settings settings,
+					  final @NotNull TaskPerformer<Settings> performer) {
+		performer.enqueue(new Validate(mode, images));
+		performer.onTaskCompleted();
+	}
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Reset.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Reset.java
@@ -1,0 +1,151 @@
+package io.runtime.mcumgr.dfu.task;
+
+import android.util.Log;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+
+import io.runtime.mcumgr.McuMgrTransport;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
+import io.runtime.mcumgr.exception.McuMgrException;
+import io.runtime.mcumgr.task.TaskPerformer;
+
+class Reset extends FirmwareUpgradeTask {
+
+	/**
+	 * The timestamp at which the response to Reset command was received.
+	 * Assuming that the target device has reset just after sending this response,
+	 * the time difference between this moment and receiving disconnection event may be deducted
+	 * from the estimated swap time.
+	 */
+	private long mResetResponseTime;
+
+	Reset() {
+	}
+
+	@Override
+	@NotNull
+	public FirmwareUpgradeManager.State getState() {
+		return FirmwareUpgradeManager.State.RESET;
+	}
+
+	@Override
+	public int getPriority() {
+		return PRIORITY_RESET;
+	}
+
+	@Override
+	public void start(@NotNull final FirmwareUpgradeManager.Settings settings,
+					  @NotNull final TaskPerformer<FirmwareUpgradeManager.Settings> performer) {
+		//		mDefaultManager.getTransporter().addObserver(mResetObserver);
+		//		mDefaultManager.reset(mResetCallback);
+		Log.d("AAA", "Reset");
+		performer.onTaskCompleted();
+	}
+
+//	/**
+//	 * State: RESET.
+//	 * Observer for the transport disconnection.
+//	 */
+//	private final McuMgrTransport.ConnectionObserver mResetObserver = new McuMgrTransport.ConnectionObserver() {
+//		@Override
+//		public void onConnected() {
+//			// Do nothing
+//		}
+//
+//		@Override
+//		public void onDisconnected() {
+//			mManager.getTransporter().removeObserver(mResetObserver);
+//
+//			LOG.info("Device disconnected");
+//			Runnable reconnect = () -> mDefaultManager.getTransporter().connect(mReconnectCallback);
+//			// Calculate the delay needed before verification.
+//			// It may have taken 20 sec before the phone realized that it's
+//			// disconnected. No need to wait more, perhaps?
+//			long now = SystemClock.elapsedRealtime();
+//			long timeSinceReset = now - mResetResponseTime;
+//			long remainingTime = mEstimatedSwapTime - timeSinceReset;
+//
+//			if (remainingTime > 0) {
+//				LOG.trace("Waiting for estimated swap time {}ms", mEstimatedSwapTime);
+//				new Handler(Looper.getMainLooper()).postDelayed(reconnect, remainingTime);
+//			} else {
+//				reconnect.run();
+//			}
+//		}
+//	};
+//
+//	/**
+//	 * State: RESET.
+//	 * Callback for the reset command.
+//	 */
+//	private final McuMgrCallback<McuMgrResponse> mResetCallback = new McuMgrCallback<McuMgrResponse>() {
+//		@Override
+//		public void onResponse(@NotNull McuMgrResponse response) {
+//			// Check for an error return code
+//			if (!response.isSuccess()) {
+//				fail(new McuMgrErrorException(response.getReturnCode()));
+//				return;
+//			}
+//			mResetResponseTime = SystemClock.elapsedRealtime();
+//			LOG.trace("Reset request success. Waiting for disconnect...");
+//		}
+//
+//		@Override
+//		public void onError(@NotNull McuMgrException e) {
+//			fail(e);
+//		}
+//	};
+//
+//	/**
+//	 * State: RESET.
+//	 * Callback for reconnecting to the device.
+//	 */
+//	private final McuMgrTransport.ConnectionCallback mReconnectCallback = new McuMgrTransport.ConnectionCallback() {
+//
+//		@Override
+//		public void onConnected() {
+//			LOG.info("Reconnect successful");
+//			continueUpgrade();
+//		}
+//
+//		@Override
+//		public void onDeferred() {
+//			LOG.info("Reconnect deferred");
+//			continueUpgrade();
+//		}
+//
+//		@Override
+//		public void onError(@NotNull Throwable t) {
+//			LOG.error("Reconnect failed");
+//			fail(new McuMgrException(t));
+//		}
+//
+//		public void continueUpgrade() {
+//			switch (mState) {
+//				case NONE:
+//					// Upload cancelled in state validate.
+//					cancelled(FirmwareUpgradeManager.State.VALIDATE);
+//					break;
+//				case VALIDATE:
+//					// If the reset occurred in the validate state, we must re-validate as
+//					// multiple resets may be required.
+//					validate();
+//					break;
+//				case RESET:
+//					switch (mMode) {
+//						case TEST_AND_CONFIRM:
+//							// The device reconnected after testing.
+//							verify();
+//							break;
+//						case TEST_ONLY:
+//						case CONFIRM_ONLY:
+//							// The device has been tested or confirmed.
+//							success();
+//							break;
+//					}
+//			}
+//		}
+//	};
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Reset.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Reset.java
@@ -1,17 +1,24 @@
 package io.runtime.mcumgr.dfu.task;
 
-import android.util.Log;
+import android.os.Handler;
+import android.os.SystemClock;
 
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-
+import io.runtime.mcumgr.McuMgrCallback;
 import io.runtime.mcumgr.McuMgrTransport;
-import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
+import io.runtime.mcumgr.exception.McuMgrErrorException;
 import io.runtime.mcumgr.exception.McuMgrException;
-import io.runtime.mcumgr.task.TaskPerformer;
+import io.runtime.mcumgr.managers.DefaultManager;
+import io.runtime.mcumgr.response.McuMgrResponse;
+import io.runtime.mcumgr.task.TaskManager;
 
 class Reset extends FirmwareUpgradeTask {
+	private final static Logger LOG = LoggerFactory.getLogger(Reset.class);
 
 	/**
 	 * The timestamp at which the response to Reset command was received.
@@ -26,8 +33,8 @@ class Reset extends FirmwareUpgradeTask {
 
 	@Override
 	@NotNull
-	public FirmwareUpgradeManager.State getState() {
-		return FirmwareUpgradeManager.State.RESET;
+	public State getState() {
+		return State.RESET;
 	}
 
 	@Override
@@ -36,116 +43,70 @@ class Reset extends FirmwareUpgradeTask {
 	}
 
 	@Override
-	public void start(@NotNull final FirmwareUpgradeManager.Settings settings,
-					  @NotNull final TaskPerformer<FirmwareUpgradeManager.Settings> performer) {
-		//		mDefaultManager.getTransporter().addObserver(mResetObserver);
-		//		mDefaultManager.reset(mResetCallback);
-		Log.d("AAA", "Reset");
-		performer.onTaskCompleted();
-	}
+	public void start(@NotNull final TaskManager<Settings, State> performer) {
+		final Settings settings = performer.getSettings();
+		final McuMgrTransport transport = settings.transport;
 
-//	/**
-//	 * State: RESET.
-//	 * Observer for the transport disconnection.
-//	 */
-//	private final McuMgrTransport.ConnectionObserver mResetObserver = new McuMgrTransport.ConnectionObserver() {
-//		@Override
-//		public void onConnected() {
-//			// Do nothing
-//		}
-//
-//		@Override
-//		public void onDisconnected() {
-//			mManager.getTransporter().removeObserver(mResetObserver);
-//
-//			LOG.info("Device disconnected");
-//			Runnable reconnect = () -> mDefaultManager.getTransporter().connect(mReconnectCallback);
-//			// Calculate the delay needed before verification.
-//			// It may have taken 20 sec before the phone realized that it's
-//			// disconnected. No need to wait more, perhaps?
-//			long now = SystemClock.elapsedRealtime();
-//			long timeSinceReset = now - mResetResponseTime;
-//			long remainingTime = mEstimatedSwapTime - timeSinceReset;
-//
-//			if (remainingTime > 0) {
-//				LOG.trace("Waiting for estimated swap time {}ms", mEstimatedSwapTime);
-//				new Handler(Looper.getMainLooper()).postDelayed(reconnect, remainingTime);
-//			} else {
-//				reconnect.run();
-//			}
-//		}
-//	};
-//
-//	/**
-//	 * State: RESET.
-//	 * Callback for the reset command.
-//	 */
-//	private final McuMgrCallback<McuMgrResponse> mResetCallback = new McuMgrCallback<McuMgrResponse>() {
-//		@Override
-//		public void onResponse(@NotNull McuMgrResponse response) {
-//			// Check for an error return code
-//			if (!response.isSuccess()) {
-//				fail(new McuMgrErrorException(response.getReturnCode()));
-//				return;
-//			}
-//			mResetResponseTime = SystemClock.elapsedRealtime();
-//			LOG.trace("Reset request success. Waiting for disconnect...");
-//		}
-//
-//		@Override
-//		public void onError(@NotNull McuMgrException e) {
-//			fail(e);
-//		}
-//	};
-//
-//	/**
-//	 * State: RESET.
-//	 * Callback for reconnecting to the device.
-//	 */
-//	private final McuMgrTransport.ConnectionCallback mReconnectCallback = new McuMgrTransport.ConnectionCallback() {
-//
-//		@Override
-//		public void onConnected() {
-//			LOG.info("Reconnect successful");
-//			continueUpgrade();
-//		}
-//
-//		@Override
-//		public void onDeferred() {
-//			LOG.info("Reconnect deferred");
-//			continueUpgrade();
-//		}
-//
-//		@Override
-//		public void onError(@NotNull Throwable t) {
-//			LOG.error("Reconnect failed");
-//			fail(new McuMgrException(t));
-//		}
-//
-//		public void continueUpgrade() {
-//			switch (mState) {
-//				case NONE:
-//					// Upload cancelled in state validate.
-//					cancelled(FirmwareUpgradeManager.State.VALIDATE);
-//					break;
-//				case VALIDATE:
-//					// If the reset occurred in the validate state, we must re-validate as
-//					// multiple resets may be required.
-//					validate();
-//					break;
-//				case RESET:
-//					switch (mMode) {
-//						case TEST_AND_CONFIRM:
-//							// The device reconnected after testing.
-//							verify();
-//							break;
-//						case TEST_ONLY:
-//						case CONFIRM_ONLY:
-//							// The device has been tested or confirmed.
-//							success();
-//							break;
-//					}
-//			}
-//		}
-//	};
+		transport.addObserver(new McuMgrTransport.ConnectionObserver() {
+			@Override
+			public void onConnected() {
+				// Do nothing
+			}
+
+			@Override
+			public void onDisconnected() {
+				transport.removeObserver(this);
+
+				LOG.info("Device disconnected");
+				final Runnable reconnect = () -> transport.connect(new McuMgrTransport.ConnectionCallback() {
+					@Override
+					public void onConnected() {
+						performer.onTaskCompleted(Reset.this);
+					}
+
+					@Override
+					public void onDeferred() {
+						performer.onTaskCompleted(Reset.this);
+					}
+
+					@Override
+					public void onError(@NotNull final Throwable t) {
+						performer.onTaskFailed(Reset.this, new McuMgrException(t));
+					}
+				});
+				// Calculate the delay needed before verification.
+				// It may have taken 20 sec before the phone realized that it's
+				// disconnected. No need to wait more, perhaps?
+				long now = SystemClock.elapsedRealtime();
+				long timeSinceReset = now - mResetResponseTime;
+				long remainingTime = settings.estimatedSwapTime - timeSinceReset;
+
+				if (remainingTime > 0) {
+					LOG.trace("Waiting for estimated swap time {} ms", settings.estimatedSwapTime);
+					new Handler().postDelayed(reconnect, remainingTime);
+				} else {
+					reconnect.run();
+				}
+			}
+		});
+
+		final DefaultManager manager = new DefaultManager(transport);
+		manager.reset(new McuMgrCallback<McuMgrResponse>() {
+			@Override
+			public void onResponse(@NotNull final McuMgrResponse response) {
+				// Check for an error return code.
+				if (!response.isSuccess()) {
+					performer.onTaskFailed(Reset.this, new McuMgrErrorException(response.getReturnCode()));
+					return;
+				}
+				mResetResponseTime = SystemClock.elapsedRealtime();
+				LOG.trace("Reset request success. Waiting for disconnect...");
+			}
+
+			@Override
+			public void onError(@NotNull final McuMgrException error) {
+				performer.onTaskFailed(Reset.this, error);
+			}
+		});
+	}
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/ResetBeforeUpload.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/ResetBeforeUpload.java
@@ -1,0 +1,12 @@
+package io.runtime.mcumgr.dfu.task;
+
+class ResetBeforeUpload extends Reset {
+
+	ResetBeforeUpload() {
+	}
+
+	@Override
+	public int getPriority() {
+		return PRIORITY_RESET_INITIAL;
+	}
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Test.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Test.java
@@ -1,0 +1,75 @@
+package io.runtime.mcumgr.dfu.task;
+
+import android.util.Log;
+
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+import io.runtime.mcumgr.McuMgrCallback;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
+import io.runtime.mcumgr.exception.McuMgrErrorException;
+import io.runtime.mcumgr.exception.McuMgrException;
+import io.runtime.mcumgr.response.img.McuMgrImageStateResponse;
+import io.runtime.mcumgr.task.TaskPerformer;
+
+class Test extends FirmwareUpgradeTask {
+	private final static Logger LOG = LoggerFactory.getLogger(Test.class);
+
+	private final byte @NotNull [] hash;
+
+	Test(final byte @NotNull [] hash) {
+		this.hash = hash;
+	}
+
+	@Override
+	@NotNull
+	public FirmwareUpgradeManager.State getState() {
+		return FirmwareUpgradeManager.State.TEST;
+	}
+
+	@Override
+	public int getPriority() {
+		return PRIORITY_TEST_AFTER_UPLOAD;
+	}
+
+	@Override
+	public void start(@NotNull final FirmwareUpgradeManager.Settings settings,
+					  @NotNull final TaskPerformer<FirmwareUpgradeManager.Settings> performer) {
+		Log.d("AAA", "Test " + Arrays.toString(hash));
+		performer.onTaskCompleted();
+	}
+
+//	/**
+//	 * State: TEST.
+//	 * Callback for the test command.
+//	 */
+//	private final McuMgrCallback<McuMgrImageStateResponse> mTestCallback = new McuMgrCallback<McuMgrImageStateResponse>() {
+//		@Override
+//		public void onResponse(@NotNull McuMgrImageStateResponse response) {
+//			LOG.trace("Test response: {}", response.toString());
+//			// Check for an error return code
+//			if (!response.isSuccess()) {
+//				fail(new McuMgrErrorException(response.getReturnCode()));
+//				return;
+//			}
+//			if (response.images.length != 2) {
+//				fail(new McuMgrException("Test response does not contain enough info"));
+//				return;
+//			}
+//			if (!response.images[1].pending) {
+//				fail(new McuMgrException("Tested image is not in a pending state."));
+//				return;
+//			}
+//			// Test image success, begin device reset.
+//			reset();
+//		}
+//
+//		@Override
+//		public void onError(@NotNull McuMgrException e) {
+//			fail(e);
+//		}
+//	};
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Upload.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Upload.java
@@ -1,0 +1,98 @@
+package io.runtime.mcumgr.dfu.task;
+
+import android.util.Log;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
+import io.runtime.mcumgr.image.McuMgrImage;
+import io.runtime.mcumgr.task.TaskPerformer;
+import io.runtime.mcumgr.transfer.TransferController;
+
+class Upload extends FirmwareUpgradeTask {
+	private final McuMgrImage mcuMgrImage;
+	private final int image;
+
+	/**
+	 * Upload controller used to pause, resume, and cancel upload. Set when the upload is started.
+	 */
+	private TransferController mUploadController;
+
+	Upload(@NotNull final McuMgrImage mcuMgrImage, final int image) {
+		this.mcuMgrImage = mcuMgrImage;
+		this.image = image;
+	}
+
+	@Override
+	@NotNull
+	public FirmwareUpgradeManager.State getState() {
+		return FirmwareUpgradeManager.State.UPLOAD;
+	}
+
+	@Override
+	public int getPriority() {
+		return PRIORITY_UPLOAD;
+	}
+
+	@Override
+	public void start(@NotNull final FirmwareUpgradeManager.Settings settings,
+					  @NotNull final TaskPerformer<FirmwareUpgradeManager.Settings> performer) {
+//		if (mWindowCapacity > 1) {
+//			mUploadController = windowUpload(mImageManager, mImageData, mWindowCapacity,
+//					mImageUploadCallback);
+//		} else {
+//			mUploadController = mImageManager.imageUpload(mImageData, mImageUploadCallback);
+//		}
+		Log.d("AAA", "Uploading " + image);
+		performer.onTaskCompleted();
+	}
+
+	@Override
+	public void pause() {
+
+	}
+
+	@Override
+	public void cancel() {
+
+	}
+
+	//******************************************************************
+	// Image Upload Callback
+	//******************************************************************
+
+//	/**
+//	 * Image upload callback. Forwards upload callbacks to the FirmwareUpgradeCallback.
+//	 */
+//	private final UploadCallback mImageUploadCallback = new UploadCallback() {
+//
+//		@Override
+//		public void onUploadProgressChanged(int current, int total, long timestamp) {
+//			mInternalCallback.onUploadProgressChanged(current, total, timestamp);
+//		}
+//
+//		@Override
+//		public void onUploadFailed(@NotNull McuMgrException error) {
+//			fail(error);
+//		}
+//
+//		@Override
+//		public void onUploadCanceled() {
+//			cancelled(FirmwareUpgradeManager.State.UPLOAD);
+//		}
+//
+//		@Override
+//		public void onUploadCompleted() {
+//			// When upload is complete, send test on confirm commands, depending on the mode.
+//			switch (mMode) {
+//				case TEST_ONLY:
+//				case TEST_AND_CONFIRM:
+//					test();
+//					break;
+//				case CONFIRM_ONLY:
+//					confirm();
+//					break;
+//			}
+//		}
+//	};
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Validate.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Validate.java
@@ -1,0 +1,201 @@
+package io.runtime.mcumgr.dfu.task;
+
+import android.util.Pair;
+
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.runtime.mcumgr.McuMgrCallback;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
+import io.runtime.mcumgr.exception.McuMgrErrorException;
+import io.runtime.mcumgr.exception.McuMgrException;
+import io.runtime.mcumgr.image.McuMgrImage;
+import io.runtime.mcumgr.managers.ImageManager;
+import io.runtime.mcumgr.response.img.McuMgrImageStateResponse;
+import io.runtime.mcumgr.task.TaskPerformer;
+
+class Validate extends FirmwareUpgradeTask {
+	private final static Logger LOG = LoggerFactory.getLogger(Validate.class);
+
+	private static final int SLOT_PRIMARY = 0;
+	private static final int SLOT_SECONDARY = 1;
+
+	@NotNull
+	private final List<Pair<Integer, McuMgrImage>> images;
+	@NotNull
+	private final FirmwareUpgradeManager.Mode mode;
+
+	Validate(final @NotNull FirmwareUpgradeManager.Mode mode,
+			 final @NotNull List<Pair<Integer, McuMgrImage>> images) {
+		this.mode = mode;
+		this.images = images;
+	}
+
+	@Override
+	@NotNull
+	public FirmwareUpgradeManager.State getState() {
+		return FirmwareUpgradeManager.State.VALIDATE;
+	}
+
+	@Override
+	public int getPriority() {
+		return PRIORITY_VALIDATE;
+	}
+
+	@Override
+	public void start(@NotNull final Settings settings,
+					  @NotNull final TaskPerformer<Settings> performer) {
+		final ImageManager manager = new ImageManager(settings.transport);
+		manager.list(new McuMgrCallback<McuMgrImageStateResponse>() {
+			@Override
+			public void onResponse(@NotNull final McuMgrImageStateResponse response) {
+				LOG.trace("Validation response: {}", response.toString());
+
+				// Check for an error return code.
+				if (!response.isSuccess()) {
+					performer.onTaskFailed(new McuMgrErrorException(response.getReturnCode()));
+					return;
+				}
+
+				// Initial validation.
+				McuMgrImageStateResponse.ImageSlot[] slots = response.images;
+				if (slots == null) {
+					LOG.error("Missing images information: {}", response.toString());
+					performer.onTaskFailed(new McuMgrException("Missing images information"));
+					return;
+				}
+
+				// The following code adds Erase, Upload, Test, Reset and Confirm operations
+				// to the task priority queue. The priorities of those tasks ensure they are executed
+				// in the right (given 2 lines above) order.
+
+				// The flag indicates whether a reset operation should be performed during the process.
+				boolean resetRequired = false;
+				boolean initialResetRequired = false;
+
+				// For each image that is to be sent, check if the same image has already been sent.
+				for (final Pair<Integer, McuMgrImage> pair : images) {
+					final int image = pair.first;
+					final McuMgrImage mcuMgrImage = pair.second;
+
+					// The following flags will be updated based on the received slot information.
+					boolean found = false;
+					boolean pending = false;   // TEST command was sent
+					boolean permanent = false; // CONFIRM command was sent
+					boolean confirmed = false; // Image has booted and confirmed itself
+					for (final McuMgrImageStateResponse.ImageSlot slot : slots) {
+						if (slot.image != image)
+							continue;
+
+						// If the same image was found in any of the slots, the upload will not be
+						// required. The image may need testing or confirming, or may already be running.
+						if (Arrays.equals(slot.hash, mcuMgrImage.getHash())) {
+							found = true;
+							pending = slot.pending;
+							permanent = slot.permanent;
+							confirmed = slot.confirmed;
+
+							// If the image has been found on the secondary slot and it's confirmed,
+							// we just need to restart the device in order for it to be swapped back to
+							// primary slot.
+							if (confirmed && slot.slot == SLOT_SECONDARY) {
+								resetRequired = true;
+							}
+							break;
+						} else {
+							if (slot.slot == SLOT_SECONDARY) {
+								// A different image in the secondary slot of required image may be found
+								// in 3 cases:
+
+								// 1. All flags are clear -> a previous update has taken place.
+								//    The slot will be overridden automatically. Nothing needs to be done.
+								if (!slot.pending && !slot.confirmed) {
+									continue;
+								}
+
+								// 2. The confirmed flag is set -> the device is in test mode.
+								//    In that case we need to reset the device to restore the original
+								//    image. We could also confirm the image-under-test, but that's more
+								//    risky.
+								if (slot.confirmed) {
+									initialResetRequired = true;
+								}
+
+								// 3. The pending or permanent flags are set -> the test or confirm
+								//    command have been sent before, but reset was not performed.
+								//    In that case we have to reset before uploading, as pending
+								//    slot cannot be overwritten (NO MEMORY error would be returned).
+								if (slot.pending || slot.permanent) {
+									initialResetRequired = true;
+								}
+							}
+						}
+					}
+					if (!found) {
+						performer.enqueue(new Upload(mcuMgrImage, image));
+					}
+					switch (mode) {
+						case TEST_AND_CONFIRM:
+							// If the image is not pending (test command has not been sent) and not
+							// confirmed (another image is under test), send test command and update the
+							// flag.
+							if (!pending && !confirmed) {
+								performer.enqueue(new Test(mcuMgrImage.getHash()));
+								pending = true;
+							}
+							// If the image is pending, reset is required.
+							if (pending) {
+								resetRequired = true;
+							}
+							if (!permanent && !confirmed) {
+								performer.enqueue(new ConfirmAfterReset(mcuMgrImage.getHash()));
+							}
+							break;
+						case TEST_ONLY:
+							// If the image is not pending (test command has not been sent) and not
+							// confirmed (another image is under test), send test command and update the
+							// flag.
+							if (!pending && !confirmed) {
+								performer.enqueue(new Test(mcuMgrImage.getHash()));
+								pending = true;
+							}
+							// If the image is pending, reset is required.
+							if (pending) {
+								resetRequired = true;
+							}
+							break;
+						case CONFIRM_ONLY:
+							// If the firmware is not confirmed yet, confirm t.
+							if (!permanent && !confirmed) {
+								performer.enqueue(new Confirm(mcuMgrImage.getHash()));
+								permanent = true;
+							}
+							if (permanent) {
+								resetRequired = true;
+							}
+							break;
+					}
+				}
+				// To make sure the reset command are added just once, they're added based on flags.
+				if (initialResetRequired) {
+					performer.enqueue(new ResetBeforeUpload());
+				}
+				if (resetRequired) {
+					performer.enqueue(new Reset());
+				}
+
+				performer.onTaskCompleted();
+			}
+
+			@Override
+			public void onError(@NotNull final McuMgrException e) {
+				performer.onTaskFailed(e);
+			}
+		});
+	}
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/InsufficientMtuException.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/InsufficientMtuException.java
@@ -16,8 +16,8 @@ import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
  */
 @SuppressWarnings("unused")
 public class InsufficientMtuException extends McuMgrException {
-    private int mMtu;
-    private int mDataLength;
+    private final int mMtu;
+    private final int mDataLength;
 
     public InsufficientMtuException(int payloadLength, int mtu) {
         super("Payload (" + payloadLength + " bytes) too long for MTU: " + mtu);

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/McuMgrCoapException.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/McuMgrCoapException.java
@@ -13,9 +13,9 @@ import io.runtime.mcumgr.McuMgrCallback;
  */
 @SuppressWarnings("unused")
 public class McuMgrCoapException extends McuMgrException {
-    private byte[] mBytes;
-    private int mCodeClass;
-    private int mCodeDetail;
+    private final byte[] mBytes;
+    private final int mCodeClass;
+    private final int mCodeDetail;
 
     public McuMgrCoapException(byte[] bytes, int codeClass, int codeDetail) {
         super("McuManager CoAP request resulted in an error response: "  + codeClass + ".0" + codeDetail);

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/McuMgrErrorException.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/McuMgrErrorException.java
@@ -20,7 +20,7 @@ import io.runtime.mcumgr.response.McuMgrResponse;
 @SuppressWarnings("unused")
 public class McuMgrErrorException extends McuMgrException {
     @NotNull
-    private McuMgrErrorCode mCode;
+    private final McuMgrErrorCode mCode;
 
     public McuMgrErrorException(@NotNull McuMgrErrorCode code) {
         super("Mcu Mgr Error: " + code);

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/image/McuMgrImage.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/image/McuMgrImage.java
@@ -31,16 +31,15 @@ public class McuMgrImage {
     private final McuMgrImageTlv mProtectedTlv;
     @NotNull
     private final McuMgrImageTlv mTlv;
-    @NotNull
-    private final byte[] mHash;
-    @NotNull
-    private final byte[] mData;
+
+    private final byte @NotNull [] mHash;
+    private final byte @NotNull [] mData;
 
     public McuMgrImage(@NotNull McuMgrImageHeader header,
                        @Nullable McuMgrImageTlv protectedTlv,
                        @NotNull McuMgrImageTlv tlv,
-                       @NotNull byte[] hash,
-                       @NotNull byte[] data) {
+                       byte @NotNull [] hash,
+                       byte @NotNull [] data) {
         mHeader = header;
         mProtectedTlv = protectedTlv;
         mTlv = tlv;
@@ -49,7 +48,7 @@ public class McuMgrImage {
     }
 
     @Deprecated
-    public McuMgrImage(@NotNull byte[] data) throws McuMgrException {
+    public McuMgrImage(byte @NotNull [] data) throws McuMgrException {
         McuMgrImage image = fromBytes(data);
         mHeader = image.mHeader;
         mProtectedTlv = image.mProtectedTlv;
@@ -58,8 +57,7 @@ public class McuMgrImage {
         mData = image.mData;
     }
 
-    @NotNull
-    public byte[] getData() {
+    public byte @NotNull [] getData() {
         return mData;
     }
 
@@ -78,18 +76,16 @@ public class McuMgrImage {
         return mTlv;
     }
 
-    @NotNull
-    public byte[] getHash() {
+    public byte @NotNull [] getHash() {
         return mHash;
     }
 
-    @NotNull
-    public static byte[] getHash(@NotNull byte[] data) throws McuMgrException {
+    public static byte @NotNull [] getHash(byte @NotNull [] data) throws McuMgrException {
         return fromBytes(data).getHash();
     }
 
     @NotNull
-    public static McuMgrImage fromBytes(@NotNull byte[] data) throws McuMgrException {
+    public static McuMgrImage fromBytes(byte @NotNull [] data) throws McuMgrException {
         McuMgrImageHeader header = McuMgrImageHeader.fromBytes(data);
         int tlvOffset = header.getHdrSize() + header.getImgSize();
         McuMgrImageTlv tlv = McuMgrImageTlv.fromBytes(data, tlvOffset, header.isLegacy());

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/image/McuMgrImageHeader.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/image/McuMgrImageHeader.java
@@ -27,13 +27,13 @@ public class McuMgrImageHeader {
     private static final int IMG_HEADER_MAGIC_V1   = 0x96f3b83c;
 
     private static final int HEADER_LENGTH = 24;
-    private int mMagic;
-    private int mLoadAddr;
-    private short mHdrSize;
-    private int mImgSize;
-    private int mFlags;
+    private final int mMagic;
+    private final int mLoadAddr;
+    private final short mHdrSize;
+    private final int mImgSize;
+    private final int mFlags;
     @NotNull
-    private McuMgrImageVersion mVersion;
+    private final McuMgrImageVersion mVersion;
 
     private McuMgrImageHeader(int magic,
                               int loadAddr,
@@ -50,12 +50,12 @@ public class McuMgrImageHeader {
     }
 
     @NotNull
-    public static McuMgrImageHeader fromBytes(@NotNull byte[] b) throws McuMgrException {
+    public static McuMgrImageHeader fromBytes(byte @NotNull [] b) throws McuMgrException {
         return fromBytes(b, 0);
     }
 
     @NotNull
-    public static McuMgrImageHeader fromBytes(@NotNull byte[] b, int offset) throws McuMgrException {
+    public static McuMgrImageHeader fromBytes(byte @NotNull [] b, int offset) throws McuMgrException {
         if (b.length - offset < getSize()) {
             throw new McuMgrException("The byte array is too short to be a McuMgrImageHeader");
         }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/image/McuMgrImageVersion.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/image/McuMgrImageVersion.java
@@ -35,12 +35,12 @@ public class McuMgrImageVersion {
     }
 
     @NotNull
-    public static McuMgrImageVersion fromBytes(@NotNull byte[] b) throws McuMgrException {
+    public static McuMgrImageVersion fromBytes(byte @NotNull [] b) throws McuMgrException {
         return fromBytes(b, 0);
     }
 
     @NotNull
-    public static McuMgrImageVersion fromBytes(@NotNull byte[] b, int offset) throws McuMgrException {
+    public static McuMgrImageVersion fromBytes(byte @NotNull [] b, int offset) throws McuMgrException {
         if (b.length - offset < getSize()) {
             throw new McuMgrException("The byte array is too short to be a McuMgrImageVersion");
         }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/image/McuMgrImageVersion.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/image/McuMgrImageVersion.java
@@ -22,10 +22,10 @@ import io.runtime.mcumgr.util.Endian;
 @SuppressWarnings("unused")
 public class McuMgrImageVersion {
 
-    private byte mMajor;
-    private byte mMinor;
-    private short mRevision;
-    private int mBuildNum;
+    private final byte mMajor;
+    private final byte mMinor;
+    private final short mRevision;
+    private final int mBuildNum;
 
     private McuMgrImageVersion(byte major, byte minor, short revision, int buildNum) {
         mMajor = major;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/image/tlv/McuMgrImageTlv.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/image/tlv/McuMgrImageTlv.java
@@ -54,11 +54,11 @@ public class McuMgrImageTlv {
     public final static int IMG_TLV_PROTECTED_INFO_MAGIC = 0x6908;
 
     @Nullable
-    private McuMgrImageTlvInfo mTlvInfo;
+    private final McuMgrImageTlvInfo mTlvInfo;
     @NotNull
-    private List<McuMgrImageTlvTrailerEntry> mTrailerEntries;
-    private boolean mIsLegacy;
-    private int mSize;
+    private final List<McuMgrImageTlvTrailerEntry> mTrailerEntries;
+    private final boolean mIsLegacy;
+    private final int mSize;
 
     private McuMgrImageTlv(@NotNull McuMgrImageTlvInfo tlvInfo,
                            @NotNull ArrayList<McuMgrImageTlvTrailerEntry> entries) {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/image/tlv/McuMgrImageTlv.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/image/tlv/McuMgrImageTlv.java
@@ -103,8 +103,7 @@ public class McuMgrImageTlv {
         return mTlvInfo.isProtected();
     }
 
-    @Nullable
-    public byte[] getHash() {
+    public byte @Nullable [] getHash() {
         for (McuMgrImageTlvTrailerEntry entry : getTrailerEntries()) {
             if (mIsLegacy && entry.type == IMG_TLV_SHA256_V1 ||
                     !mIsLegacy && entry.type == IMG_TLV_SHA256) {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/CrashManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/CrashManager.java
@@ -28,10 +28,14 @@ public class CrashManager extends McuManager {
         REF_0("ref0"),
         ASSERT("assert"),
         WDOG("wdog");
+
         private final String value;
-        Test(String value) {
+
+        Test(@NotNull String value) {
             this.value = value;
         }
+
+        @NotNull
         @Override
         public String toString() {
             return value;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/FsManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/FsManager.java
@@ -103,7 +103,7 @@ public class FsManager extends TransferManager {
      * @param callback the asynchronous callback.
      * @see #fileUpload(String, byte[], UploadCallback)
      */
-    public void upload(@NotNull String name, @NotNull byte[] data, int offset,
+    public void upload(@NotNull String name, byte @NotNull [] data, int offset,
                        @NotNull McuMgrCallback<McuMgrFsUploadResponse> callback) {
         HashMap<String, Object> payloadMap = buildUploadPayload(name, data, offset);
         send(OP_WRITE, ID_FILE, payloadMap, McuMgrFsUploadResponse.class, callback);
@@ -126,7 +126,7 @@ public class FsManager extends TransferManager {
      * @see #fileUpload(String, byte[], UploadCallback)
      */
     @NotNull
-    public McuMgrFsUploadResponse upload(@NotNull String name, @NotNull byte[] data, int offset)
+    public McuMgrFsUploadResponse upload(@NotNull String name, byte @NotNull [] data, int offset)
             throws McuMgrException {
         HashMap<String, Object> payloadMap = buildUploadPayload(name, data, offset);
         return send(OP_WRITE, ID_FILE, payloadMap, McuMgrFsUploadResponse.class);
@@ -136,7 +136,7 @@ public class FsManager extends TransferManager {
      * Build the upload payload map.
      */
     @NotNull
-    private HashMap<String, Object> buildUploadPayload(@NotNull String name, @NotNull byte[] data, int offset) {
+    private HashMap<String, Object> buildUploadPayload(@NotNull String name, byte @NotNull [] data, int offset) {
         // Get the length of data (in bytes) to put into the upload packet. This calculated as:
         // min(MTU - packetOverhead, imageLength - uploadOffset)
         int dataLength = Math.min(mMtu - calculatePacketOverhead(name, data, offset),
@@ -177,7 +177,7 @@ public class FsManager extends TransferManager {
      * @see TransferController
      */
     @NotNull
-    public TransferController fileUpload(@NotNull String name, @NotNull byte[] data, @NotNull UploadCallback callback) {
+    public TransferController fileUpload(@NotNull String name, byte @NotNull [] data, @NotNull UploadCallback callback) {
         return startUpload(new FileUpload(name, data, callback));
     }
 
@@ -187,15 +187,15 @@ public class FsManager extends TransferManager {
     public class FileUpload extends Upload {
 
         @NotNull
-        private String mName;
+        private final String mName;
 
-        protected FileUpload(@NotNull String name, @NotNull byte[] data, @NotNull UploadCallback callback) {
+        protected FileUpload(@NotNull String name, byte @NotNull [] data, @NotNull UploadCallback callback) {
             super(data, callback);
             mName = name;
         }
 
         @Override
-        protected UploadResponse write(@NotNull byte[] data, int offset) throws McuMgrException {
+        protected UploadResponse write(byte @NotNull [] data, int offset) throws McuMgrException {
             return upload(mName, data, offset);
         }
     }
@@ -236,7 +236,7 @@ public class FsManager extends TransferManager {
      */
     @Deprecated
     @NotNull
-    public TransferController fileDownload(@NotNull String name, @NotNull byte[] data, @NotNull DownloadCallback callback) {
+    public TransferController fileDownload(@NotNull String name, byte @NotNull [] data, @NotNull DownloadCallback callback) {
         return fileDownload(name, callback);
     }
 
@@ -246,7 +246,7 @@ public class FsManager extends TransferManager {
     public class FileDownload extends Download {
 
         @NotNull
-        private String mName;
+        private final String mName;
 
         protected FileDownload(@NotNull String name, @NotNull DownloadCallback callback) {
             super(callback);
@@ -311,7 +311,7 @@ public class FsManager extends TransferManager {
      * @deprecated Use {@link #fileUpload(String, byte[], UploadCallback)} instead.
      */
     @Deprecated
-    public synchronized void upload(@NotNull String name, @NotNull byte[] data,
+    public synchronized void upload(@NotNull String name, byte @NotNull [] data,
                                     @NotNull FileUploadCallback callback) {
         if (mTransferState == STATE_NONE) {
             mTransferState = STATE_UPLOADING;
@@ -604,7 +604,7 @@ public class FsManager extends TransferManager {
             };
 
     // TODO more precise overhead calculations
-    private int calculatePacketOverhead(@NotNull String name, @NotNull byte[] data, int offset) {
+    private int calculatePacketOverhead(@NotNull String name, byte @NotNull [] data, int offset) {
         HashMap<String, Object> overheadTestMap = new HashMap<>();
         overheadTestMap.put("name", name);
         overheadTestMap.put("data", new byte[0]);
@@ -708,6 +708,6 @@ public class FsManager extends TransferManager {
          * @param data file data.
          * @deprecated Old implementation. See {@link #fileUpload} and {@link #fileDownload}
          */
-        void onDownloadFinished(@NotNull String name, @NotNull byte[] data);
+        void onDownloadFinished(@NotNull String name, byte @NotNull [] data);
     }
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
@@ -118,7 +118,7 @@ public class ImageManager extends TransferManager {
      * @param callback the asynchronous callback.
      * @see #imageUpload(byte[], UploadCallback)
      */
-    public void upload(@NotNull byte[] data, int offset,
+    public void upload(byte @NotNull [] data, int offset,
                        @NotNull McuMgrCallback<McuMgrImageUploadResponse> callback) {
         upload(data, offset, 0, callback);
     }
@@ -142,7 +142,7 @@ public class ImageManager extends TransferManager {
      * @param callback the asynchronous callback.
      * @see #imageUpload(byte[], UploadCallback)
      */
-    public void upload(@NotNull byte[] data, int offset, int image,
+    public void upload(byte @NotNull [] data, int offset, int image,
                        @NotNull McuMgrCallback<McuMgrImageUploadResponse> callback) {
         HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, image);
         send(OP_WRITE, ID_UPLOAD, payloadMap, McuMgrImageUploadResponse.class, callback);
@@ -165,7 +165,7 @@ public class ImageManager extends TransferManager {
      * @see #imageUpload(byte[], UploadCallback)
      */
     @NotNull
-    public McuMgrImageUploadResponse upload(@NotNull byte[] data, int offset) throws McuMgrException {
+    public McuMgrImageUploadResponse upload(byte @NotNull [] data, int offset) throws McuMgrException {
         return upload(data, offset, 0);
     }
 
@@ -188,7 +188,7 @@ public class ImageManager extends TransferManager {
      * @see #imageUpload(byte[], UploadCallback)
      */
     @NotNull
-    public McuMgrImageUploadResponse upload(@NotNull byte[] data, int offset, int image)
+    public McuMgrImageUploadResponse upload(byte @NotNull [] data, int offset, int image)
             throws McuMgrException {
         HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, image);
         return send(OP_WRITE, ID_UPLOAD, payloadMap, McuMgrImageUploadResponse.class);
@@ -198,7 +198,7 @@ public class ImageManager extends TransferManager {
      * Build the upload payload.
      */
     @NotNull
-    private HashMap<String, Object> buildUploadPayload(@NotNull byte[] data, int offset, int image) {
+    private HashMap<String, Object> buildUploadPayload(byte @NotNull [] data, int offset, int image) {
         // Get chunk of image data to send
         int dataLength = Math.min(mMtu - calculatePacketOverhead(data, offset, image), data.length - offset);
         byte[] sendBuffer = new byte[dataLength];
@@ -244,7 +244,7 @@ public class ImageManager extends TransferManager {
      * @param hash     the hash of the image to test.
      * @param callback the asynchronous callback.
      */
-    public void test(@NotNull byte[] hash, @NotNull McuMgrCallback<McuMgrImageStateResponse> callback) {
+    public void test(byte @NotNull [] hash, @NotNull McuMgrCallback<McuMgrImageStateResponse> callback) {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("hash", hash);
         payloadMap.put("confirm", false);
@@ -262,7 +262,7 @@ public class ImageManager extends TransferManager {
      * @throws McuMgrException Transport error. See cause.
      */
     @NotNull
-    public McuMgrImageStateResponse test(@NotNull byte[] hash) throws McuMgrException {
+    public McuMgrImageStateResponse test(byte @NotNull [] hash) throws McuMgrException {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("hash", hash);
         payloadMap.put("confirm", false);
@@ -279,7 +279,7 @@ public class ImageManager extends TransferManager {
      *                 permanent.
      * @param callback the asynchronous callback.
      */
-    public void confirm(@Nullable byte[] hash, @NotNull McuMgrCallback<McuMgrImageStateResponse> callback) {
+    public void confirm(byte @Nullable [] hash, @NotNull McuMgrCallback<McuMgrImageStateResponse> callback) {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("confirm", true);
         if (hash != null) {
@@ -300,7 +300,7 @@ public class ImageManager extends TransferManager {
      * @throws McuMgrException Transport error. See cause.
      */
     @NotNull
-    public McuMgrImageStateResponse confirm(@Nullable byte[] hash) throws McuMgrException {
+    public McuMgrImageStateResponse confirm(byte @Nullable [] hash) throws McuMgrException {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("confirm", true);
         if (hash != null) {
@@ -541,7 +541,7 @@ public class ImageManager extends TransferManager {
      * @see TransferController
      */
     @NotNull
-    public TransferController imageUpload(@NotNull byte[] imageData,
+    public TransferController imageUpload(byte @NotNull [] imageData,
                                           @NotNull UploadCallback callback) {
         return imageUpload(imageData, 0, callback);
     }
@@ -561,7 +561,7 @@ public class ImageManager extends TransferManager {
      * @see TransferController
      */
     @NotNull
-    public TransferController imageUpload(@NotNull byte[] imageData, int image,
+    public TransferController imageUpload(byte @NotNull [] imageData, int image,
                                           @NotNull UploadCallback callback) {
         return startUpload(new ImageUpload(imageData, image, callback));
     }
@@ -572,13 +572,13 @@ public class ImageManager extends TransferManager {
     public class ImageUpload extends Upload {
         private final int mImage;
 
-        protected ImageUpload(@NotNull byte[] imageData, int image, @NotNull UploadCallback callback) {
+        protected ImageUpload(byte @NotNull [] imageData, int image, @NotNull UploadCallback callback) {
             super(imageData, callback);
             mImage = image;
         }
 
         @Override
-        protected UploadResponse write(@NotNull byte[] data, int offset) throws McuMgrException {
+        protected UploadResponse write(byte @NotNull [] data, int offset) throws McuMgrException {
             return upload(data, offset, mImage);
         }
     }
@@ -610,7 +610,7 @@ public class ImageManager extends TransferManager {
      * @deprecated Use the new transfer implementation's imageUpload(...) method
      */
     @Deprecated
-    public synchronized boolean upload(@NotNull byte[] data, @NotNull ImageUploadCallback callback) {
+    public synchronized boolean upload(byte @NotNull [] data, @NotNull ImageUploadCallback callback) {
         if (mUploadState == STATE_NONE) {
             mUploadState = STATE_UPLOADING;
         } else {
@@ -793,7 +793,7 @@ public class ImageManager extends TransferManager {
             };
 
     // TODO more precise overhead calculations
-    private int calculatePacketOverhead(@NotNull byte[] data, int offset, int image) {
+    private int calculatePacketOverhead(byte @NotNull [] data, int offset, int image) {
         HashMap<String, Object> overheadTestMap = new HashMap<>();
         overheadTestMap.put("data", new byte[0]);
         overheadTestMap.put("off", offset);

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
@@ -120,7 +120,31 @@ public class ImageManager extends TransferManager {
      */
     public void upload(@NotNull byte[] data, int offset,
                        @NotNull McuMgrCallback<McuMgrImageUploadResponse> callback) {
-        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset);
+        upload(data, offset, 0, callback);
+    }
+
+    /**
+     * Send a packet of given data from the specified offset to the given core (image) on the
+     * device (asynchronous).
+     * <p>
+     * The chunk size is limited by the current MTU. If the current MTU set by
+     * {@link #setUploadMtu(int)} is too large, the {@link McuMgrCallback#onError(McuMgrException)}
+     * with {@link InsufficientMtuException} error will be returned.
+     * Use {@link InsufficientMtuException#getMtu()} to get the current MTU and
+     * pass it to {@link #setUploadMtu(int)} and try again.
+     * <p>
+     * Use {@link #imageUpload(byte[], UploadCallback)} to send the whole file asynchronously
+     * using one command.
+     *
+     * @param data     image data.
+     * @param offset   the offset, from which the chunk will be sent.
+     * @param image    the image number, default is 0. Use 0 for core0, 1 for core1, etc.
+     * @param callback the asynchronous callback.
+     * @see #imageUpload(byte[], UploadCallback)
+     */
+    public void upload(@NotNull byte[] data, int offset, int image,
+                       @NotNull McuMgrCallback<McuMgrImageUploadResponse> callback) {
+        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, image);
         send(OP_WRITE, ID_UPLOAD, payloadMap, McuMgrImageUploadResponse.class, callback);
     }
 
@@ -142,7 +166,31 @@ public class ImageManager extends TransferManager {
      */
     @NotNull
     public McuMgrImageUploadResponse upload(@NotNull byte[] data, int offset) throws McuMgrException {
-        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset);
+        return upload(data, offset, 0);
+    }
+
+    /**
+     * Send a packet of given data from the specified offset to the given core (image) on the
+     * device (synchronous).
+     * <p>
+     * The chunk size is limited by the current MTU. If the current MTU set by
+     * {@link #setUploadMtu(int)} is too large, the {@link InsufficientMtuException} error will be
+     * thrown. Use {@link InsufficientMtuException#getMtu()} to get the current MTU and
+     * pass it to {@link #setUploadMtu(int)} and try again.
+     * <p>
+     * Use {@link #imageUpload(byte[], UploadCallback)} to send the whole file asynchronously
+     * using one command.
+     *
+     * @param data   image data.
+     * @param offset the offset, from which the chunk will be sent.
+     * @param image    the image number, default is 0. Use 0 for core0, 1 for core1, etc.
+     * @return The upload response.
+     * @see #imageUpload(byte[], UploadCallback)
+     */
+    @NotNull
+    public McuMgrImageUploadResponse upload(@NotNull byte[] data, int offset, int image)
+            throws McuMgrException {
+        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, image);
         return send(OP_WRITE, ID_UPLOAD, payloadMap, McuMgrImageUploadResponse.class);
     }
 
@@ -150,9 +198,9 @@ public class ImageManager extends TransferManager {
      * Build the upload payload.
      */
     @NotNull
-    private HashMap<String, Object> buildUploadPayload(@NotNull byte[] data, int offset) {
+    private HashMap<String, Object> buildUploadPayload(@NotNull byte[] data, int offset, int image) {
         // Get chunk of image data to send
-        int dataLength = Math.min(mMtu - calculatePacketOverhead(data, offset), data.length - offset);
+        int dataLength = Math.min(mMtu - calculatePacketOverhead(data, offset, image), data.length - offset);
         byte[] sendBuffer = new byte[dataLength];
         System.arraycopy(data, offset, sendBuffer, 0, dataLength);
 
@@ -161,7 +209,11 @@ public class ImageManager extends TransferManager {
         payloadMap.put("data", sendBuffer);
         payloadMap.put("off", offset);
         if (offset == 0) {
-            // Only send the length of the image in the first packet of the upload
+            // Only send the length and image of the image in the first packet of the upload
+            if (image > 0) {
+                // Image 0 does not need to be sent, as it's default.
+                payloadMap.put("image", image);
+            }
             payloadMap.put("len", data.length);
 
             /*
@@ -258,43 +310,107 @@ public class ImageManager extends TransferManager {
     }
 
     /**
-     * Erase the image in slot 1 (asynchronous).
+     * Erase the secondary slot of the main image (asynchronous).
      *
      * @param callback the asynchronous callback.
      */
     public void erase(@NotNull McuMgrCallback<McuMgrResponse> callback) {
-        send(OP_WRITE, ID_ERASE, null, McuMgrResponse.class, callback);
+        erase(0, callback);
     }
 
     /**
-     * Erase the image in slot 1 (synchronous).
+     * Erase the secondary slot of the given image (asynchronous).
+     *
+     * @param image    the image number, default is 0. Use 0 for core0, 1 for core1, etc.
+     * @param callback the asynchronous callback.
+     */
+    public void erase(int image, @NotNull McuMgrCallback<McuMgrResponse> callback) {
+        HashMap<String, Object> payloadMap = null;
+        if (image > 0) {
+            payloadMap = new HashMap<>();
+            payloadMap.put("image", image);
+        }
+        send(OP_WRITE, ID_ERASE, payloadMap, McuMgrResponse.class, callback);
+    }
+
+    /**
+     * Erase the secondary slot of the main image (synchronous).
      *
      * @return The response.
      * @throws McuMgrException Transport error. See cause.
      */
     @NotNull
     public McuMgrResponse erase() throws McuMgrException {
-        return send(OP_WRITE, ID_ERASE, null, McuMgrResponse.class);
+        return erase(0);
     }
 
     /**
-     * Erase the state of image in slot 1 (asynchronous).
+     * Erase the secondary slot of the given image (synchronous).
+     *
+     * @param image the image number, default is 0. Use 0 for core0, 1 for core1, etc.
+     * @return The response.
+     * @throws McuMgrException Transport error. See cause.
+     */
+    @NotNull
+    public McuMgrResponse erase(int image) throws McuMgrException {
+        HashMap<String, Object> payloadMap = null;
+        if (image > 0) {
+            payloadMap = new HashMap<>();
+            payloadMap.put("image", image);
+        }
+        return send(OP_WRITE, ID_ERASE, payloadMap, McuMgrResponse.class);
+    }
+
+    /**
+     * Erase the state of secondary slot of main image (asynchronous).
      *
      * @param callback the asynchronous callback.
      */
     public void eraseState(@NotNull McuMgrCallback<McuMgrResponse> callback) {
-        send(OP_WRITE, ID_ERASE_STATE, null, McuMgrResponse.class, callback);
+        eraseState(0, callback);
     }
 
     /**
-     * Erase the state of image in slot 1 (synchronous).
+     * Erase the state of secondary slot of the main image (asynchronous).
+     *
+     * @param image    the image number, default is 0. Use 0 for core0, 1 for core1, etc.
+     * @param callback the asynchronous callback.
+     */
+    public void eraseState(int image, @NotNull McuMgrCallback<McuMgrResponse> callback) {
+        HashMap<String, Object> payloadMap = null;
+        if (image > 0) {
+            payloadMap = new HashMap<>();
+            payloadMap.put("image", image);
+        }
+        send(OP_WRITE, ID_ERASE_STATE, payloadMap, McuMgrResponse.class, callback);
+    }
+
+    /**
+     * Erase the state of secondary slot of the main image (synchronous).
      *
      * @return The response.
      * @throws McuMgrException Transport error. See cause.
      */
     @NotNull
     public McuMgrResponse eraseState() throws McuMgrException {
-        return send(OP_WRITE, ID_ERASE_STATE, null, McuMgrResponse.class);
+        return eraseState(0);
+    }
+
+    /**
+     * Erase the state of secondary slot of given image (synchronous).
+     *
+     * @param image the image number, default is 0. Use 0 for core0, 1 for core1, etc.
+     * @return The response.
+     * @throws McuMgrException Transport error. See cause.
+     */
+    @NotNull
+    public McuMgrResponse eraseState(int image) throws McuMgrException {
+        HashMap<String, Object> payloadMap = null;
+        if (image > 0) {
+            payloadMap = new HashMap<>();
+            payloadMap.put("image", image);
+        }
+        return send(OP_WRITE, ID_ERASE_STATE, payloadMap, McuMgrResponse.class);
     }
 
     /**
@@ -425,21 +541,45 @@ public class ImageManager extends TransferManager {
      * @see TransferController
      */
     @NotNull
-    public TransferController imageUpload(@NotNull byte[] imageData, @NotNull UploadCallback callback) {
-        return startUpload(new ImageUpload(imageData, callback));
+    public TransferController imageUpload(@NotNull byte[] imageData,
+                                          @NotNull UploadCallback callback) {
+        return imageUpload(imageData, 0, callback);
+    }
+
+    /**
+     * Start image upload.
+     * <p>
+     * Multiple calls will queue multiple uploads, executed sequentially. This includes core
+     * downloads executed from {@link #coreDownload}.
+     * <p>
+     * The upload may be controlled using the {@link TransferController} returned by this method.
+     *
+     * @param imageData The image data to upload.
+     * @param image     The image number, default is 0. Use 0 for core0, 1 for core1, etc.
+     * @param callback  Receives callbacks from the upload.
+     * @return The object used to control this upload.
+     * @see TransferController
+     */
+    @NotNull
+    public TransferController imageUpload(@NotNull byte[] imageData, int image,
+                                          @NotNull UploadCallback callback) {
+        return startUpload(new ImageUpload(imageData, image, callback));
     }
 
     /**
      * Image Upload Implementation
      */
     public class ImageUpload extends Upload {
-        protected ImageUpload(@NotNull byte[] imageData, @NotNull UploadCallback callback) {
+        private final int mImage;
+
+        protected ImageUpload(@NotNull byte[] imageData, int image, @NotNull UploadCallback callback) {
             super(imageData, callback);
+            mImage = image;
         }
 
         @Override
         protected UploadResponse write(@NotNull byte[] data, int offset) throws McuMgrException {
-            return upload(data, offset);
+            return upload(data, offset, mImage);
         }
     }
 
@@ -653,11 +793,14 @@ public class ImageManager extends TransferManager {
             };
 
     // TODO more precise overhead calculations
-    private int calculatePacketOverhead(@NotNull byte[] data, int offset) {
+    private int calculatePacketOverhead(@NotNull byte[] data, int offset, int image) {
         HashMap<String, Object> overheadTestMap = new HashMap<>();
         overheadTestMap.put("data", new byte[0]);
         overheadTestMap.put("off", offset);
         if (offset == 0) {
+            if (image > 0) {
+                overheadTestMap.put("image", image);
+            }
             overheadTestMap.put("len", data.length);
             overheadTestMap.put("sha", new byte[TRUNCATED_HASH_LEN]);
         }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/LogManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/LogManager.java
@@ -335,12 +335,12 @@ public class LogManager extends McuManager {
         /**
          * The name of the log.
          */
-        private String mName;
+        private final String mName;
 
         /**
          * The next index to use to get new logs.
          */
-        private long mNextIndex = 0;
+        private long mNextIndex;
 
         /**
          * The list of entries pulled from the log.

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/McuMgrResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/McuMgrResponse.java
@@ -142,8 +142,7 @@ public class McuMgrResponse {
      *
      * @return The payload bytes.
      */
-    @Nullable
-    public byte[] getPayload() {
+    public byte @Nullable [] getPayload() {
         return mPayload;
     }
 
@@ -185,8 +184,8 @@ public class McuMgrResponse {
      * @param header  McuMgrHeader.
      * @param payload McuMgr CBOR payload.
      */
-    void initFields(@NotNull McuMgrScheme scheme, @NotNull byte[] bytes,
-                    @NotNull McuMgrHeader header, @NotNull byte[] payload) {
+    void initFields(@NotNull McuMgrScheme scheme, byte @NotNull [] bytes,
+                    @NotNull McuMgrHeader header, byte @NotNull [] payload) {
         mScheme = scheme;
         mBytes = bytes;
         mHeader = header;
@@ -206,7 +205,7 @@ public class McuMgrResponse {
      */
     @NotNull
     public static <T extends McuMgrResponse> T buildResponse(@NotNull McuMgrScheme scheme,
-                                                             @NotNull byte[] bytes,
+                                                             byte @NotNull [] bytes,
                                                              @NotNull Class<T> type)
             throws IOException {
         if (scheme.isCoap()) {
@@ -241,9 +240,9 @@ public class McuMgrResponse {
      */
     @NotNull
     public static <T extends McuMgrResponse> T buildCoapResponse(@NotNull McuMgrScheme scheme,
-                                                                 @NotNull byte[] bytes,
-                                                                 @NotNull byte[] header,
-                                                                 @NotNull byte[] payload,
+                                                                 byte @NotNull [] bytes,
+                                                                 byte @NotNull [] header,
+                                                                 byte @NotNull [] payload,
                                                                  int codeClass, int codeDetail,
                                                                  Class<T> type)
             throws IOException, McuMgrCoapException {
@@ -272,7 +271,7 @@ public class McuMgrResponse {
      * @throws IOException                   thrown when the header could not be parsed.
      * @throws UnsupportedOperationException when scheme is not equal to {@link McuMgrScheme#BLE}.
      */
-    public static int getExpectedLength(@NotNull McuMgrScheme scheme, @NotNull byte[] bytes)
+    public static int getExpectedLength(@NotNull McuMgrScheme scheme, byte @NotNull [] bytes)
             throws IOException {
         if (scheme.isCoap()) {
             throw new UnsupportedOperationException("Method not implemented for CoAP");

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/fs/McuMgrFsDownloadResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/fs/McuMgrFsDownloadResponse.java
@@ -8,10 +8,8 @@
 package io.runtime.mcumgr.response.fs;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.runtime.mcumgr.response.DownloadResponse;
-import io.runtime.mcumgr.response.McuMgrResponse;
 
 public class McuMgrFsDownloadResponse extends DownloadResponse {
     @JsonCreator

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/fs/McuMgrFsUploadResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/fs/McuMgrFsUploadResponse.java
@@ -8,9 +8,7 @@
 package io.runtime.mcumgr.response.fs;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
-import io.runtime.mcumgr.response.McuMgrResponse;
 import io.runtime.mcumgr.response.UploadResponse;
 
 public class McuMgrFsUploadResponse extends UploadResponse {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrCoreLoadResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrCoreLoadResponse.java
@@ -23,10 +23,8 @@
 package io.runtime.mcumgr.response.img;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.runtime.mcumgr.response.DownloadResponse;
-import io.runtime.mcumgr.response.McuMgrResponse;
 
 public class McuMgrCoreLoadResponse extends DownloadResponse {
     @JsonCreator

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageStateResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageStateResponse.java
@@ -35,6 +35,14 @@ public class McuMgrImageStateResponse extends McuMgrResponse {
      * The single image slot data structure.
      */
     public static class ImageSlot {
+        /**
+         * The image number used for multi-core devices.
+         * The main core image has index 0, second core image is 1, etc.
+         * E.g. nRF5340 has 2 cores: application core (0) and network core (1).
+         * For single core devices the value is 0 (default).
+         */
+        @JsonProperty("image")
+        public int image;
         /** The slot number: 0 or 1. */
         @JsonProperty("slot")
         public int slot;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageUploadResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageUploadResponse.java
@@ -7,9 +7,7 @@
 package io.runtime.mcumgr.response.img;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
-import io.runtime.mcumgr.response.McuMgrResponse;
 import io.runtime.mcumgr.response.UploadResponse;
 
 public class McuMgrImageUploadResponse extends UploadResponse {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/task/Task.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/task/Task.java
@@ -1,11 +1,9 @@
 package io.runtime.mcumgr.task;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
-import io.runtime.mcumgr.exception.McuMgrException;
-
-public abstract class Task<S> implements Comparable<Task<S>> {
+public abstract class Task<S, State> implements Comparable<Task<S, State>> {
 
 	protected Task() {
 	}
@@ -16,9 +14,14 @@ public abstract class Task<S> implements Comparable<Task<S>> {
 	 * @return The task priority.
 	 */
 	public abstract int getPriority();
+	/**
+	 * Returns the state that will be reported to the callback.
+	 * @return The state in which the manager is in.
+	 */
+	@Nullable
+	public abstract State getState();
 
-	public abstract void start(@NotNull final S settings,
-							   @NotNull final TaskPerformer<S> performer);
+	public abstract void start(@NotNull final TaskManager<S, State> performer);
 
 	public void pause() {
 		// Empty default implementation.
@@ -29,7 +32,7 @@ public abstract class Task<S> implements Comparable<Task<S>> {
 	}
 
 	@Override
-	public final int compareTo(final Task<S> o) {
+	public final int compareTo(final Task<S, State> o) {
 		return getPriority() - o.getPriority();
 	}
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/task/Task.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/task/Task.java
@@ -1,0 +1,35 @@
+package io.runtime.mcumgr.task;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
+import io.runtime.mcumgr.exception.McuMgrException;
+
+public abstract class Task<S> implements Comparable<Task<S>> {
+
+	protected Task() {
+	}
+
+	/**
+	 * Returns task priority. Tasks are added to a priority queue and must be executed in
+	 * the right order, but can be added to the list in any order.
+	 * @return The task priority.
+	 */
+	public abstract int getPriority();
+
+	public abstract void start(@NotNull final S settings,
+							   @NotNull final TaskPerformer<S> performer);
+
+	public void pause() {
+		// Empty default implementation.
+	}
+
+	public void cancel() {
+		// Empty default implementation.
+	}
+
+	@Override
+	public final int compareTo(final Task<S> o) {
+		return getPriority() - o.getPriority();
+	}
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/task/TaskManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/task/TaskManager.java
@@ -1,0 +1,21 @@
+package io.runtime.mcumgr.task;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.runtime.mcumgr.exception.McuMgrException;
+
+public interface TaskManager<S, State> {
+
+	@NotNull
+	S getSettings();
+
+	void enqueue(@NotNull final Task<S, State> task);
+
+	void onTaskProgressChanged(@NotNull final Task<S, State> task,
+							   final int current, final int total, final long timestamp);
+
+	void onTaskCompleted(@NotNull final Task<S, State> task);
+
+	void onTaskFailed(@NotNull final Task<S, State> task, @NotNull final McuMgrException error);
+
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/task/TaskPerformer.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/task/TaskPerformer.java
@@ -1,11 +1,206 @@
 package io.runtime.mcumgr.task;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
 import io.runtime.mcumgr.exception.McuMgrException;
 
-public interface TaskPerformer<S> {
-	void enqueue(@NotNull final Task<S> task);
-	void onTaskCompleted();
-	void onTaskFailed(@NotNull final McuMgrException error);
+public abstract class TaskPerformer<S, State> {
+
+	@Nullable
+	private TaskManagerImpl manager;
+
+	public TaskPerformer() {
+	}
+
+	public void start(@NotNull final S settings,
+					  @NotNull final Task<S, State> task) {
+		this.manager = new TaskManagerImpl(settings);
+
+		onTaskStarted(null, task);
+		task.start(manager);
+	}
+
+	@Nullable
+	public Task<S, State> getCurrentTask() {
+		if (manager != null) {
+			return manager.currentTask;
+		}
+		return null;
+	}
+
+	public void pause() {
+		if (manager != null) {
+			manager.pause();
+		}
+	}
+
+	public void resume() {
+		if (manager != null) {
+			manager.resume();
+		}
+	}
+
+	public void cancel() {
+		if (manager != null) {
+			manager.cancel();
+		}
+	}
+
+	public boolean isPaused() {
+		if (manager != null) {
+			return manager.isPaused();
+		}
+		return false;
+	}
+
+	public boolean isBusy() {
+		return getCurrentTask() != null;
+	}
+
+	private class TaskManagerImpl implements TaskManager<S, State> {
+		/**
+		 * The queue of tasks to be performed during the update. The content of the queue
+		 * depends on the images given in {@link FirmwareUpgradeManager#start(List)} and the state of the device,
+		 * which is determined by validation step before the upload begins.
+		 */
+		@NotNull
+		private final Queue<Task<S, State>> taskQueue = new PriorityQueue<>();
+
+		/**
+		 * The currently performed task.
+		 */
+		@Nullable
+		private Task<S, State> currentTask;
+
+		@NotNull
+		private final S settings;
+
+		private boolean paused;
+		private boolean cancelled;
+
+		private TaskManagerImpl(@NotNull final S settings) {
+			this.settings = settings;
+		}
+
+		private void pause() {
+			final Task<S, State> task = currentTask;
+			if (paused || task == null)
+				return;
+			paused = true;
+			task.pause();
+		}
+
+		private void resume() {
+			final Task<S, State> task = currentTask;
+			if (!paused || task == null)
+				return;
+			paused = false;
+			task.start(this);
+		}
+
+		private void cancel() {
+			final Task<S, State> task = currentTask;
+			if (cancelled || task == null)
+				return;
+			cancelled = true;
+			paused = false;
+			task.cancel();
+		}
+
+		private boolean isPaused() {
+			return paused;
+		}
+
+		@NotNull
+		@Override
+		public S getSettings() {
+			return settings;
+		}
+
+		@Override
+		public void enqueue(final @NotNull Task<S, State> task) {
+			taskQueue.add(task);
+		}
+
+		@Override
+		public void onTaskProgressChanged(final @NotNull Task<S, State> task,
+										  final int current, final int total, final long timestamp) {
+			TaskPerformer.this.onTaskProgressChanged(task, current, total, timestamp);
+		}
+
+		@Override
+		public void onTaskCompleted(final @NotNull Task<S, State> task) {
+			// Has the process been cancelled?
+			if (cancelled) {
+				cleanUp();
+				TaskPerformer.this.onCancelled(task);
+				return;
+			}
+
+			// Poll the next task. If there's nothing, we're done.
+			final Task<S, State> nextTask = currentTask = taskQueue.poll();
+			if (nextTask == null) {
+				cleanUp();
+				TaskPerformer.this.onCompleted(task);
+				return;
+			}
+
+			TaskPerformer.this.onTaskStarted(task, nextTask);
+
+			// Should we pause a bit?
+			if (paused) {
+				return;
+			}
+
+			// Run the next task.
+			nextTask.start(this);
+		}
+
+		@Override
+		public void onTaskFailed(final @NotNull Task<S, State> task,
+								 final @NotNull McuMgrException error) {
+			cleanUp();
+			TaskPerformer.this.onTaskFailed(task, error);
+		}
+
+		private void cleanUp() {
+			taskQueue.clear();
+			currentTask = null;
+			paused = false;
+			cancelled = false;
+			TaskPerformer.this.manager = null;
+		}
+	}
+
+	public void onTaskProgressChanged(final @NotNull Task<S, State> task,
+									  final int current, final int total, final long timestamp) {
+
+	}
+
+	public void onTaskStarted(@Nullable final Task<S, State> previousTask,
+							  @NotNull final Task<S, State> newTask) {
+
+	}
+
+	public void onCancelled(@NotNull final Task<S, State> task) {
+
+	}
+
+	public void onCompleted(@NotNull final Task<S, State> task) {
+
+	}
+
+	public void onTaskFailed(@NotNull final Task<S, State> task,
+							 @NotNull final McuMgrException error) {
+	}
+
+	private void cleanUp() {
+		manager = null;
+	}
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/task/TaskPerformer.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/task/TaskPerformer.java
@@ -1,0 +1,11 @@
+package io.runtime.mcumgr.task;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.runtime.mcumgr.exception.McuMgrException;
+
+public interface TaskPerformer<S> {
+	void enqueue(@NotNull final Task<S> task);
+	void onTaskCompleted();
+	void onTaskFailed(@NotNull final McuMgrException error);
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Download.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Download.java
@@ -14,7 +14,7 @@ import io.runtime.mcumgr.response.McuMgrResponse;
 public abstract class Download extends Transfer {
 
     @Nullable
-    private DownloadCallback mCallback;
+    private final DownloadCallback mCallback;
 
     protected Download() {
         this(null);

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/DownloadCallback.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/DownloadCallback.java
@@ -1,7 +1,6 @@
 package io.runtime.mcumgr.transfer;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import io.runtime.mcumgr.exception.McuMgrException;
 
@@ -32,5 +31,5 @@ public interface DownloadCallback {
      *
      * @param data downloaded data.
      */
-    void onDownloadCompleted(@NotNull byte[] data);
+    void onDownloadCompleted(byte @NotNull [] data);
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Transfer.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Transfer.java
@@ -8,8 +8,7 @@ import io.runtime.mcumgr.response.McuMgrResponse;
 @SuppressWarnings({"WeakerAccess", "unused"})
 public abstract class Transfer implements TransferCallback {
 
-    @Nullable
-    byte[] mData;
+    byte @Nullable [] mData;
     int mOffset;
 
     Transfer() {
@@ -22,12 +21,12 @@ public abstract class Transfer implements TransferCallback {
         mOffset = offset;
     }
 
-    Transfer(@Nullable byte[] data) {
+    Transfer(byte @Nullable [] data) {
         mData = data;
         mOffset = 0;
     }
 
-    Transfer(@Nullable byte[] data, int offset) {
+    Transfer(byte @Nullable [] data, int offset) {
         mData = data;
         mOffset = offset;
     }
@@ -63,8 +62,7 @@ public abstract class Transfer implements TransferCallback {
      *
      * @return the data.
      */
-    @Nullable
-    public byte[] getData() {
+    public byte @Nullable [] getData() {
         return mData;
     }
 

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/TransferCallable.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/TransferCallable.java
@@ -15,7 +15,7 @@ public class TransferCallable implements Callable<Transfer>, TransferController 
         NONE, TRANSFER, PAUSED, CLOSED
     }
 
-    private Transfer mTransfer;
+    private final Transfer mTransfer;
     private State mState;
     private final ConditionVariable mPauseLock = new ConditionVariable(true);
 

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Upload.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Upload.java
@@ -12,7 +12,7 @@ import io.runtime.mcumgr.response.UploadResponse;
 @SuppressWarnings("unused")
 public abstract class Upload extends Transfer {
 
-    private UploadCallback mCallback;
+    private final UploadCallback mCallback;
 
     protected Upload(@NotNull byte[] data) {
         this(data, null);

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Upload.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Upload.java
@@ -14,16 +14,16 @@ public abstract class Upload extends Transfer {
 
     private final UploadCallback mCallback;
 
-    protected Upload(@NotNull byte[] data) {
+    protected Upload(byte @NotNull [] data) {
         this(data, null);
     }
 
-    protected Upload(@NotNull byte[] data, @Nullable UploadCallback callback) {
+    protected Upload(byte @NotNull [] data, @Nullable UploadCallback callback) {
         super(data);
         mCallback = callback;
     }
 
-    protected abstract UploadResponse write(@NotNull byte[] data, int offset) throws McuMgrException;
+    protected abstract UploadResponse write(byte @NotNull [] data, int offset) throws McuMgrException;
 
     @Override
     public McuMgrResponse send(int offset) throws McuMgrException {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/UploadResult.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/UploadResult.kt
@@ -1,7 +1,6 @@
 package io.runtime.mcumgr.transfer
 
 import io.runtime.mcumgr.McuMgrErrorCode
-import io.runtime.mcumgr.R
 import io.runtime.mcumgr.response.UploadResponse
 
 class ErrorResponseException internal constructor(

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
@@ -203,7 +203,7 @@ abstract class Uploader(
         // Size of the string "off" plus the length of the offset integer
         val offsetSize = cborStringLength("off") + cborUIntLength(offset)
 
-        val lengthSize = if (offset == 0) {
+        val lengthSize = getAdditionalSize() + if (offset == 0) {
             // Size of the string "len" plus the length of the data size integer
             cborStringLength("len") + cborUIntLength(data.size)
         } else {
@@ -226,6 +226,8 @@ abstract class Uploader(
         val maxChunkSize = mtu - combinedSize - maxDataUIntTokenSize
         return min(maxChunkSize, data.size - offset)
     }
+
+    internal open fun getAdditionalSize() = 0
 }
 
 /**

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/util/ByteUtil.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/util/ByteUtil.java
@@ -41,7 +41,7 @@ public class ByteUtil {
      * @param data the byte array.
      * @return The unsigned integer.
      */
-    public static int byteArrayToUnsignedInt(@NotNull byte[] data) {
+    public static int byteArrayToUnsignedInt(byte @NotNull [] data) {
         return byteArrayToUnsignedInt(data, 0, Endian.BIG, INT_WIDTH);
     }
 
@@ -54,7 +54,7 @@ public class ByteUtil {
      * @param offset the offset to start parsing the int.
      * @return The unsigned integer.
      */
-    public static int byteArrayToUnsignedInt(@NotNull byte[] data, int offset) {
+    public static int byteArrayToUnsignedInt(byte @NotNull [] data, int offset) {
         return byteArrayToUnsignedInt(data, offset, Endian.BIG, INT_WIDTH);
     }
 
@@ -70,7 +70,7 @@ public class ByteUtil {
      *               If null, {@link Endian#BIG} is assumed
      * @return The unsigned integer.
      */
-    public static int byteArrayToUnsignedInt(@NotNull byte[] data,
+    public static int byteArrayToUnsignedInt(byte @NotNull [] data,
                                              int offset,
                                              @Nullable Endian endian) {
         return byteArrayToUnsignedInt(data, offset, endian, INT_WIDTH);
@@ -86,7 +86,7 @@ public class ByteUtil {
      * @param length the number of bytes to convert to an int. This number must be between 0 and 4.
      * @return The unsigned integer.
      */
-    public static int byteArrayToUnsignedInt(@NotNull byte[] data,
+    public static int byteArrayToUnsignedInt(byte @NotNull [] data,
                                              int offset,
                                              @Nullable Endian endian,
                                              int length) {
@@ -128,7 +128,7 @@ public class ByteUtil {
      * @param data the byte array.
      * @return The unsigned long.
      */
-    public static long byteArrayToUnsignedLong(@NotNull byte[] data) {
+    public static long byteArrayToUnsignedLong(byte @NotNull [] data) {
         return byteArrayToUnsignedLong(data, 0, Endian.BIG, LONG_WIDTH);
     }
 
@@ -141,7 +141,7 @@ public class ByteUtil {
      * @param offset the offset to start parsing the long.
      * @return The unsigned long.
      */
-    public static long byteArrayToUnsignedLong(@NotNull byte[] data, int offset) {
+    public static long byteArrayToUnsignedLong(byte @NotNull [] data, int offset) {
         return byteArrayToUnsignedLong(data, offset, Endian.BIG, LONG_WIDTH);
     }
 
@@ -157,7 +157,7 @@ public class ByteUtil {
      *               If null, {@link Endian#BIG} is assumed
      * @return The unsigned long.
      */
-    public static long byteArrayToUnsignedLong(@NotNull byte[] data,
+    public static long byteArrayToUnsignedLong(byte @NotNull [] data,
                                              int offset,
                                              @Nullable Endian endian) {
         return byteArrayToUnsignedLong(data, offset, endian, LONG_WIDTH);
@@ -173,7 +173,7 @@ public class ByteUtil {
      * @param length the number of bytes to convert to a long. This number must be between 0 and 4.
      * @return The unsigned long.
      */
-    public static long byteArrayToUnsignedLong(@NotNull byte[] data,
+    public static long byteArrayToUnsignedLong(byte @NotNull [] data,
                                              int offset,
                                              @Nullable Endian endian,
                                              int length) {
@@ -199,17 +199,17 @@ public class ByteUtil {
     //******************************************************************
 
     @NotNull
-    public static String byteArrayToHex(@NotNull byte[] a) {
+    public static String byteArrayToHex(byte @NotNull [] a) {
         return byteArrayToHex(a, 0, a.length, "%02x ");
     }
 
     @NotNull
-    public static String byteArrayToHex(@NotNull byte[] a, String format) {
+    public static String byteArrayToHex(byte @NotNull [] a, String format) {
         return byteArrayToHex(a, 0, a.length, format);
     }
 
     @NotNull
-    public static String byteArrayToHex(@NotNull byte[] a, int offset, int length, String format) {
+    public static String byteArrayToHex(byte @NotNull [] a, int offset, int length, String format) {
         StringBuilder sb = new StringBuilder(a.length * 2);
         for (int i = offset; i < length; i++) {
             sb.append(String.format(format, a[i]));

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/util/CBOR.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/util/CBOR.java
@@ -41,7 +41,6 @@ public class CBOR {
         return mapper.readTree(data, offset, data.length - offset).toString();
     }
 
-    @SuppressWarnings("RedundantThrows")
     public static <T> String toString(T obj) throws IOException {
         ObjectMapper mapper = new ObjectMapper(sFactory);
         return mapper.valueToTree(obj).toString();
@@ -64,13 +63,13 @@ public class CBOR {
         return mapper.readValue(inputStream, typeRef);
     }
 
-    public static <T> T getObject(@NotNull byte[] data, @NotNull String key, @NotNull Class<T> type) throws IOException {
+    public static <T> T getObject(byte @NotNull [] data, @NotNull String key, @NotNull Class<T> type) throws IOException {
         ObjectMapper mapper = new ObjectMapper(sFactory);
         return mapper.convertValue(mapper.readTree(data).get(key), type);
     }
 
     @NotNull
-    public static String getString(@NotNull byte[] data, @NotNull String key) throws IOException {
+    public static String getString(byte @NotNull [] data, @NotNull String key) throws IOException {
         ObjectMapper mapper = new ObjectMapper(sFactory);
         return mapper.readTree(data).get(key).asText();
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -45,22 +45,25 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 
     // Dagger 2
-    implementation 'com.google.dagger:dagger:2.35.1'
-    implementation 'com.google.dagger:dagger-android:2.35.1'
+    implementation 'com.google.dagger:dagger:2.38.1'
+    implementation 'com.google.dagger:dagger-android:2.38.1'
     implementation 'com.google.dagger:dagger-android-support:2.27'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.27'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.38.1'
     annotationProcessor 'com.google.dagger:dagger-android-processor:2.27'
 
     // Brings the new BluetoothLeScanner API to older platforms
     implementation 'no.nordicsemi.android.support.v18:scanner:1.5.0'
 
     // Timber & SLF4J
-    implementation 'com.arcao:slf4j-timber:3.1@aar'
+    implementation 'com.arcao:slf4j-timber:3.1'
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'no.nordicsemi.android:log-timber:2.3.0'
 
     // Mcu Mgr
     implementation project(':mcumgr-ble')
+
+    // GSON
+    implementation 'com.google.code.gson:gson:2.8.8'
 
     // Test
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
 			<category android:name="android.intent.category.DEFAULT" />
 			<data android:scheme="https" />
 		</intent>
+		<package android:name="no.nordicsemi.android.log" />
 	</queries>
 
 	<application

--- a/sample/src/main/java/io/runtime/mcumgr/sample/MainActivity.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/MainActivity.java
@@ -8,6 +8,7 @@ package io.runtime.mcumgr.sample;
 
 import android.bluetooth.BluetoothDevice;
 import android.os.Bundle;
+import android.os.HandlerThread;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -40,6 +41,8 @@ public class MainActivity extends AppCompatActivity
     DispatchingAndroidInjector<Object> mDispatchingAndroidInjector;
     @Inject
     McuMgrViewModelFactory mViewModelFactory;
+    @Inject
+    HandlerThread mHandlerThread;
 
     private Fragment mDeviceFragment;
     private Fragment mImageFragment;
@@ -126,5 +129,12 @@ public class MainActivity extends AppCompatActivity
             mFilesFragment = getSupportFragmentManager().findFragmentByTag("fs");
             mLogsStatsFragment = getSupportFragmentManager().findFragmentByTag("logs");
         }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        // This will stop the handler thread that is used by transport object.
+        mHandlerThread.quitSafely();
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrTransportModule.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrTransportModule.java
@@ -8,12 +8,13 @@ package io.runtime.mcumgr.sample.di.module;
 
 import android.bluetooth.BluetoothDevice;
 import android.content.Context;
-
-import androidx.annotation.NonNull;
-import androidx.lifecycle.MutableLiveData;
+import android.os.Handler;
+import android.os.HandlerThread;
 
 import javax.inject.Named;
 
+import androidx.annotation.NonNull;
+import androidx.lifecycle.MutableLiveData;
 import dagger.Module;
 import dagger.Provides;
 import io.runtime.mcumgr.McuMgrTransport;
@@ -35,7 +36,24 @@ public class McuMgrTransportModule {
     @McuMgrScope
     @NonNull
     static McuMgrTransport provideMcuMgrTransport(@NonNull final Context context,
-                                                  @NonNull final BluetoothDevice device) {
-        return new ObservableMcuMgrBleTransport(context, device);
+                                                  @NonNull final BluetoothDevice device,
+                                                  @NonNull final Handler handler) {
+        return new ObservableMcuMgrBleTransport(context, device, handler);
+    }
+
+    @Provides
+    @McuMgrScope
+    @NonNull
+    static HandlerThread provideTransportHandlerThread() {
+        final HandlerThread handlerThread = new HandlerThread("McuMgrTransport");
+        handlerThread.start(); // The handler thread is stopped in MainActivity#onDestroy().
+        return handlerThread;
+    }
+
+    @Provides
+    @McuMgrScope
+    @NonNull
+    static Handler provideTransportHandler(@NonNull final HandlerThread handlerThread) {
+        return new Handler(handlerThread.getLooper());
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/dialog/FirmwareUpgradeModeDialogFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/dialog/FirmwareUpgradeModeDialogFragment.java
@@ -10,6 +10,7 @@ import android.app.Dialog;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
@@ -28,7 +29,7 @@ public class FirmwareUpgradeModeDialogFragment extends DialogFragment {
     @SuppressWarnings("ConstantConditions")
     @NonNull
     @Override
-    public Dialog onCreateDialog(final Bundle savedInstanceState) {
+    public Dialog onCreateDialog(@Nullable final Bundle savedInstanceState) {
         if (savedInstanceState != null) {
             mSelectedItem = savedInstanceState.getInt(SIS_ITEM);
         } else {

--- a/sample/src/main/java/io/runtime/mcumgr/sample/dialog/GenerateFileDialogFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/dialog/GenerateFileDialogFragment.java
@@ -38,7 +38,7 @@ public class GenerateFileDialogFragment extends DialogFragment {
     @SuppressWarnings("ConstantConditions")
     @NonNull
     @Override
-    public Dialog onCreateDialog(final Bundle savedInstanceState) {
+    public Dialog onCreateDialog(@Nullable final Bundle savedInstanceState) {
         final LayoutInflater inflater = requireActivity().getLayoutInflater();
         final View view = inflater.inflate(R.layout.dialog_generate_file, null);
         final EditText fileSize = view.findViewById(R.id.file_size);

--- a/sample/src/main/java/io/runtime/mcumgr/sample/dialog/HelpDialogFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/dialog/HelpDialogFragment.java
@@ -10,6 +10,7 @@ import android.app.Dialog;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatDialogFragment;
@@ -34,7 +35,7 @@ public class HelpDialogFragment extends AppCompatDialogFragment {
 
     @NonNull
     @Override
-    public Dialog onCreateDialog(final Bundle savedInstanceState) {
+    public Dialog onCreateDialog(@Nullable final Bundle savedInstanceState) {
         final Bundle args = getArguments();
         if (args == null) {
             throw new UnsupportedOperationException("HelpDialogFragment created without arguments");

--- a/sample/src/main/java/io/runtime/mcumgr/sample/dialog/PartitionDialogFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/dialog/PartitionDialogFragment.java
@@ -45,7 +45,7 @@ public class PartitionDialogFragment extends DialogFragment implements Injectabl
 
     @NonNull
     @Override
-    public Dialog onCreateDialog(final Bundle savedInstanceState) {
+    public Dialog onCreateDialog(@Nullable final Bundle savedInstanceState) {
         final LayoutInflater inflater = requireActivity().getLayoutInflater();
         final View view = inflater.inflate(R.layout.dialog_files_settings, null);
         final EditText partition = view.findViewById(R.id.partition);

--- a/sample/src/main/java/io/runtime/mcumgr/sample/dialog/SelectImageDialogFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/dialog/SelectImageDialogFragment.java
@@ -45,7 +45,7 @@ public class SelectImageDialogFragment extends DialogFragment {
 				.setView(binding.getRoot())
 				// Setting the positive button listener here would cause the dialog to dismiss.
 				// We have to validate the value before.
-				.setPositiveButton(R.string.image_upload_action_start, (dialog1, which) -> {
+				.setPositiveButton(android.R.string.ok, (dialog, which) -> {
 					final Bundle args = requireArguments();
 					final int requestId = args.getInt(ARG_REQUEST_ID);
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/dialog/SelectImageDialogFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/dialog/SelectImageDialogFragment.java
@@ -1,0 +1,59 @@
+package io.runtime.mcumgr.sample.dialog;
+
+import android.app.Dialog;
+import android.os.Bundle;
+import android.widget.ArrayAdapter;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+import io.runtime.mcumgr.sample.R;
+import io.runtime.mcumgr.sample.databinding.DialogSelectImageBinding;
+
+public class SelectImageDialogFragment extends DialogFragment {
+	private static final String ARG_REQUEST_ID = "requestId";
+	private int mPosition = 0;
+
+	public interface OnImageSelectedListener {
+		void onImageSelected(final int requestId, final int image);
+	}
+
+	public static DialogFragment getInstance(final int requestId) {
+		final DialogFragment fragment = new SelectImageDialogFragment();
+
+		final Bundle args = new Bundle();
+		args.putInt(ARG_REQUEST_ID, requestId);
+		fragment.setArguments(args);
+
+		return fragment;
+	}
+
+	@NonNull
+	@Override
+	public Dialog onCreateDialog(@Nullable final Bundle savedInstanceState) {
+		final DialogSelectImageBinding binding = DialogSelectImageBinding.inflate(getLayoutInflater());
+		final CharSequence[] items = getResources().getTextArray(R.array.image_select_images);
+		binding.image.setAdapter(new ArrayAdapter<>(requireContext(), R.layout.dialog_select_image_item, items));
+		binding.image.setText(items[0], false);
+		binding.image.setOnItemClickListener((parent, view, position, id) -> {
+			mPosition = position;
+		});
+
+		return new AlertDialog.Builder(requireContext())
+				.setTitle(R.string.image_select_image)
+				.setView(binding.getRoot())
+				// Setting the positive button listener here would cause the dialog to dismiss.
+				// We have to validate the value before.
+				.setPositiveButton(R.string.image_upload_action_start, (dialog1, which) -> {
+					final Bundle args = requireArguments();
+					final int requestId = args.getInt(ARG_REQUEST_ID);
+
+					final OnImageSelectedListener listener = (OnImageSelectedListener) getParentFragment();
+					if (listener != null)
+						listener.onImageSelected(requestId, mPosition);
+				})
+				.setNegativeButton(android.R.string.cancel, null)
+				.create();
+	}
+}

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/EchoFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/EchoFragment.java
@@ -66,7 +66,7 @@ public class EchoFragment extends Fragment implements Injectable {
         mViewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> mBinding.actionSend.setEnabled(!busy));
         mViewModel.getRequest().observe(getViewLifecycleOwner(), text -> {
             mBinding.echoContent.setVisibility(View.VISIBLE);
-            print(mBinding.echoResponse, text);
+            print(mBinding.echoRequest, text);
             if (mBinding.echoResponse.getVisibility() == View.VISIBLE) {
                 mBinding.echoResponse.setVisibility(View.INVISIBLE);
             }
@@ -76,12 +76,11 @@ public class EchoFragment extends Fragment implements Injectable {
             print(mBinding.echoResponse, response);
         });
         mViewModel.getError().observe(getViewLifecycleOwner(), error -> {
-            mBinding.echoResponse.setVisibility(View.VISIBLE);
             mBinding.echoResponse.setBackgroundResource(R.drawable.echo_error);
             if (error instanceof McuMgrTimeoutException) {
-                mBinding.echoResponse.setText(R.string.status_connection_timeout);
+                print(mBinding.echoResponse, getString(R.string.status_connection_timeout));
             } else {
-                mBinding.echoResponse.setText(error.getMessage());
+                print(mBinding.echoResponse, error.getMessage());
             }
         });
         mBinding.actionSend.setOnClickListener(v -> {

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FileBrowserFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FileBrowserFragment.java
@@ -57,13 +57,9 @@ public abstract class FileBrowserFragment extends Fragment implements LoaderMana
         mFileBrowserLauncher = registerForActivityResult(
                 new ActivityResultContracts.GetContent(),
                 uri -> {
-                    clearFileContent();
-
-                    if (uri == null) {
-                        Toast.makeText(requireContext(), R.string.file_loader_error_no_uri,
-                                Toast.LENGTH_SHORT).show();
+                    if (uri == null)
                         return;
-                    }
+                    clearFileContent();
 
                     final String scheme = uri.getScheme();
                     if (scheme != null && scheme.equals("content")) {

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FilesUploadFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FilesUploadFragment.java
@@ -92,11 +92,17 @@ public class FilesUploadFragment extends FileBrowserFragment implements Injectab
                     break;
                 case COMPLETE:
                     clearFileContent();
-                    mBinding.status.setText(R.string.image_upgrade_status_completed);
+                    mBinding.status.setText(R.string.files_upload_status_completed);
+                    mBinding.speed.setText(null);
                     break;
             }
         });
-        mViewModel.getProgress().observe(getViewLifecycleOwner(), progress -> mBinding.progress.setProgress(progress));
+        mViewModel.getTransferSpeed().observe(getViewLifecycleOwner(), speed ->
+                mBinding.speed.setText(getString(R.string.files_upload_speed, speed))
+        );
+        mViewModel.getProgress().observe(getViewLifecycleOwner(), progress ->
+                mBinding.progress.setProgress(progress)
+        );
         mViewModel.getError().observe(getViewLifecycleOwner(), error -> {
             mBinding.actionGenerate.setVisibility(View.VISIBLE);
             mBinding.actionSelectFile.setVisibility(View.VISIBLE);
@@ -111,6 +117,7 @@ public class FilesUploadFragment extends FileBrowserFragment implements Injectab
             mBinding.filePath.setText(null);
             mBinding.fileSize.setText(null);
             mBinding.status.setText(null);
+            mBinding.speed.setText(null);
             mBinding.actionGenerate.setVisibility(View.VISIBLE);
             mBinding.actionSelectFile.setVisibility(View.VISIBLE);
             mBinding.actionUpload.setVisibility(View.VISIBLE);
@@ -195,6 +202,7 @@ public class FilesUploadFragment extends FileBrowserFragment implements Injectab
         }
         if (message == null) {
             mBinding.status.setText(null);
+            mBinding.speed.setText(null);
             return;
         }
         final SpannableString spannable = new SpannableString(message);
@@ -204,5 +212,6 @@ public class FilesUploadFragment extends FileBrowserFragment implements Injectab
         spannable.setSpan(new StyleSpan(Typeface.BOLD),
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
         mBinding.status.setText(spannable);
+        mBinding.speed.setText(null);
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
@@ -17,22 +17,13 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
+import javax.inject.Inject;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProvider;
-
-import javax.inject.Inject;
-
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.exception.McuMgrTimeoutException;

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
@@ -90,20 +90,29 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
                     break;
                 case TESTING:
                     mBinding.status.setText(R.string.image_upgrade_status_testing);
+                    mBinding.speed.setText(null);
                     break;
                 case CONFIRMING:
                     mBinding.status.setText(R.string.image_upgrade_status_confirming);
+                    mBinding.speed.setText(null);
                     break;
                 case RESETTING:
                     mBinding.status.setText(R.string.image_upgrade_status_resetting);
+                    mBinding.speed.setText(null);
                     break;
                 case COMPLETE:
                     clearFileContent();
                     mBinding.status.setText(R.string.image_upgrade_status_completed);
+                    mBinding.speed.setText(null);
                     break;
             }
         });
-        mViewModel.getProgress().observe(getViewLifecycleOwner(), progress -> mBinding.progress.setProgress(progress));
+        mViewModel.getTransferSpeed().observe(getViewLifecycleOwner(), speed ->
+                mBinding.speed.setText(getString(R.string.image_upgrade_speed, speed))
+        );
+        mViewModel.getProgress().observe(getViewLifecycleOwner(), progress ->
+                mBinding.progress.setProgress(progress)
+        );
         mViewModel.getError().observe(getViewLifecycleOwner(), error -> {
             mBinding.actionSelectFile.setVisibility(View.VISIBLE);
             mBinding.actionStart.setVisibility(View.VISIBLE);
@@ -117,6 +126,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
             mBinding.fileSize.setText(null);
             mBinding.fileHash.setText(null);
             mBinding.status.setText(null);
+            mBinding.speed.setText(null);
             mBinding.actionSelectFile.setVisibility(View.VISIBLE);
             mBinding.actionStart.setVisibility(View.VISIBLE);
             mBinding.actionStart.setEnabled(false);
@@ -236,6 +246,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
         }
         if (message == null) {
             mBinding.status.setText(null);
+            mBinding.speed.setText(null);
             return;
         }
         final SpannableString spannable = new SpannableString(message);
@@ -245,5 +256,6 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
         spannable.setSpan(new StyleSpan(Typeface.BOLD),
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
         mBinding.status.setText(spannable);
+        mBinding.speed.setText(null);
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUploadFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUploadFragment.java
@@ -96,10 +96,16 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
                 case COMPLETE:
                     clearFileContent();
                     mBinding.status.setText(R.string.image_upload_status_completed);
+                    mBinding.speed.setText(null);
                     break;
             }
         });
-        mViewModel.getProgress().observe(getViewLifecycleOwner(), progress -> mBinding.progress.setProgress(progress));
+        mViewModel.getTransferSpeed().observe(getViewLifecycleOwner(), speed ->
+                mBinding.speed.setText(getString(R.string.image_upload_speed, speed))
+        );
+        mViewModel.getProgress().observe(getViewLifecycleOwner(), progress ->
+                mBinding.progress.setProgress(progress)
+        );
         mViewModel.getError().observe(getViewLifecycleOwner(), error -> {
             mBinding.actionSelectFile.setVisibility(View.VISIBLE);
             mBinding.actionUpload.setVisibility(View.VISIBLE);
@@ -113,6 +119,7 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
             mBinding.fileSize.setText(null);
             mBinding.fileHash.setText(null);
             mBinding.status.setText(null);
+            mBinding.speed.setText(null);
             mBinding.actionSelectFile.setVisibility(View.VISIBLE);
             mBinding.actionUpload.setVisibility(View.VISIBLE);
             mBinding.actionUpload.setEnabled(false);
@@ -205,6 +212,7 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
         }
         if (message == null) {
             mBinding.status.setText(null);
+            mBinding.speed.setText(null);
             return;
         }
         final SpannableString spannable = new SpannableString(message);
@@ -214,5 +222,6 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
         spannable.setSpan(new StyleSpan(Typeface.BOLD),
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
         mBinding.status.setText(spannable);
+        mBinding.speed.setText(null);
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/observable/ObservableMcuMgrBleTransport.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/observable/ObservableMcuMgrBleTransport.java
@@ -8,12 +8,12 @@ package io.runtime.mcumgr.sample.observable;
 
 import android.bluetooth.BluetoothDevice;
 import android.content.Context;
+import android.os.Handler;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
-
 import io.runtime.mcumgr.ble.McuMgrBleTransport;
 import no.nordicsemi.android.ble.observer.BondingObserver;
 
@@ -26,63 +26,66 @@ public class ObservableMcuMgrBleTransport extends McuMgrBleTransport {
      *
      * @param context the context used to connect to the device.
      * @param device  the device to connect to and communicate with.
+     * @param handler the handler for BLE calls.
      */
-    public ObservableMcuMgrBleTransport(@NonNull final Context context, @NonNull final BluetoothDevice device) {
-        super(context, device);
+    public ObservableMcuMgrBleTransport(@NonNull final Context context,
+                                        @NonNull final BluetoothDevice device,
+                                        @NonNull final Handler handler) {
+        super(context, device, handler);
 
         setConnectionObserver(new no.nordicsemi.android.ble.observer.ConnectionObserver() {
             @Override
             public void onDeviceConnecting(@NonNull final BluetoothDevice device) {
-                mConnectionState.setValue(ConnectionState.CONNECTING);
+                mConnectionState.postValue(ConnectionState.CONNECTING);
             }
 
             @Override
             public void onDeviceConnected(@NonNull final BluetoothDevice device) {
-                mConnectionState.setValue(ConnectionState.INITIALIZING);
+                mConnectionState.postValue(ConnectionState.INITIALIZING);
             }
 
             @Override
             public void onDeviceFailedToConnect(@NonNull final BluetoothDevice device, final int reason) {
                 if (reason == no.nordicsemi.android.ble.observer.ConnectionObserver.REASON_TIMEOUT) {
-                    mConnectionState.setValue(ConnectionState.TIMEOUT);
+                    mConnectionState.postValue(ConnectionState.TIMEOUT);
                 } else {
-                    mConnectionState.setValue(ConnectionState.DISCONNECTED);
+                    mConnectionState.postValue(ConnectionState.DISCONNECTED);
                 }
             }
 
             @Override
             public void onDeviceReady(@NonNull final BluetoothDevice device) {
-                mConnectionState.setValue(ConnectionState.READY);
+                mConnectionState.postValue(ConnectionState.READY);
             }
 
             @Override
             public void onDeviceDisconnecting(@NonNull final BluetoothDevice device) {
-                mConnectionState.setValue(ConnectionState.DISCONNECTING);
+                mConnectionState.postValue(ConnectionState.DISCONNECTING);
             }
 
             @Override
             public void onDeviceDisconnected(@NonNull final BluetoothDevice device, final int reason) {
                 if (reason == no.nordicsemi.android.ble.observer.ConnectionObserver.REASON_NOT_SUPPORTED) {
-                    mConnectionState.setValue(ConnectionState.NOT_SUPPORTED);
+                    mConnectionState.postValue(ConnectionState.NOT_SUPPORTED);
                 } else {
-                    mConnectionState.setValue(ConnectionState.DISCONNECTED);
+                    mConnectionState.postValue(ConnectionState.DISCONNECTED);
                 }
             }
         });
         setBondingObserver(new BondingObserver() {
             @Override
             public void onBondingRequired(@NonNull final BluetoothDevice device) {
-                mBondingState.setValue(BondingState.BONDING);
+                mBondingState.postValue(BondingState.BONDING);
             }
 
             @Override
             public void onBonded(@NonNull final BluetoothDevice device) {
-                mBondingState.setValue(BondingState.BONDED);
+                mBondingState.postValue(BondingState.BONDED);
             }
 
             @Override
             public void onBondingFailed(@NonNull final BluetoothDevice device) {
-                mBondingState.setValue(BondingState.NOT_BONDED);
+                mBondingState.postValue(BondingState.NOT_BONDED);
             }
         });
         setLoggingEnabled(true);

--- a/sample/src/main/java/io/runtime/mcumgr/sample/utils/FsUtils.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/utils/FsUtils.java
@@ -62,7 +62,6 @@ public class FsUtils {
      */
     @NonNull
     public String getPartitionString() {
-        //noinspection ConstantConditions
         return mPreferences.getString(PREFS_PARTITION, PARTITION_DEFAULT);
     }
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/utils/ZipPackage.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/utils/ZipPackage.java
@@ -1,0 +1,132 @@
+package io.runtime.mcumgr.sample.utils;
+
+import android.util.Pair;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import androidx.annotation.Keep;
+import androidx.annotation.NonNull;
+import timber.log.Timber;
+
+public final class ZipPackage {
+	private static final String MANIFEST = "manifest.json";
+
+	@Keep
+	private static class Manifest {
+		private int formatVersion;
+		private File[] files;
+
+		@Keep
+		private static class File {
+			private String version;
+			private String file;
+			private int size;
+			private int image;
+		}
+	}
+
+	private Manifest manifest;
+	private List<Pair<Integer, byte[]>> binaries;
+
+	public ZipPackage(@NonNull final byte[] data) throws IOException {
+		ZipEntry ze;
+		Map<String, byte[]> entries = new HashMap<>();
+
+		// Unzip the file and look for the manifest.json.
+		final ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(data));
+		while ((ze = zis.getNextEntry()) != null) {
+			if (ze.isDirectory())
+				throw new IOException("Invalid ZIP");
+
+			final String name = validateFilename(ze.getName(), ".");
+
+			if (name.equals(MANIFEST)) {
+				final Gson gson = new GsonBuilder()
+						.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_DASHES)
+						.create();
+				manifest = gson.fromJson(new InputStreamReader(zis), Manifest.class);
+			} else if (name.endsWith(".bin")) {
+				final byte[] content = getData(zis);
+				entries.put(name, content);
+			} else {
+				Timber.w("Unsupported file found: %s", name);
+			}
+		}
+
+		binaries = new ArrayList<>(2);
+
+		// Search for images.
+		for (final Manifest.File file: manifest.files) {
+			final String name = file.file;
+			final byte[] content = entries.get(name);
+			if (content == null)
+				throw new IOException("File not found: " + name);
+
+			binaries.add(new Pair<>(file.image, content));
+		}
+	}
+
+	public List<Pair<Integer, byte[]>> getBinaries() {
+		return binaries;
+	}
+
+	private byte[] getData(@NonNull ZipInputStream zis) throws IOException {
+		final byte[] buffer = new byte[1024];
+
+		// Read file content to byte array
+		final ByteArrayOutputStream os = new ByteArrayOutputStream();
+		int count;
+		while ((count = zis.read(buffer)) != -1) {
+			os.write(buffer, 0, count);
+		}
+		return os.toByteArray();
+	}
+
+	/**
+	 * Validates the path (not the content) of the zip file to prevent path traversal issues.
+	 *
+	 * <p> When unzipping an archive, always validate the compressed files' paths and reject any path
+	 * that has a path traversal (such as ../..). Simply looking for .. characters in the compressed
+	 * file's path may not be enough to prevent path traversal issues. The code validates the name of
+	 * the entry before extracting the entry. If the name is invalid, the entire extraction is aborted.
+	 * <p>
+	 *
+	 * @param filename The path to the file.
+	 * @param intendedDir The intended directory where the zip should be.
+	 * @return The validated path to the file.
+	 * @throws java.io.IOException Thrown in case of path traversal issues.
+	 */
+	@SuppressWarnings("SameParameterValue")
+	private String validateFilename(@NonNull final String filename,
+									@NonNull final String intendedDir)
+			throws IOException {
+		File f = new File(filename);
+		String canonicalPath = f.getCanonicalPath();
+
+		File iD = new File(intendedDir);
+		String canonicalID = iD.getCanonicalPath();
+
+		if (canonicalPath.startsWith(canonicalID)) {
+			return canonicalPath.substring(1); // remove leading "/"
+		} else {
+			throw new IllegalStateException("File is outside extraction target directory.");
+		}
+	}
+
+}

--- a/sample/src/main/java/io/runtime/mcumgr/sample/utils/ZipPackage.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/utils/ZipPackage.java
@@ -6,7 +6,6 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -15,7 +14,6 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -27,6 +25,7 @@ import timber.log.Timber;
 public final class ZipPackage {
 	private static final String MANIFEST = "manifest.json";
 
+	@SuppressWarnings({"unused", "MismatchedReadAndWriteOfArray"})
 	@Keep
 	private static class Manifest {
 		private int formatVersion;
@@ -37,12 +36,12 @@ public final class ZipPackage {
 			private String version;
 			private String file;
 			private int size;
-			private int image;
+			private int imageIndex;
 		}
 	}
 
 	private Manifest manifest;
-	private List<Pair<Integer, byte[]>> binaries;
+	private final List<Pair<Integer, byte[]>> binaries;
 
 	public ZipPackage(@NonNull final byte[] data) throws IOException {
 		ZipEntry ze;
@@ -58,7 +57,7 @@ public final class ZipPackage {
 
 			if (name.equals(MANIFEST)) {
 				final Gson gson = new GsonBuilder()
-						.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_DASHES)
+						.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
 						.create();
 				manifest = gson.fromJson(new InputStreamReader(zis), Manifest.class);
 			} else if (name.endsWith(".bin")) {
@@ -78,7 +77,7 @@ public final class ZipPackage {
 			if (content == null)
 				throw new IOException("File not found: " + name);
 
-			binaries.add(new Pair<>(file.image, content));
+			binaries.add(new Pair<>(file.imageIndex, content));
 		}
 	}
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUploadViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUploadViewModel.java
@@ -17,7 +17,6 @@ import androidx.lifecycle.MutableLiveData;
 import io.runtime.mcumgr.McuMgrCallback;
 import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.ble.McuMgrBleTransport;
-import io.runtime.mcumgr.exception.McuMgrErrorException;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.image.McuMgrImage;
 import io.runtime.mcumgr.managers.ImageManager;
@@ -85,7 +84,7 @@ public class ImageUploadViewModel extends McuMgrViewModel implements UploadCallb
         return mCancelledEvent;
     }
 
-    public void upload(@NonNull final byte[] data) {
+    public void upload(@NonNull final byte[] data, final int image) {
         if (mController != null) {
             return;
         }
@@ -122,10 +121,10 @@ public class ImageUploadViewModel extends McuMgrViewModel implements UploadCallb
                     postReady();
                     return;
                 }
-
+                // TODO: Validate net core as well.
                 // Send the firmware.
                 mStateLiveData.postValue(State.UPLOADING);
-                mController = mManager.imageUpload(data, ImageUploadViewModel.this);
+                mController = mManager.imageUpload(data, image,ImageUploadViewModel.this);
             }
 
             @Override

--- a/sample/src/main/res/layout/dialog_select_image.xml
+++ b/sample/src/main/res/layout/dialog_select_image.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp"
+    android:orientation="vertical">
+
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/image_select_image">
+
+        <com.google.android.material.textfield.MaterialAutoCompleteTextView
+            android:id="@+id/image"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="none"/>
+    </com.google.android.material.textfield.TextInputLayout>
+</LinearLayout>

--- a/sample/src/main/res/layout/dialog_select_image_item.xml
+++ b/sample/src/main/res/layout/dialog_select_image_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<com.google.android.material.textview.MaterialTextView
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content"
+	android:ellipsize="end"
+	android:maxLines="1"
+	android:padding="16dp"
+	android:textAppearance="?attr/textAppearanceSubtitle1" />

--- a/sample/src/main/res/layout/fragment_card_files_upload.xml
+++ b/sample/src/main/res/layout/fragment_card_files_upload.xml
@@ -103,10 +103,19 @@
             android:layout_height="wrap_content"
             android:freezesText="true"
             android:textStyle="bold"
-            app:layout_constraintEnd_toEndOf="@+id/file_name"
+            app:layout_constraintEnd_toStartOf="@+id/speed"
             app:layout_constraintStart_toStartOf="@+id/file_name"
             app:layout_constraintTop_toTopOf="@+id/status_label"
             tools:text="@string/files_upload_status_uploading"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/speed"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:freezesText="true"
+            app:layout_constraintEnd_toEndOf="@+id/file_name"
+            app:layout_constraintTop_toTopOf="@+id/status_label"
+            tools:text="2.3 KB/s"/>
 
         <ProgressBar
             android:id="@+id/progress"
@@ -160,7 +169,8 @@
             android:text="@string/files_upload_action_start"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/action_cancel"
-            app:layout_constraintTop_toBottomOf="@+id/divider"/>
+            app:layout_constraintTop_toBottomOf="@+id/divider"
+            tools:ignore="DuplicateSpeakableTextCheck" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/action_cancel"

--- a/sample/src/main/res/layout/fragment_card_image_upgrade.xml
+++ b/sample/src/main/res/layout/fragment_card_image_upgrade.xml
@@ -100,10 +100,19 @@
             android:layout_height="wrap_content"
             android:freezesText="true"
             android:textStyle="bold"
-            app:layout_constraintEnd_toEndOf="@+id/file_name"
+            app:layout_constraintEnd_toStartOf="@+id/speed"
             app:layout_constraintStart_toStartOf="@+id/file_name"
             app:layout_constraintTop_toTopOf="@+id/status_label"
             tools:text="@string/image_upload_status_uploading"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/speed"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:freezesText="true"
+            app:layout_constraintEnd_toEndOf="@+id/file_name"
+            app:layout_constraintTop_toTopOf="@+id/status_label"
+            tools:text="2.3 KB/s"/>
 
         <ProgressBar
             android:id="@+id/progress"

--- a/sample/src/main/res/layout/fragment_card_image_upload.xml
+++ b/sample/src/main/res/layout/fragment_card_image_upload.xml
@@ -100,10 +100,19 @@
             android:layout_height="wrap_content"
             android:freezesText="true"
             android:textStyle="bold"
-            app:layout_constraintEnd_toEndOf="@+id/file_name"
+            app:layout_constraintEnd_toStartOf="@+id/speed"
             app:layout_constraintStart_toStartOf="@+id/file_name"
             app:layout_constraintTop_toTopOf="@+id/status_label"
             tools:text="@string/image_upload_status_uploading"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/speed"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:freezesText="true"
+            app:layout_constraintEnd_toEndOf="@+id/file_name"
+            app:layout_constraintTop_toTopOf="@+id/status_label"
+            tools:text="2.3 KB/s"/>
 
         <ProgressBar
             android:id="@+id/progress"

--- a/sample/src/main/res/values/strings_files_upload.xml
+++ b/sample/src/main/res/values/strings_files_upload.xml
@@ -12,6 +12,7 @@
     <string name="files_upload_size">File Size:</string>
     <string name="files_upload_size_value">%d bytes</string>
     <string name="files_upload_status">State:</string>
+    <string name="files_upload_speed">%.1f KB/s</string>
     <string name="files_upload_action_start">Upload</string>
 
     <string name="files_upload_status_ready">READY</string>

--- a/sample/src/main/res/values/strings_image_control.xml
+++ b/sample/src/main/res/values/strings_image_control.xml
@@ -15,7 +15,8 @@
 
 	<string name="image_control_already_flashed">Image is identical to the active one</string>
     <string name="image_control_split_status">Split Status: %d</string>
-    <string name="image_control_slot"><b>Slot: %d</b>\n
+	<string name="image_control_image_slot">Image: %d, Slot: %d</string>
+    <string name="image_control_flags">
 		• Version: %s\n
 		• Hash: %s\n
 		• Bootable: %B\n
@@ -26,12 +27,12 @@
 
     <string name="image_control_dialog_help_title">Help</string>
     <string name="image_control_dialog_help_message"><b>Images</b> card lets you read the status
-		of image slots on the device.\nWhen a new firmware has been sent to slot&#160;1,
+		of image slots on the device.\nWhen a new firmware has been sent to secondary slot,
 		the TEST, CONFIRM and ERASE buttons become available.
 		The TEST button tells the device to run the new image on its next boot.
 		Such firmware may automatically confirm itself when it\'s configured to do so.
 		You may also make the image swap permanent by tapping CONFIRM button.
 		Each action requires rebooting the target to take effect. You can do this using the
-		<b>Reset</b> card below.\nERASE button erases the slot&#160;1.
+		<b>Reset</b> card below.\nERASE button erases the secondary slot(s).
 	</string>
 </resources>

--- a/sample/src/main/res/values/strings_image_upgrade.xml
+++ b/sample/src/main/res/values/strings_image_upgrade.xml
@@ -12,6 +12,7 @@
     <string name="image_upgrade_size_value">%d bytes</string>
     <string name="image_upgrade_hash">File Hash:</string>
     <string name="image_upgrade_status">State:</string>
+    <string name="image_upgrade_speed">%.1f KB/s</string>
     <string name="image_upgrade_action_start">Start</string>
 
     <string name="image_upgrade_mode">Select Mode</string>

--- a/sample/src/main/res/values/strings_image_upload.xml
+++ b/sample/src/main/res/values/strings_image_upload.xml
@@ -14,6 +14,12 @@
     <string name="image_upload_status">State:</string>
     <string name="image_upload_action_start">Upload</string>
 
+    <string name="image_select_image">Select Image</string>
+    <string-array name="image_select_images">
+        <item>Application Core (0)</item>
+        <item>Network Core (1)</item>
+    </string-array>
+
     <string name="image_upload_status_ready">READY</string>
     <string name="image_upload_status_validating">VALIDATING…</string>
     <string name="image_upload_status_uploading">UPLOADING…</string>

--- a/sample/src/main/res/values/strings_image_upload.xml
+++ b/sample/src/main/res/values/strings_image_upload.xml
@@ -12,6 +12,7 @@
     <string name="image_upload_size_value">%d bytes</string>
     <string name="image_upload_hash">File Hash:</string>
     <string name="image_upload_status">State:</string>
+    <string name="image_upload_speed">%.1f KB/s</string>
     <string name="image_upload_action_start">Upload</string>
 
     <string name="image_select_image">Select Image</string>


### PR DESCRIPTION
This PR adds support for multi-core update for example for nRF5340 devices. Those kind of devices need to update images of all their cores in a single DFU operation to prevent compatibility issues.

New API:

1. In `ImageManager` a new method has been added: https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/blob/b1ee06e29d62855addde87875973dc369bcab4ee/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java#L563-L567 which sends the data with given `image` parameter. By default this param is 0 and in which case is omitted for backwards compatibility.
2. Similar parameters were added to: https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/blob/b1ee06e29d62855addde87875973dc369bcab4ee/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java#L327-L334 and https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/blob/b1ee06e29d62855addde87875973dc369bcab4ee/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java#L379-L386
3. In `FirmwareUpgradeManager` a new method has been added: https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/blob/b1ee06e29d62855addde87875973dc369bcab4ee/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java#L346 which allows automatic update of multiple cores. The manager will upload all images, and, depending on selected mode, test, reset the device and send confirm command. The implementation takes under consideration, that primary slot of a non-main core may not be reported by image manager.

Additionally, this PR adds the following improvements:
1. The app can again log to nRF Logger on Android 11+ https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/commit/93a9cb1fb77f7853c2e05ef69fe50f25b7cdb149
2. Plenty of warnings were fixed in core module https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/commit/94d70ef9b6091840533f238af748eb593d907c37 and https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/commit/2dd036497b0ba29238ad49762b13cc45dcb59cec
3. Response timeout has been increased to 30 seconds https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/commit/44b6af617be98f3c49ceac4e9169e67d57d56d38
4. BLE transport uses MTU = 498, which uses maximum size of two maximum LL packets with DLE enabled and set to 251 https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/commit/6fdc4965223cd709a1320eba27fb3ea3c21e8a6c
5. BLE connection retry delay was increased to 500 ms https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/commit/a2a8ab88edd3890765837356625bdea87830ead6