### PR TITLE
Option to erase app storage for Zephyr-based devices

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
@@ -59,6 +59,10 @@ public abstract class McuManager {
     protected final static int GROUP_SPLIT = 6;
     protected final static int GROUP_RUN = 7;
     protected final static int GROUP_FS = 8;
+    // https://github.com/nrfconnect/sdk-zephyr/blob/master/include/mgmt/mcumgr/zephyr_groups.h
+    protected final static int GROUP_BASIC = 63;
+
+    // User defined groups should start from GROUP_PERUSER.
     protected final static int GROUP_PERUSER = 64;
 
     /**

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
@@ -328,7 +328,7 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      */
     public synchronized void start(final byte @NotNull [] imageData) throws McuMgrException {
         final Pair<Integer, byte[]> image = new Pair<>(0, imageData);
-        start(Collections.singletonList(image));
+        start(Collections.singletonList(image), false);
     }
 
     /**
@@ -342,8 +342,12 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      * new firmware.  The manager will try to connect to the SMP server on the new firmware and
      * confirm the new images if they were not confirmed before, or they didn't confirm
      * automatically.
+     *
+     * @param images       list of images with image index.
+     * @param eraseStorage should the app settings be erased, or not.
      */
-    public synchronized void start(@NotNull final List<Pair<Integer, byte[]>> images) throws McuMgrException {
+    public synchronized void start(@NotNull final List<Pair<Integer, byte[]>> images,
+                                   final boolean eraseStorage) throws McuMgrException {
         if (mPerformer.isBusy()) {
             LOG.info("Firmware upgrade is already in progress");
             return;
@@ -360,7 +364,7 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
             .setEstimatedSwapTime(mEstimatedSwapTime)
             .setWindowCapacity(mWindowCapacity)
             .build();
-        mPerformer.start(settings, mMode, mcuMgrImages);
+        mPerformer.start(settings, mMode, mcuMgrImages, eraseStorage);
     }
 
     //******************************************************************

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradePerformer.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradePerformer.java
@@ -41,9 +41,10 @@ public class FirmwareUpgradePerformer extends TaskPerformer<Settings, State> {
 
 	void start(@NotNull final Settings settings,
 			   @NotNull final Mode mode,
-			   @NotNull final List<Pair<Integer, McuMgrImage>> images) {
+			   @NotNull final List<Pair<Integer, McuMgrImage>> images,
+			   final boolean eraseSettings) {
 		LOG.trace("Starting DFU, mode: {}", mode.name());
-		super.start(settings, new PerformDfu(mode, images));
+		super.start(settings, new PerformDfu(mode, images, eraseSettings));
 	}
 
 	@Override

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/EraseSettings.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/EraseSettings.java
@@ -1,0 +1,59 @@
+package io.runtime.mcumgr.dfu.task;
+
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+import io.runtime.mcumgr.McuMgrCallback;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
+import io.runtime.mcumgr.exception.McuMgrErrorException;
+import io.runtime.mcumgr.exception.McuMgrException;
+import io.runtime.mcumgr.managers.BasicManager;
+import io.runtime.mcumgr.managers.ImageManager;
+import io.runtime.mcumgr.response.McuMgrResponse;
+import io.runtime.mcumgr.response.img.McuMgrImageStateResponse;
+import io.runtime.mcumgr.task.TaskManager;
+
+class EraseSettings extends FirmwareUpgradeTask {
+	private final static Logger LOG = LoggerFactory.getLogger(EraseSettings.class);
+
+	EraseSettings() {
+	}
+
+	@Override
+	@NotNull
+	public State getState() {
+		return State.UPLOAD;
+	}
+
+	@Override
+	public int getPriority() {
+		return PRIORITY_ERASE_SETTINGS;
+	}
+
+	@Override
+	public void start(final @NotNull TaskManager<Settings, State> performer) {
+		final Settings settings = performer.getSettings();
+		final BasicManager manager = new BasicManager(settings.transport);
+		manager.eraseStorage(new McuMgrCallback<McuMgrResponse>() {
+			@Override
+			public void onResponse(@NotNull final McuMgrResponse response) {
+				LOG.trace("Erase settings response: {}", response.toString());
+				// Check for an error return code.
+				if (!response.isSuccess()) {
+					performer.onTaskFailed(EraseSettings.this, new McuMgrErrorException(response.getReturnCode()));
+					return;
+				}
+				performer.onTaskCompleted(EraseSettings.this);
+			}
+
+			@Override
+			public void onError(@NotNull McuMgrException e) {
+				performer.onTaskFailed(EraseSettings.this, e);
+			}
+		});
+	}
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/FirmwareUpgradeTask.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/FirmwareUpgradeTask.java
@@ -8,8 +8,9 @@ public abstract class FirmwareUpgradeTask extends Task<Settings, State> {
 	final static int PRIORITY_VALIDATE = 0;
 	final static int PRIORITY_RESET_INITIAL = 1;
 	final static int PRIORITY_UPLOAD = 2;
-	final static int PRIORITY_TEST_AFTER_UPLOAD = PRIORITY_UPLOAD + 1;
-	final static int PRIORITY_CONFIRM_AFTER_UPLOAD = PRIORITY_UPLOAD + 1;
+	final static int PRIORITY_ERASE_SETTINGS = PRIORITY_UPLOAD + 1;
+	final static int PRIORITY_TEST_AFTER_UPLOAD = PRIORITY_ERASE_SETTINGS + 1;
+	final static int PRIORITY_CONFIRM_AFTER_UPLOAD = PRIORITY_ERASE_SETTINGS + 1;
 	final static int PRIORITY_RESET = 10;
 	final static int PRIORITY_CONFIRM_AFTER_RESET = PRIORITY_RESET + 1;
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/PerformDfu.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/PerformDfu.java
@@ -23,10 +23,14 @@ public class PerformDfu extends FirmwareUpgradeTask {
 	@NotNull
 	private final FirmwareUpgradeManager.Mode mode;
 
+	private final boolean eraseSettings;
+
 	public PerformDfu(final @NotNull FirmwareUpgradeManager.Mode mode,
-					  final @NotNull List<Pair<Integer, McuMgrImage>> images) {
+					  final @NotNull List<Pair<Integer, McuMgrImage>> images,
+					  final boolean eraseSettings) {
 		this.mode = mode;
 		this.images = images;
+		this.eraseSettings = eraseSettings;
 	}
 
 	@NotNull
@@ -42,7 +46,7 @@ public class PerformDfu extends FirmwareUpgradeTask {
 
 	@Override
 	public void start(final @NotNull TaskManager<Settings, State> performer) {
-		performer.enqueue(new Validate(mode, images));
+		performer.enqueue(new Validate(mode, images, eraseSettings));
 		performer.onTaskCompleted(this);
 	}
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Validate.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Validate.java
@@ -31,10 +31,14 @@ class Validate extends FirmwareUpgradeTask {
 	@NotNull
 	private final Mode mode;
 
+	private final boolean eraseSettings;
+
 	Validate(final @NotNull Mode mode,
-			 final @NotNull List<Pair<Integer, McuMgrImage>> images) {
+			 final @NotNull List<Pair<Integer, McuMgrImage>> images,
+			 final boolean eraseSettings) {
 		this.mode = mode;
 		this.images = images;
+		this.eraseSettings = eraseSettings;
 	}
 
 	@Override
@@ -187,6 +191,8 @@ class Validate extends FirmwareUpgradeTask {
 					performer.enqueue(new ResetBeforeUpload());
 				}
 				if (resetRequired) {
+					if (eraseSettings)
+						performer.enqueue(new EraseSettings());
 					performer.enqueue(new Reset());
 				}
 

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/BasicManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/BasicManager.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017-2018 Runtime Inc.
+ * Copyright (c) Intellinium SAS, 2014-present
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.runtime.mcumgr.managers;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.runtime.mcumgr.McuManager;
+import io.runtime.mcumgr.McuMgrCallback;
+import io.runtime.mcumgr.McuMgrTransport;
+import io.runtime.mcumgr.exception.McuMgrException;
+import io.runtime.mcumgr.response.McuMgrResponse;
+
+/**
+ * Basic command group manager for Zephyr-based devices.
+ */
+@SuppressWarnings("unused")
+public class BasicManager extends McuManager {
+
+    // Command IDs
+    // https://github.com/nrfconnect/sdk-zephyr/blob/master/include/mgmt/mcumgr/zephyr_groups.h
+    private final static int ID_ERASE_STORAGE = 0;
+
+    /**
+     * Construct an stats manager.
+     *
+     * @param transport the transport to use to send commands.
+     */
+    public BasicManager(@NotNull McuMgrTransport transport) {
+        super(GROUP_BASIC, transport);
+    }
+
+    /**
+     * Erase application storage partition (asynchronous).
+     *
+     * @param callback the asynchronous callback.
+     */
+    public void eraseStorage(@NotNull McuMgrCallback<McuMgrResponse> callback) {
+        send(OP_WRITE, ID_ERASE_STORAGE, null, McuMgrResponse.class, callback);
+    }
+
+    /**
+     * Erase application storage partition (synchronous).
+     *
+     * @return The response.
+     * @throws McuMgrException Transport error. See cause.
+     */
+    @NotNull
+    public McuMgrResponse eraseStorage() throws McuMgrException {
+        return send(OP_WRITE, ID_ERASE_STORAGE, null, McuMgrResponse.class);
+    }
+}

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
@@ -81,6 +81,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
             switch (state) {
                 case VALIDATING:
                     mBinding.status.setText(R.string.image_upgrade_status_validating);
+                    mBinding.optionEraseSettings.setEnabled(false);
                     break;
                 case UPLOADING:
                     mBinding.status.setText(R.string.image_upgrade_status_uploading);
@@ -104,6 +105,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
                     clearFileContent();
                     mBinding.status.setText(R.string.image_upgrade_status_completed);
                     mBinding.speed.setText(null);
+                    mBinding.optionEraseSettings.setEnabled(true);
                     break;
             }
         });
@@ -118,6 +120,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
             mBinding.actionStart.setVisibility(View.VISIBLE);
             mBinding.actionCancel.setVisibility(View.GONE);
             mBinding.actionPauseResume.setVisibility(View.GONE);
+            mBinding.optionEraseSettings.setEnabled(true);
             printError(error);
         });
         mViewModel.getCancelledEvent().observe(getViewLifecycleOwner(), nothing -> {
@@ -132,6 +135,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
             mBinding.actionStart.setEnabled(false);
             mBinding.actionCancel.setVisibility(View.GONE);
             mBinding.actionPauseResume.setVisibility(View.GONE);
+            mBinding.optionEraseSettings.setEnabled(true);
         });
         mViewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> {
             mBinding.actionSelectFile.setEnabled(!busy);
@@ -171,7 +175,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
      */
     @SuppressWarnings("ConstantConditions")
     public void start(@NonNull final FirmwareUpgradeManager.Mode mode) {
-        mViewModel.upgrade(getFileContent(), mode);
+        mViewModel.upgrade(getFileContent(), mode, mBinding.optionEraseSettings.isChecked());
     }
 
     @Override

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -115,7 +115,9 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
         return mCancelledEvent;
     }
 
-    public void upgrade(@NonNull final byte[] data, @NonNull final FirmwareUpgradeManager.Mode mode) {
+    public void upgrade(@NonNull final byte[] data,
+                        @NonNull final FirmwareUpgradeManager.Mode mode,
+                        final boolean eraseSettings) {
         List<Pair<Integer, byte[]>> images;
         try {
             // Check if the BIN file is valid.
@@ -136,7 +138,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
                 ((McuMgrBleTransport) transport).requestConnPriority(ConnectionPriorityRequest.CONNECTION_PRIORITY_HIGH);
             }
             mManager.setMode(mode);
-            mManager.start(images);
+            mManager.start(images, eraseSettings);
         } catch (final McuMgrException e) {
             // TODO Externalize the text
             mErrorLiveData.setValue(new McuMgrException("Invalid image file."));

--- a/sample/src/main/res/layout/fragment_card_image_upgrade.xml
+++ b/sample/src/main/res/layout/fragment_card_image_upgrade.xml
@@ -103,7 +103,7 @@
             app:layout_constraintEnd_toStartOf="@+id/speed"
             app:layout_constraintStart_toStartOf="@+id/file_name"
             app:layout_constraintTop_toTopOf="@+id/status_label"
-            tools:text="@string/image_upload_status_uploading"/>
+            tools:text="@string/image_upgrade_status_uploading"/>
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/speed"
@@ -113,6 +113,15 @@
             app:layout_constraintEnd_toEndOf="@+id/file_name"
             app:layout_constraintTop_toTopOf="@+id/status_label"
             tools:text="2.3 KB/s"/>
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/option_erase_settings"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/image_upgrade_erase_storage"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/file_name_label"
+            app:layout_constraintTop_toBottomOf="@+id/status" />
 
         <ProgressBar
             android:id="@+id/progress"
@@ -124,7 +133,7 @@
             android:progressBackgroundTint="?colorSurface"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/status"/>
+            app:layout_constraintTop_toBottomOf="@+id/option_erase_settings"/>
 
         <View
             android:id="@+id/divider"

--- a/sample/src/main/res/values/strings_image_upgrade.xml
+++ b/sample/src/main/res/values/strings_image_upgrade.xml
@@ -21,6 +21,7 @@
         <item>Test only</item>
         <item>Confirm only</item>
     </string-array>
+    <string name="image_upgrade_erase_storage">Erase application storage</string>
 
     <string name="image_upgrade_status_ready">READY</string>
     <string name="image_upgrade_status_validating">VALIDATING…</string>


### PR DESCRIPTION
This PR adds option to erase app storage (similar to factory reset) using the new `BasicManager` (don't ask me why this name, it's based on the impl in Zephyr [here](https://github.com/nrfconnect/sdk-zephyr/blob/master/include/mgmt/mcumgr/zephyr_groups.h).
```
New group ID added: 63
New command: 0 (erase storage)
```
The behavior is that the mgr manager should erase app storage. This is useful when doing upgrade with a major version where the new app is not compatible with the old one, or when changing firmware from one app to another. Unfortunately, it is the user who needs to decide whether the storage needs to be erased, or not. This information is not present in the binaries.