### PR TITLE
Option to erase app settings

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/component/McuMgrViewModelSubComponent.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/component/McuMgrViewModelSubComponent.java
@@ -13,6 +13,7 @@ import io.runtime.mcumgr.sample.viewmodel.mcumgr.EchoViewModel;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.FilesDownloadViewModel;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.FilesUploadViewModel;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.ImageControlViewModel;
+import io.runtime.mcumgr.sample.viewmodel.mcumgr.ImageSettingsViewModel;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.ImageUpgradeViewModel;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.ImageUploadViewModel;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.McuMgrViewModel;
@@ -42,6 +43,7 @@ public interface McuMgrViewModelSubComponent {
     ImageUpgradeViewModel imageUpgradeViewModel();
     ImageUploadViewModel imageUploadViewModel();
     ImageControlViewModel imageControlViewModel();
+    ImageSettingsViewModel imageSettingsViewModel();
     FilesDownloadViewModel filesDownloadViewModel();
     FilesUploadViewModel filesUploadViewModel();
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrFragmentBuildersModule.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrFragmentBuildersModule.java
@@ -15,6 +15,7 @@ import io.runtime.mcumgr.sample.fragment.mcumgr.EchoFragment;
 import io.runtime.mcumgr.sample.fragment.mcumgr.FilesDownloadFragment;
 import io.runtime.mcumgr.sample.fragment.mcumgr.FilesUploadFragment;
 import io.runtime.mcumgr.sample.fragment.mcumgr.ImageControlFragment;
+import io.runtime.mcumgr.sample.fragment.mcumgr.ImageSettingsFragment;
 import io.runtime.mcumgr.sample.fragment.mcumgr.ImageUpgradeFragment;
 import io.runtime.mcumgr.sample.fragment.mcumgr.ImageUploadFragment;
 import io.runtime.mcumgr.sample.fragment.mcumgr.ResetFragment;
@@ -39,6 +40,8 @@ public abstract class McuMgrFragmentBuildersModule {
     abstract ImageUploadFragment contributeImageUploadFragment();
     @ContributesAndroidInjector
     abstract ImageControlFragment contributeImageControlFragment();
+    @ContributesAndroidInjector
+    abstract ImageSettingsFragment contributeImageSettingsFragment();
     @ContributesAndroidInjector
     abstract PartitionDialogFragment contributePartitionDialogFragment();
     @ContributesAndroidInjector

--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrManagerModule.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrManagerModule.java
@@ -10,6 +10,7 @@ import dagger.Module;
 import dagger.Provides;
 import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
+import io.runtime.mcumgr.managers.BasicManager;
 import io.runtime.mcumgr.managers.ConfigManager;
 import io.runtime.mcumgr.managers.DefaultManager;
 import io.runtime.mcumgr.managers.FsManager;
@@ -43,6 +44,11 @@ public class McuMgrManagerModule {
     @Provides
     static ImageManager provideImageManager(final McuMgrTransport transport) {
         return new ImageManager(transport);
+    }
+
+    @Provides
+    static BasicManager provideBasicManager(final McuMgrTransport transport) {
+        return new BasicManager(transport);
     }
 
     @Provides

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/ImageFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/ImageFragment.java
@@ -40,6 +40,7 @@ public class ImageFragment extends Fragment implements Injectable {
     // Advanced
     private Fragment mImageUploadFragment;
     private Fragment mImageControlFragment;
+    private Fragment mImageSettingsFragment;
     private Fragment mResetFragment;
 
     private boolean mModeAdvanced;
@@ -83,6 +84,7 @@ public class ImageFragment extends Fragment implements Injectable {
                 getChildFragmentManager().beginTransaction()
                         .show(mImageUploadFragment)
                         .show(mImageControlFragment)
+                        .show(mImageSettingsFragment)
                         .show(mResetFragment)
                         .hide(mImageUpgradeFragment)
                         .commit();
@@ -94,6 +96,7 @@ public class ImageFragment extends Fragment implements Injectable {
                         .show(mImageUpgradeFragment)
                         .hide(mImageUploadFragment)
                         .hide(mImageControlFragment)
+                        .hide(mImageSettingsFragment)
                         .hide(mResetFragment)
                         .commit();
                 requireActivity().invalidateOptionsMenu();
@@ -118,6 +121,7 @@ public class ImageFragment extends Fragment implements Injectable {
         mImageUpgradeFragment = fm.findFragmentById(R.id.fragment_image_upgrade);
         mImageUploadFragment = fm.findFragmentById(R.id.fragment_image_upload);
         mImageControlFragment = fm.findFragmentById(R.id.fragment_image_control);
+        mImageSettingsFragment = fm.findFragmentById(R.id.fragment_image_settings);
         mResetFragment = fm.findFragmentById(R.id.fragment_reset);
 
         // Initially, show only the basic Image Upgrade fragment
@@ -125,6 +129,7 @@ public class ImageFragment extends Fragment implements Injectable {
             getChildFragmentManager().beginTransaction()
                     .hide(mImageUploadFragment)
                     .hide(mImageControlFragment)
+                    .hide(mImageSettingsFragment)
                     .hide(mResetFragment)
                     .commit();
         }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageSettingsViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageSettingsViewModel.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018, Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.runtime.mcumgr.sample.viewmodel.mcumgr;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import io.runtime.mcumgr.McuMgrCallback;
+import io.runtime.mcumgr.exception.McuMgrException;
+import io.runtime.mcumgr.managers.BasicManager;
+import io.runtime.mcumgr.response.McuMgrResponse;
+
+public class ImageSettingsViewModel extends McuMgrViewModel {
+    private final BasicManager mManager;
+
+    private final MutableLiveData<McuMgrException> mErrorLiveData = new MutableLiveData<>();
+
+    @Inject
+	ImageSettingsViewModel(final BasicManager manager,
+						   @Named("busy") final MutableLiveData<Boolean> state) {
+        super(state);
+        mManager = manager;
+    }
+
+    @NonNull
+    public LiveData<McuMgrException> getError() {
+        return mErrorLiveData;
+    }
+
+    public void eraseSettings() {
+        setBusy();
+        mErrorLiveData.setValue(null);
+        mManager.eraseStorage(new McuMgrCallback<McuMgrResponse>() {
+            @Override
+            public void onResponse(@NonNull final McuMgrResponse response) {
+                mErrorLiveData.postValue(null);
+                postReady();
+            }
+
+            @Override
+            public void onError(@NonNull final McuMgrException error) {
+                mErrorLiveData.postValue(error);
+                postReady();
+            }
+        });
+    }
+}

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/McuMgrViewModelFactory.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/McuMgrViewModelFactory.java
@@ -35,6 +35,7 @@ public class McuMgrViewModelFactory implements ViewModelProvider.Factory {
         creators.put(ImageUpgradeViewModel.class, viewModelSubComponent::imageUpgradeViewModel);
         creators.put(ImageUploadViewModel.class, viewModelSubComponent::imageUploadViewModel);
         creators.put(ImageControlViewModel.class, viewModelSubComponent::imageControlViewModel);
+        creators.put(ImageSettingsViewModel.class, viewModelSubComponent::imageSettingsViewModel);
         creators.put(FilesDownloadViewModel.class, viewModelSubComponent::filesDownloadViewModel);
         creators.put(FilesUploadViewModel.class, viewModelSubComponent::filesUploadViewModel);
     }

--- a/sample/src/main/res/layout/fragment_card_image_erase_settings.xml
+++ b/sample/src/main/res/layout/fragment_card_image_erase_settings.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:animateLayoutChanges="true"
+    android:layout_marginBottom="8dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:title="@string/image_settings_title"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/image_settings_hint"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:layout_marginStart="16dp"
+            android:freezesText="true"
+            android:text="@string/image_settings_hint"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/toolbar"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/image_control_error"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:layout_marginStart="16dp"
+            android:freezesText="true"
+            android:textColor="?colorError"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/image_settings_hint"
+            tools:text="Some error"
+            tools:visibility="visible"/>
+
+        <View
+            android:id="@+id/divider"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_marginTop="16dp"
+            android:background="@color/colorDivider"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/image_control_error"/>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/action_erase"
+            style="@style/Widget.ActionButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:enabled="false"
+            android:text="@string/image_settings_action_erase"
+            android:textColor="@color/button_destructive"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/divider"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/sample/src/main/res/layout/fragment_image.xml
+++ b/sample/src/main/res/layout/fragment_image.xml
@@ -38,7 +38,16 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
-        tools:layout="@layout/fragment_card_image_control"/>
+        tools:layout="@layout/fragment_card_image_control" />
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_image_settings"
+        android:name="io.runtime.mcumgr.sample.fragment.mcumgr.ImageSettingsFragment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        tools:layout="@layout/fragment_card_image_erase_settings"/>
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_reset"

--- a/sample/src/main/res/values/strings_image_erase_settings.xml
+++ b/sample/src/main/res/values/strings_image_erase_settings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<resources>
+    <string name="image_settings_title">Erase Settings</string>
+    <string name="image_settings_hint">Tap ERASE button to erase application settings.</string>
+    <string name="image_settings_action_erase">Erase</string>
+
+    <string name="image_settings_dialog_help_title">Help</string>
+    <string name="image_settings_dialog_help_message"><b>Erase Settings</b> card lets you erase
+        application data, including bond information. This feature is supported on devices
+        running NCS 1.7 or later with settings erase feature enabled.\n\nIf your device is bonded
+        remember to remove bond information also from the phone (Bluetooth settings -> Forget device).
+	</string>
+</resources>


### PR DESCRIPTION
This PR adds an option to erase application settings page on the connected device. This feature was added in NCS 1.7 with [#36548](https://github.com/zephyrproject-rtos/zephyr/pull/36548).
If a connected device does not support this feature, it should respond with an error.

Application settings page contains all app data, bond information, states of CCC descriptors, etc.
Erasing app settings works like factory reset.