### PR TITLE
Bug fixing

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
@@ -46,7 +46,7 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
     //******************************************************************
 
     public enum State {
-        NONE, VALIDATE, UPLOAD, TEST, RESET, CONFIRM, SUCCESS;
+        NONE, VALIDATE, UPLOAD, TEST, RESET, CONFIRM;
 
         public boolean isInProgress() {
             return this == VALIDATE || this == UPLOAD || this == TEST ||

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/EraseSettings.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/EraseSettings.java
@@ -42,11 +42,13 @@ class EraseSettings extends FirmwareUpgradeTask {
 			@Override
 			public void onResponse(@NotNull final McuMgrResponse response) {
 				LOG.trace("Erase settings response: {}", response.toString());
+
+				// Fix: If this feature is not supported on the device, this should not cause fail the process.
 				// Check for an error return code.
-				if (!response.isSuccess()) {
-					performer.onTaskFailed(EraseSettings.this, new McuMgrErrorException(response.getReturnCode()));
-					return;
-				}
+				// if (!response.isSuccess()) {
+				//    performer.onTaskFailed(EraseSettings.this, new McuMgrErrorException(response.getReturnCode()));
+				//	  return;
+				// }
 				performer.onTaskCompleted(EraseSettings.this);
 			}
 

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/EraseStorage.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/EraseStorage.java
@@ -4,23 +4,18 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-
 import io.runtime.mcumgr.McuMgrCallback;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
-import io.runtime.mcumgr.exception.McuMgrErrorException;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.managers.BasicManager;
-import io.runtime.mcumgr.managers.ImageManager;
 import io.runtime.mcumgr.response.McuMgrResponse;
-import io.runtime.mcumgr.response.img.McuMgrImageStateResponse;
 import io.runtime.mcumgr.task.TaskManager;
 
-class EraseSettings extends FirmwareUpgradeTask {
-	private final static Logger LOG = LoggerFactory.getLogger(EraseSettings.class);
+class EraseStorage extends FirmwareUpgradeTask {
+	private final static Logger LOG = LoggerFactory.getLogger(EraseStorage.class);
 
-	EraseSettings() {
+	EraseStorage() {
 	}
 
 	@Override
@@ -41,20 +36,22 @@ class EraseSettings extends FirmwareUpgradeTask {
 		manager.eraseStorage(new McuMgrCallback<McuMgrResponse>() {
 			@Override
 			public void onResponse(@NotNull final McuMgrResponse response) {
-				LOG.trace("Erase settings response: {}", response.toString());
+				LOG.trace("Erase storage response: {}", response.toString());
 
-				// Fix: If this feature is not supported on the device, this should not cause fail the process.
+				// Fix: If this feature is not supported on the device, this should not cause fail
+				//      the process.
+
 				// Check for an error return code.
 				// if (!response.isSuccess()) {
 				//    performer.onTaskFailed(EraseSettings.this, new McuMgrErrorException(response.getReturnCode()));
 				//	  return;
 				// }
-				performer.onTaskCompleted(EraseSettings.this);
+				performer.onTaskCompleted(EraseStorage.this);
 			}
 
 			@Override
 			public void onError(@NotNull McuMgrException e) {
-				performer.onTaskFailed(EraseSettings.this, e);
+				performer.onTaskFailed(EraseStorage.this, e);
 			}
 		});
 	}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Validate.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Validate.java
@@ -192,7 +192,7 @@ class Validate extends FirmwareUpgradeTask {
 				}
 				if (resetRequired) {
 					if (eraseSettings)
-						performer.enqueue(new EraseSettings());
+						performer.enqueue(new EraseStorage());
 					performer.enqueue(new Reset());
 				}
 


### PR DESCRIPTION
This PR fixes several bugs found during testing:
* Removing reconnection from Reset task. Some devices will advertise with a different MAC after the update, so reconnection would not be possible. If reconnection is required, e.g. to set confirm command, the Confirm task will handle connection on its own.
* Ignoring a failure during storage erase procedure, as devices may not support it.
* Potential breaking issue: Unused `SUCCESS` state removed from `FirmwareUpgradeManager`.
* Logging gets re-enabled in case of an error during DFU.