### PR TITLE
Fixed displaying initial device state

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/observable/BondingState.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/observable/BondingState.java
@@ -6,8 +6,24 @@
 
 package io.runtime.mcumgr.sample.observable;
 
+import android.bluetooth.BluetoothDevice;
+
+import androidx.annotation.NonNull;
+
 public enum BondingState {
     NOT_BONDED,
     BONDING,
-    BONDED
+    BONDED;
+
+    static BondingState of(@NonNull final BluetoothDevice device) {
+        switch (device.getBondState()) {
+            case BluetoothDevice.BOND_BONDING:
+                return BONDING;
+            case BluetoothDevice.BOND_BONDED:
+                return BONDED;
+            case BluetoothDevice.BOND_NONE:
+            default:
+                return NOT_BONDED;
+        }
+    }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/observable/ConnectionState.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/observable/ConnectionState.java
@@ -6,6 +6,13 @@
 
 package io.runtime.mcumgr.sample.observable;
 
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothManager;
+import android.bluetooth.BluetoothProfile;
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
 public enum ConnectionState {
     CONNECTING,
     INITIALIZING,
@@ -13,5 +20,18 @@ public enum ConnectionState {
     DISCONNECTING,
     DISCONNECTED,
     TIMEOUT,
-    NOT_SUPPORTED
+    NOT_SUPPORTED;
+
+    static ConnectionState of(@NonNull final Context context,
+                              @NonNull final BluetoothDevice device) {
+        final BluetoothManager manager = (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);
+        if (manager == null)
+            return DISCONNECTED;
+
+        final int state = manager.getConnectionState(device, BluetoothProfile.GATT);
+        if (state == BluetoothProfile.STATE_CONNECTED)
+            return READY;
+
+        return DISCONNECTED;
+    }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/observable/ObservableMcuMgrBleTransport.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/observable/ObservableMcuMgrBleTransport.java
@@ -18,8 +18,8 @@ import io.runtime.mcumgr.ble.McuMgrBleTransport;
 import no.nordicsemi.android.ble.observer.BondingObserver;
 
 public class ObservableMcuMgrBleTransport extends McuMgrBleTransport {
-    private final MutableLiveData<ConnectionState> mConnectionState = new MutableLiveData<>(ConnectionState.DISCONNECTED);
-    private final MutableLiveData<BondingState> mBondingState = new MutableLiveData<>(BondingState.NOT_BONDED);
+    private final MutableLiveData<ConnectionState> mConnectionState;
+    private final MutableLiveData<BondingState> mBondingState;
 
     /**
      * Construct a McuMgrBleTransport object.
@@ -33,6 +33,7 @@ public class ObservableMcuMgrBleTransport extends McuMgrBleTransport {
                                         @NonNull final Handler handler) {
         super(context, device, handler);
 
+        mConnectionState = new MutableLiveData<>(ConnectionState.of(context, device));
         setConnectionObserver(new no.nordicsemi.android.ble.observer.ConnectionObserver() {
             @Override
             public void onDeviceConnecting(@NonNull final BluetoothDevice device) {
@@ -72,6 +73,8 @@ public class ObservableMcuMgrBleTransport extends McuMgrBleTransport {
                 }
             }
         });
+
+        mBondingState = new MutableLiveData<>(BondingState.of(device));
         setBondingObserver(new BondingObserver() {
             @Override
             public void onBondingRequired(@NonNull final BluetoothDevice device) {


### PR DESCRIPTION
Until now the UI showed state as NOT CONNECTED and NOT BONDED until the state changed.
Now, the initial state is obtained from the device state at the time of displaying the UI, so it may e.g. show the state as bonded.