### PR TITLE
Dead Handler thread fixed

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/MainActivity.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/MainActivity.java
@@ -8,22 +8,19 @@ package io.runtime.mcumgr.sample;
 
 import android.bluetooth.BluetoothDevice;
 import android.os.Bundle;
-import android.os.HandlerThread;
+
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+
+import javax.inject.Inject;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
-
-import com.google.android.material.bottomnavigation.BottomNavigationView;
-
-import javax.inject.Inject;
-
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasAndroidInjector;
-import io.runtime.mcumgr.sample.application.Dagger2Application;
 import io.runtime.mcumgr.sample.di.Injectable;
 import io.runtime.mcumgr.sample.fragment.DeviceFragment;
 import io.runtime.mcumgr.sample.fragment.FilesFragment;
@@ -41,8 +38,6 @@ public class MainActivity extends AppCompatActivity
     DispatchingAndroidInjector<Object> mDispatchingAndroidInjector;
     @Inject
     McuMgrViewModelFactory mViewModelFactory;
-    @Inject
-    HandlerThread mHandlerThread;
 
     private Fragment mDeviceFragment;
     private Fragment mImageFragment;
@@ -56,15 +51,12 @@ public class MainActivity extends AppCompatActivity
 
     @Override
     protected void onCreate(@Nullable final Bundle savedInstanceState) {
-        // The target must be set before calling super.onCreate(Bundle).
-        // Otherwise, Dagger2 will fail to inflate this Activity.
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
         final BluetoothDevice device = getIntent().getParcelableExtra(EXTRA_DEVICE);
         final String deviceName = device.getName();
         final String deviceAddress = device.getAddress();
-        ((Dagger2Application) getApplication()).setTarget(device);
-
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
 
         new ViewModelProvider(this, mViewModelFactory)
                 .get(MainViewModel.class);
@@ -129,12 +121,5 @@ public class MainActivity extends AppCompatActivity
             mFilesFragment = getSupportFragmentManager().findFragmentByTag("fs");
             mLogsStatsFragment = getSupportFragmentManager().findFragmentByTag("logs");
         }
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        // This will stop the handler thread that is used by transport object.
-        mHandlerThread.quitSafely();
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/ScannerActivity.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/ScannerActivity.java
@@ -38,6 +38,7 @@ import androidx.recyclerview.widget.SimpleItemAnimator;
 import javax.inject.Inject;
 
 import io.runtime.mcumgr.sample.adapter.DevicesAdapter;
+import io.runtime.mcumgr.sample.application.Dagger2Application;
 import io.runtime.mcumgr.sample.databinding.ActivityScannerBinding;
 import io.runtime.mcumgr.sample.di.Injectable;
 import io.runtime.mcumgr.sample.utils.Utils;
@@ -223,6 +224,10 @@ public class ScannerActivity extends AppCompatActivity
 
     @Override
     public void onItemClick(@NonNull final BluetoothDevice device) {
+        // The target must be set before calling super.onCreate(Bundle).
+        // Otherwise, Dagger2 will fail to inflate this Activity.
+        ((Dagger2Application) getApplication()).setTarget(device);
+
         final Intent intent = new Intent(this, MainActivity.class);
         intent.putExtra(MainActivity.EXTRA_DEVICE, device);
         startActivity(intent);

--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrTransportModule.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrTransportModule.java
@@ -11,10 +11,7 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.HandlerThread;
 
-import javax.inject.Named;
-
 import androidx.annotation.NonNull;
-import androidx.lifecycle.MutableLiveData;
 import dagger.Module;
 import dagger.Provides;
 import io.runtime.mcumgr.McuMgrTransport;
@@ -23,14 +20,6 @@ import io.runtime.mcumgr.sample.observable.ObservableMcuMgrBleTransport;
 
 @Module
 public class McuMgrTransportModule {
-
-    @Provides
-    @Named("busy")
-    @McuMgrScope
-    @NonNull
-    static MutableLiveData<Boolean> provideBusyStateLiveData() {
-        return new MutableLiveData<>();
-    }
 
     @Provides
     @McuMgrScope

--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrTransportModule.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrTransportModule.java
@@ -46,7 +46,7 @@ public class McuMgrTransportModule {
     @NonNull
     static HandlerThread provideTransportHandlerThread() {
         final HandlerThread handlerThread = new HandlerThread("McuMgrTransport");
-        handlerThread.start(); // The handler thread is stopped in MainActivity#onDestroy().
+        handlerThread.start(); // The handler thread is stopped in MainViewModel#onCleard().
         return handlerThread;
     }
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrViewModelModule.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrViewModelModule.java
@@ -6,6 +6,10 @@
 
 package io.runtime.mcumgr.sample.di.module;
 
+import javax.inject.Named;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.MutableLiveData;
 import dagger.Module;
 import dagger.Provides;
 import io.runtime.mcumgr.sample.di.McuMgrScope;
@@ -16,6 +20,14 @@ import io.runtime.mcumgr.sample.viewmodel.mcumgr.McuMgrViewModelFactory;
         McuMgrViewModelSubComponent.class
 })
 public class McuMgrViewModelModule {
+
+    @Provides
+    @Named("busy")
+    @McuMgrScope
+    @NonNull
+    static MutableLiveData<Boolean> provideBusyStateLiveData() {
+        return new MutableLiveData<>();
+    }
 
     @Provides
     @McuMgrScope

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/MainViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/MainViewModel.java
@@ -1,6 +1,7 @@
 package io.runtime.mcumgr.sample.viewmodel;
 
 import android.app.Application;
+import android.os.HandlerThread;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
@@ -12,6 +13,8 @@ import io.runtime.mcumgr.McuMgrTransport;
 public class MainViewModel extends AndroidViewModel {
     @Inject
     McuMgrTransport mMcuMgrTransport;
+    @Inject
+    HandlerThread mHandlerThread;
 
     @Inject
     public MainViewModel(@NonNull final Application application) {
@@ -23,5 +26,6 @@ public class MainViewModel extends AndroidViewModel {
         super.onCleared();
 
         mMcuMgrTransport.release();
+        mHandlerThread.quitSafely();
     }
 }


### PR DESCRIPTION
This PR fixes an issue observer after rotating the screen when in `MainActivity`. The handler thread was killed by `MainActivity#onDestroy()`, but the `McuMgrBleTransport` object, created in the view model, would live longer, which actually meant that the `McuMgrScope`d objects were mixed.

After the fix, the `McuMgrSubComponent` is created immediately when the used selects a device and all objects that use `McuMgrScope` are scoped correctly.