### PR TITLE
Migration away from Hungarian notation

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/MainActivity.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/MainActivity.java
@@ -35,18 +35,18 @@ public class MainActivity extends AppCompatActivity
     public static final String EXTRA_DEVICE = "device";
 
     @Inject
-    DispatchingAndroidInjector<Object> mDispatchingAndroidInjector;
+    DispatchingAndroidInjector<Object> dispatchingAndroidInjector;
     @Inject
-    McuMgrViewModelFactory mViewModelFactory;
+    McuMgrViewModelFactory viewModelFactory;
 
-    private Fragment mDeviceFragment;
-    private Fragment mImageFragment;
-    private Fragment mFilesFragment;
-    private Fragment mLogsStatsFragment;
+    private Fragment deviceFragment;
+    private Fragment imageFragment;
+    private Fragment filesFragment;
+    private Fragment logsStatsFragment;
 
     @Override
     public AndroidInjector<Object> androidInjector() {
-        return mDispatchingAndroidInjector;
+        return dispatchingAndroidInjector;
     }
 
     @Override
@@ -58,7 +58,7 @@ public class MainActivity extends AppCompatActivity
         final String deviceName = device.getName();
         final String deviceAddress = device.getAddress();
 
-        new ViewModelProvider(this, mViewModelFactory)
+        new ViewModelProvider(this, viewModelFactory)
                 .get(MainViewModel.class);
 
         // Configure the view.
@@ -74,26 +74,26 @@ public class MainActivity extends AppCompatActivity
             switch (item.getItemId()) {
                 case R.id.nav_default:
                     getSupportFragmentManager().beginTransaction()
-                            .show(mDeviceFragment).hide(mImageFragment)
-                            .hide(mFilesFragment).hide(mLogsStatsFragment)
+                            .show(deviceFragment).hide(imageFragment)
+                            .hide(filesFragment).hide(logsStatsFragment)
                             .commit();
                     return true;
                 case R.id.nav_dfu:
                     getSupportFragmentManager().beginTransaction()
-                            .hide(mDeviceFragment).show(mImageFragment)
-                            .hide(mFilesFragment).hide(mLogsStatsFragment)
+                            .hide(deviceFragment).show(imageFragment)
+                            .hide(filesFragment).hide(logsStatsFragment)
                             .commit();
                     return true;
                 case R.id.nav_fs:
                     getSupportFragmentManager().beginTransaction()
-                            .hide(mDeviceFragment).hide(mImageFragment)
-                            .show(mFilesFragment).hide(mLogsStatsFragment)
+                            .hide(deviceFragment).hide(imageFragment)
+                            .show(filesFragment).hide(logsStatsFragment)
                             .commit();
                     return true;
                 case R.id.nav_stats:
                     getSupportFragmentManager().beginTransaction()
-                            .hide(mDeviceFragment).hide(mImageFragment)
-                            .hide(mFilesFragment).show(mLogsStatsFragment)
+                            .hide(deviceFragment).hide(imageFragment)
+                            .hide(filesFragment).show(logsStatsFragment)
                             .commit();
                     return true;
             }
@@ -102,24 +102,24 @@ public class MainActivity extends AppCompatActivity
 
         // Initialize fragments.
         if (savedInstanceState == null) {
-            mDeviceFragment = new DeviceFragment();
-            mImageFragment = new ImageFragment();
-            mFilesFragment = new FilesFragment();
-            mLogsStatsFragment = new LogsStatsFragment();
+            deviceFragment = new DeviceFragment();
+            imageFragment = new ImageFragment();
+            filesFragment = new FilesFragment();
+            logsStatsFragment = new LogsStatsFragment();
 
             getSupportFragmentManager().beginTransaction()
-                    .add(R.id.container, mDeviceFragment, "device")
-                    .add(R.id.container, mImageFragment, "image")
-                    .add(R.id.container, mFilesFragment, "fs")
-                    .add(R.id.container, mLogsStatsFragment, "logs")
+                    .add(R.id.container, deviceFragment, "device")
+                    .add(R.id.container, imageFragment, "image")
+                    .add(R.id.container, filesFragment, "fs")
+                    .add(R.id.container, logsStatsFragment, "logs")
                     // Initially, show the Device fragment and hide others.
-                    .hide(mImageFragment).hide(mFilesFragment).hide(mLogsStatsFragment)
+                    .hide(imageFragment).hide(filesFragment).hide(logsStatsFragment)
                     .commit();
         } else {
-            mDeviceFragment = getSupportFragmentManager().findFragmentByTag("device");
-            mImageFragment = getSupportFragmentManager().findFragmentByTag("image");
-            mFilesFragment = getSupportFragmentManager().findFragmentByTag("fs");
-            mLogsStatsFragment = getSupportFragmentManager().findFragmentByTag("logs");
+            deviceFragment = getSupportFragmentManager().findFragmentByTag("device");
+            imageFragment = getSupportFragmentManager().findFragmentByTag("image");
+            filesFragment = getSupportFragmentManager().findFragmentByTag("fs");
+            logsStatsFragment = getSupportFragmentManager().findFragmentByTag("logs");
         }
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/adapter/DevicesAdapter.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/adapter/DevicesAdapter.java
@@ -25,8 +25,8 @@ import io.runtime.mcumgr.sample.viewmodel.DevicesLiveData;
 
 @SuppressWarnings("unused")
 public class DevicesAdapter extends RecyclerView.Adapter<DevicesAdapter.ViewHolder> {
-    private List<DiscoveredBluetoothDevice> mDevices;
-    private OnItemClickListener mOnItemClickListener;
+    private List<DiscoveredBluetoothDevice> devices;
+    private OnItemClickListener onItemClickListener;
 
     @FunctionalInterface
     public interface OnItemClickListener {
@@ -44,15 +44,15 @@ public class DevicesAdapter extends RecyclerView.Adapter<DevicesAdapter.ViewHold
      * @param listener the listener.
      */
     public void setOnItemClickListener(final OnItemClickListener listener) {
-        mOnItemClickListener = listener;
+        onItemClickListener = listener;
     }
 
     public DevicesAdapter(final ScannerActivity activity, final DevicesLiveData devicesLiveData) {
         setHasStableIds(true);
         devicesLiveData.observe(activity, devices -> {
             DiffUtil.DiffResult result = DiffUtil.calculateDiff(
-                    new DeviceDiffCallback(mDevices, devices), false);
-            mDevices = devices;
+                    new DeviceDiffCallback(this.devices, devices), false);
+            this.devices = devices;
             result.dispatchUpdatesTo(this);
         });
     }
@@ -67,47 +67,47 @@ public class DevicesAdapter extends RecyclerView.Adapter<DevicesAdapter.ViewHold
 
     @Override
     public void onBindViewHolder(@NonNull final ViewHolder holder, final int position) {
-        final DiscoveredBluetoothDevice device = mDevices.get(position);
+        final DiscoveredBluetoothDevice device = devices.get(position);
         final String deviceName = device.getName();
 
         if (!TextUtils.isEmpty(deviceName)) {
-            holder.mBinding.deviceName.setText(deviceName);
+            holder.binding.deviceName.setText(deviceName);
             // Set device icon. This is just guessing, based on the device name.
             if (deviceName.toLowerCase(Locale.US).contains("zephyr"))
-                holder.mBinding.icon.setImageResource(R.drawable.ic_device_zephyr);
+                holder.binding.icon.setImageResource(R.drawable.ic_device_zephyr);
             else if (deviceName.toLowerCase(Locale.US).contains("nimble"))
-                holder.mBinding.icon.setImageResource(R.drawable.ic_device_mynewt);
+                holder.binding.icon.setImageResource(R.drawable.ic_device_mynewt);
             else
-                holder.mBinding.icon.setImageResource(R.drawable.ic_device_other);
+                holder.binding.icon.setImageResource(R.drawable.ic_device_other);
         } else {
-            holder.mBinding.deviceName.setText(R.string.unknown_device);
-            holder.mBinding.icon.setImageResource(R.drawable.ic_device_other);
+            holder.binding.deviceName.setText(R.string.unknown_device);
+            holder.binding.icon.setImageResource(R.drawable.ic_device_other);
         }
-        holder.mBinding.deviceAddress.setText(device.getAddress());
+        holder.binding.deviceAddress.setText(device.getAddress());
         final int rssiPercent = (int) (100.0f * (127.0f + device.getRssi()) / (127.0f + 20.0f));
-        holder.mBinding.rssi.setImageLevel(rssiPercent);
+        holder.binding.rssi.setImageLevel(rssiPercent);
     }
 
     @Override
     public long getItemId(final int position) {
-        return mDevices.get(position).hashCode();
+        return devices.get(position).hashCode();
     }
 
     @Override
     public int getItemCount() {
-        return mDevices != null ? mDevices.size() : 0;
+        return devices != null ? devices.size() : 0;
     }
 
     final class ViewHolder extends RecyclerView.ViewHolder {
-        private final DeviceItemBinding mBinding;
+        private final DeviceItemBinding binding;
 
         private ViewHolder(final DeviceItemBinding binding) {
             super(binding.getRoot());
-            mBinding = binding;
+            this.binding = binding;
 
             binding.deviceContainer.setOnClickListener(v -> {
-                if (mOnItemClickListener != null) {
-                    mOnItemClickListener.onItemClick(mDevices.get(getBindingAdapterPosition()).getDevice());
+                if (onItemClickListener != null) {
+                    onItemClickListener.onItemClick(devices.get(getBindingAdapterPosition()).getDevice());
                 }
             });
         }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/application/Dagger2Application.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/application/Dagger2Application.java
@@ -25,7 +25,7 @@ public class Dagger2Application extends Application implements HasAndroidInjecto
     @Inject
     DispatchingAndroidInjector<Object> dispatchingAndroidInjector;
     @Inject
-    McuMgrSubComponent.Builder mBuilder;
+    McuMgrSubComponent.Builder builder;
 
     private Timber.Tree logger;
 
@@ -57,6 +57,6 @@ public class Dagger2Application extends Application implements HasAndroidInjecto
             logger = null;
         }
         Timber.plant(logger = new nRFLoggerTree(this, "Device Manager", device.getName()));
-        mBuilder.target(device).build().update(this);
+        builder.target(device).build().update(this);
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/module/ContextModule.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/module/ContextModule.java
@@ -18,27 +18,27 @@ import dagger.Provides;
 
 @Module
 public class ContextModule {
-    private final Application mApplication;
+    private final Application application;
 
     public ContextModule(final Application application) {
-        this.mApplication = application;
+        this.application = application;
     }
 
     @Provides
     @Singleton
     public Application provideApplication() {
-        return mApplication;
+        return application;
     }
 
     @Provides
     @Singleton
     public Context provideApplicationContext() {
-        return mApplication.getApplicationContext();
+        return application.getApplicationContext();
     }
 
     @Provides
     @Singleton
     public SharedPreferences provideSharedPreferences() {
-        return PreferenceManager.getDefaultSharedPreferences(mApplication);
+        return PreferenceManager.getDefaultSharedPreferences(application);
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/dialog/FirmwareUpgradeModeDialogFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/dialog/FirmwareUpgradeModeDialogFragment.java
@@ -20,7 +20,7 @@ import io.runtime.mcumgr.sample.fragment.mcumgr.ImageUpgradeFragment;
 public class FirmwareUpgradeModeDialogFragment extends DialogFragment {
     private static final String SIS_ITEM = "item";
 
-    private int mSelectedItem;
+    private int selectedItem;
 
     public static DialogFragment getInstance() {
         return new FirmwareUpgradeModeDialogFragment();
@@ -31,15 +31,15 @@ public class FirmwareUpgradeModeDialogFragment extends DialogFragment {
     @Override
     public Dialog onCreateDialog(@Nullable final Bundle savedInstanceState) {
         if (savedInstanceState != null) {
-            mSelectedItem = savedInstanceState.getInt(SIS_ITEM);
+            selectedItem = savedInstanceState.getInt(SIS_ITEM);
         } else {
-            mSelectedItem = 0;
+            selectedItem = 0;
         }
 
         return new AlertDialog.Builder(requireContext())
                 .setTitle(R.string.image_upgrade_mode)
-                .setSingleChoiceItems(R.array.image_upgrade_options, mSelectedItem,
-                        (dialog, which) -> mSelectedItem = which)
+                .setSingleChoiceItems(R.array.image_upgrade_options, selectedItem,
+                        (dialog, which) -> selectedItem = which)
                 .setNegativeButton(android.R.string.cancel, null)
                 .setPositiveButton(R.string.image_upgrade_action_start, (dialog, which) -> {
                     final ImageUpgradeFragment parent = (ImageUpgradeFragment) getParentFragment();
@@ -51,11 +51,11 @@ public class FirmwareUpgradeModeDialogFragment extends DialogFragment {
     @Override
     public void onSaveInstanceState(@NonNull final Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putInt(SIS_ITEM, mSelectedItem);
+        outState.putInt(SIS_ITEM, selectedItem);
     }
 
     private FirmwareUpgradeManager.Mode getMode() {
-        switch (mSelectedItem) {
+        switch (selectedItem) {
             case 2:
                 return FirmwareUpgradeManager.Mode.CONFIRM_ONLY;
             case 1:

--- a/sample/src/main/java/io/runtime/mcumgr/sample/dialog/GenerateFileDialogFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/dialog/GenerateFileDialogFragment.java
@@ -23,7 +23,7 @@ import io.runtime.mcumgr.sample.R;
 import io.runtime.mcumgr.sample.fragment.mcumgr.FilesUploadFragment;
 
 public class GenerateFileDialogFragment extends DialogFragment {
-    private InputMethodManager mImm;
+    private InputMethodManager imm;
 
     public static DialogFragment getInstance() {
         return new GenerateFileDialogFragment();
@@ -32,7 +32,7 @@ public class GenerateFileDialogFragment extends DialogFragment {
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mImm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
     }
 
     @SuppressWarnings("ConstantConditions")
@@ -51,7 +51,7 @@ public class GenerateFileDialogFragment extends DialogFragment {
                 .setPositiveButton(R.string.files_action_generate, null)
                 .setNegativeButton(android.R.string.cancel, null)
                 .create();
-        dialog.setOnShowListener(d -> mImm.showSoftInput(fileSize, InputMethodManager.SHOW_IMPLICIT));
+        dialog.setOnShowListener(d -> imm.showSoftInput(fileSize, InputMethodManager.SHOW_IMPLICIT));
         dialog.show();
         dialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
             try {

--- a/sample/src/main/java/io/runtime/mcumgr/sample/dialog/PartitionDialogFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/dialog/PartitionDialogFragment.java
@@ -29,9 +29,9 @@ import io.runtime.mcumgr.sample.utils.FsUtils;
 public class PartitionDialogFragment extends DialogFragment implements Injectable {
 
     @Inject
-    FsUtils mFsUtils;
+    FsUtils fsUtils;
 
-    private InputMethodManager mImm;
+    private InputMethodManager imm;
 
     public static DialogFragment getInstance() {
         return new PartitionDialogFragment();
@@ -40,7 +40,7 @@ public class PartitionDialogFragment extends DialogFragment implements Injectabl
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mImm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
     }
 
     @NonNull
@@ -49,7 +49,7 @@ public class PartitionDialogFragment extends DialogFragment implements Injectabl
         final LayoutInflater inflater = requireActivity().getLayoutInflater();
         final View view = inflater.inflate(R.layout.dialog_files_settings, null);
         final EditText partition = view.findViewById(R.id.partition);
-        partition.setText(mFsUtils.getPartitionString());
+        partition.setText(fsUtils.getPartitionString());
         partition.selectAll();
 
         final AlertDialog dialog = new AlertDialog.Builder(requireContext())
@@ -62,21 +62,21 @@ public class PartitionDialogFragment extends DialogFragment implements Injectabl
                 // Setting the neutral button listener here would cause the dialog to dismiss.
                 .setNeutralButton(R.string.files_settings_action_restore, null)
                 .create();
-        dialog.setOnShowListener(d -> mImm.showSoftInput(partition, InputMethodManager.SHOW_IMPLICIT));
+        dialog.setOnShowListener(d -> imm.showSoftInput(partition, InputMethodManager.SHOW_IMPLICIT));
 
         // The neutral button should not dismiss the dialog.
         // We have to overwrite the default OnClickListener.
         // This can be done only after the dialog was shown.
         dialog.show();
         dialog.getButton(DialogInterface.BUTTON_NEUTRAL).setOnClickListener(v -> {
-            final String defaultPartition = mFsUtils.getDefaultPartition();
+            final String defaultPartition = fsUtils.getDefaultPartition();
             partition.setText(defaultPartition);
             partition.setSelection(defaultPartition.length());
         });
         dialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
             final String newPartition = partition.getText().toString().trim();
             if (!TextUtils.isEmpty(newPartition)) {
-                mFsUtils.setPartition(newPartition);
+                fsUtils.setPartition(newPartition);
                 dismiss();
             } else {
                 partition.setError(getString(R.string.files_settings_error));

--- a/sample/src/main/java/io/runtime/mcumgr/sample/dialog/SelectImageDialogFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/dialog/SelectImageDialogFragment.java
@@ -13,7 +13,7 @@ import io.runtime.mcumgr.sample.databinding.DialogSelectImageBinding;
 
 public class SelectImageDialogFragment extends DialogFragment {
 	private static final String ARG_REQUEST_ID = "requestId";
-	private int mPosition = 0;
+	private int position = 0;
 
 	public interface OnImageSelectedListener {
 		void onImageSelected(final int requestId, final int image);
@@ -37,7 +37,7 @@ public class SelectImageDialogFragment extends DialogFragment {
 		binding.image.setAdapter(new ArrayAdapter<>(requireContext(), R.layout.dialog_select_image_item, items));
 		binding.image.setText(items[0], false);
 		binding.image.setOnItemClickListener((parent, view, position, id) -> {
-			mPosition = position;
+			position = position;
 		});
 
 		return new AlertDialog.Builder(requireContext())
@@ -51,7 +51,7 @@ public class SelectImageDialogFragment extends DialogFragment {
 
 					final OnImageSelectedListener listener = (OnImageSelectedListener) getParentFragment();
 					if (listener != null)
-						listener.onImageSelected(requestId, mPosition);
+						listener.onImageSelected(requestId, position);
 				})
 				.setNegativeButton(android.R.string.cancel, null)
 				.create();

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/ImageFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/ImageFragment.java
@@ -31,37 +31,37 @@ public class ImageFragment extends Fragment implements Injectable {
 
     @SuppressWarnings("WeakerAccess")
     @Inject
-    McuMgrViewModelFactory mViewModelFactory;
+    McuMgrViewModelFactory viewModelFactory;
 
-    private McuMgrViewModel mViewModel;
+    private McuMgrViewModel viewModel;
 
     // Basic
-    private Fragment mImageUpgradeFragment;
+    private Fragment imageUpgradeFragment;
     // Advanced
-    private Fragment mImageUploadFragment;
-    private Fragment mImageControlFragment;
-    private Fragment mImageSettingsFragment;
-    private Fragment mResetFragment;
+    private Fragment imageUploadFragment;
+    private Fragment imageControlFragment;
+    private Fragment imageSettingsFragment;
+    private Fragment resetFragment;
 
-    private boolean mModeAdvanced;
-    private boolean mOperationInProgress;
+    private boolean modeAdvanced;
+    private boolean operationInProgress;
 
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
 
-        mViewModel = new ViewModelProvider(this, mViewModelFactory)
+        viewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(McuMgrViewModel.class);
 
-        mModeAdvanced = savedInstanceState != null &&
+        modeAdvanced = savedInstanceState != null &&
                 savedInstanceState.getBoolean(SIS_MODE_ADVANCED);
     }
 
     @Override
     public void onSaveInstanceState(@NonNull final Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putBoolean(SIS_MODE_ADVANCED, mModeAdvanced);
+        outState.putBoolean(SIS_MODE_ADVANCED, modeAdvanced);
     }
 
     @Override
@@ -69,35 +69,35 @@ public class ImageFragment extends Fragment implements Injectable {
         inflater.inflate(R.menu.image_mode, menu);
 
         menu.findItem(R.id.action_switch_to_advanced)
-                .setVisible(!mModeAdvanced)
-                .setEnabled(!mOperationInProgress);
+                .setVisible(!modeAdvanced)
+                .setEnabled(!operationInProgress);
         menu.findItem(R.id.action_switch_to_basic)
-                .setVisible(mModeAdvanced)
-                .setEnabled(!mOperationInProgress);
+                .setVisible(modeAdvanced)
+                .setEnabled(!operationInProgress);
     }
 
     @Override
     public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
         switch (item.getItemId()) {
             case R.id.action_switch_to_advanced:
-                mModeAdvanced = true;
+                modeAdvanced = true;
                 getChildFragmentManager().beginTransaction()
-                        .show(mImageUploadFragment)
-                        .show(mImageControlFragment)
-                        .show(mImageSettingsFragment)
-                        .show(mResetFragment)
-                        .hide(mImageUpgradeFragment)
+                        .show(imageUploadFragment)
+                        .show(imageControlFragment)
+                        .show(imageSettingsFragment)
+                        .show(resetFragment)
+                        .hide(imageUpgradeFragment)
                         .commit();
                 requireActivity().invalidateOptionsMenu();
                 return true;
             case R.id.action_switch_to_basic:
-                mModeAdvanced = false;
+                modeAdvanced = false;
                 getChildFragmentManager().beginTransaction()
-                        .show(mImageUpgradeFragment)
-                        .hide(mImageUploadFragment)
-                        .hide(mImageControlFragment)
-                        .hide(mImageSettingsFragment)
-                        .hide(mResetFragment)
+                        .show(imageUpgradeFragment)
+                        .hide(imageUploadFragment)
+                        .hide(imageControlFragment)
+                        .hide(imageSettingsFragment)
+                        .hide(resetFragment)
                         .commit();
                 requireActivity().invalidateOptionsMenu();
                 return true;
@@ -118,24 +118,24 @@ public class ImageFragment extends Fragment implements Injectable {
         super.onViewCreated(view, savedInstanceState);
 
         final FragmentManager fm = getChildFragmentManager();
-        mImageUpgradeFragment = fm.findFragmentById(R.id.fragment_image_upgrade);
-        mImageUploadFragment = fm.findFragmentById(R.id.fragment_image_upload);
-        mImageControlFragment = fm.findFragmentById(R.id.fragment_image_control);
-        mImageSettingsFragment = fm.findFragmentById(R.id.fragment_image_settings);
-        mResetFragment = fm.findFragmentById(R.id.fragment_reset);
+        imageUpgradeFragment = fm.findFragmentById(R.id.fragment_image_upgrade);
+        imageUploadFragment = fm.findFragmentById(R.id.fragment_image_upload);
+        imageControlFragment = fm.findFragmentById(R.id.fragment_image_control);
+        imageSettingsFragment = fm.findFragmentById(R.id.fragment_image_settings);
+        resetFragment = fm.findFragmentById(R.id.fragment_reset);
 
         // Initially, show only the basic Image Upgrade fragment
         if (savedInstanceState == null) {
             getChildFragmentManager().beginTransaction()
-                    .hide(mImageUploadFragment)
-                    .hide(mImageControlFragment)
-                    .hide(mImageSettingsFragment)
-                    .hide(mResetFragment)
+                    .hide(imageUploadFragment)
+                    .hide(imageControlFragment)
+                    .hide(imageSettingsFragment)
+                    .hide(resetFragment)
                     .commit();
         }
 
-        mViewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> {
-            mOperationInProgress = busy;
+        viewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> {
+            operationInProgress = busy;
             requireActivity().invalidateOptionsMenu();
         });
     }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/DeviceStatusFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/DeviceStatusFragment.java
@@ -27,16 +27,16 @@ import io.runtime.mcumgr.sample.viewmodel.mcumgr.McuMgrViewModelFactory;
 public class DeviceStatusFragment extends Fragment implements Injectable {
 
     @Inject
-    McuMgrViewModelFactory mViewModelFactory;
+    McuMgrViewModelFactory viewModelFactory;
 
-    private FragmentCardDeviceStatusBinding mBinding;
+    private FragmentCardDeviceStatusBinding binding;
 
-    private DeviceStatusViewModel mViewModel;
+    private DeviceStatusViewModel viewModel;
 
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mViewModel = new ViewModelProvider(this, mViewModelFactory)
+        viewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(DeviceStatusViewModel.class);
     }
 
@@ -45,59 +45,59 @@ public class DeviceStatusFragment extends Fragment implements Injectable {
     public View onCreateView(@NonNull final LayoutInflater inflater,
                              @Nullable final ViewGroup container,
                              @Nullable final Bundle savedInstanceState) {
-        mBinding = FragmentCardDeviceStatusBinding.inflate(inflater, container, false);
-        return mBinding.getRoot();
+        binding = FragmentCardDeviceStatusBinding.inflate(inflater, container, false);
+        return binding.getRoot();
     }
 
     @Override
     public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        mViewModel.getConnectionState().observe(getViewLifecycleOwner(), state -> {
+        viewModel.getConnectionState().observe(getViewLifecycleOwner(), state -> {
             switch (state) {
                 case CONNECTING:
-                    mBinding.connectionStatus.setText(R.string.status_connecting);
+                    binding.connectionStatus.setText(R.string.status_connecting);
                     break;
                 case INITIALIZING:
-                    mBinding.connectionStatus.setText(R.string.status_initializing);
+                    binding.connectionStatus.setText(R.string.status_initializing);
                     break;
                 case READY:
-                    mBinding.connectionStatus.setText(R.string.status_connected);
+                    binding.connectionStatus.setText(R.string.status_connected);
                     break;
                 case DISCONNECTING:
-                    mBinding.connectionStatus.setText(R.string.status_disconnecting);
+                    binding.connectionStatus.setText(R.string.status_disconnecting);
                     break;
                 case DISCONNECTED:
-                    mBinding.connectionStatus.setText(R.string.status_disconnected);
+                    binding.connectionStatus.setText(R.string.status_disconnected);
                     break;
                 case TIMEOUT:
-                    mBinding.connectionStatus.setText(R.string.status_connection_timeout);
+                    binding.connectionStatus.setText(R.string.status_connection_timeout);
                     break;
                 case NOT_SUPPORTED:
-                    mBinding.connectionStatus.setText(R.string.status_not_supported);
+                    binding.connectionStatus.setText(R.string.status_not_supported);
                     break;
             }
         });
-        mViewModel.getBondState().observe(getViewLifecycleOwner(), state -> {
+        viewModel.getBondState().observe(getViewLifecycleOwner(), state -> {
             switch (state) {
                 case NOT_BONDED:
-                    mBinding.bondingStatus.setText(R.string.status_not_bonded);
+                    binding.bondingStatus.setText(R.string.status_not_bonded);
                     break;
                 case BONDING:
-                    mBinding.bondingStatus.setText(R.string.status_bonding);
+                    binding.bondingStatus.setText(R.string.status_bonding);
                     break;
                 case BONDED:
-                    mBinding.bondingStatus.setText(R.string.status_bonded);
+                    binding.bondingStatus.setText(R.string.status_bonded);
                     break;
             }
         });
-        mViewModel.getBusyState().observe(getViewLifecycleOwner(), busy ->
-                mBinding.workIndicator.setVisibility(busy ? View.VISIBLE : View.GONE));
+        viewModel.getBusyState().observe(getViewLifecycleOwner(), busy ->
+                binding.workIndicator.setVisibility(busy ? View.VISIBLE : View.GONE));
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        mBinding = null;
+        binding = null;
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/EchoFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/EchoFragment.java
@@ -33,19 +33,19 @@ import io.runtime.mcumgr.sample.viewmodel.mcumgr.McuMgrViewModelFactory;
 public class EchoFragment extends Fragment implements Injectable {
 
     @Inject
-    McuMgrViewModelFactory mViewModelFactory;
+    McuMgrViewModelFactory viewModelFactory;
 
-    private FragmentCardEchoBinding mBinding;
+    private FragmentCardEchoBinding binding;
 
-    private EchoViewModel mViewModel;
-    private InputMethodManager mImm;
+    private EchoViewModel viewModel;
+    private InputMethodManager imm;
 
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mViewModel = new ViewModelProvider(this, mViewModelFactory)
+        viewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(EchoViewModel.class);
-        mImm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
     }
 
     @Nullable
@@ -53,52 +53,52 @@ public class EchoFragment extends Fragment implements Injectable {
     public View onCreateView(@NonNull final LayoutInflater inflater,
                              @Nullable final ViewGroup container,
                              @Nullable final Bundle savedInstanceState) {
-        mBinding = FragmentCardEchoBinding.inflate(inflater, container, false);
-        return mBinding.getRoot();
+        binding = FragmentCardEchoBinding.inflate(inflater, container, false);
+        return binding.getRoot();
     }
 
     @Override
     public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        mBinding.echoValue.setSelection(mBinding.echoValue.getText().length());
+        binding.echoValue.setSelection(binding.echoValue.getText().length());
 
-        mViewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> mBinding.actionSend.setEnabled(!busy));
-        mViewModel.getRequest().observe(getViewLifecycleOwner(), text -> {
-            mBinding.echoContent.setVisibility(View.VISIBLE);
-            print(mBinding.echoRequest, text);
-            if (mBinding.echoResponse.getVisibility() == View.VISIBLE) {
-                mBinding.echoResponse.setVisibility(View.INVISIBLE);
+        viewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> binding.actionSend.setEnabled(!busy));
+        viewModel.getRequest().observe(getViewLifecycleOwner(), text -> {
+            binding.echoContent.setVisibility(View.VISIBLE);
+            print(binding.echoRequest, text);
+            if (binding.echoResponse.getVisibility() == View.VISIBLE) {
+                binding.echoResponse.setVisibility(View.INVISIBLE);
             }
         });
-        mViewModel.getResponse().observe(getViewLifecycleOwner(), response -> {
-            mBinding.echoResponse.setBackgroundResource(R.drawable.echo_response);
-            print(mBinding.echoResponse, response);
+        viewModel.getResponse().observe(getViewLifecycleOwner(), response -> {
+            binding.echoResponse.setBackgroundResource(R.drawable.echo_response);
+            print(binding.echoResponse, response);
         });
-        mViewModel.getError().observe(getViewLifecycleOwner(), error -> {
-            mBinding.echoResponse.setBackgroundResource(R.drawable.echo_error);
-            print(mBinding.echoResponse, StringUtils.toString(requireContext(), error));
+        viewModel.getError().observe(getViewLifecycleOwner(), error -> {
+            binding.echoResponse.setBackgroundResource(R.drawable.echo_error);
+            print(binding.echoResponse, StringUtils.toString(requireContext(), error));
         });
-        mBinding.actionSend.setOnClickListener(v -> {
-            mBinding.echoRequest.setText(null);
-            mBinding.echoResponse.setText(null);
+        binding.actionSend.setOnClickListener(v -> {
+            binding.echoRequest.setText(null);
+            binding.echoResponse.setText(null);
 
             hideKeyboard();
 
-            final String text = mBinding.echoValue.getText().toString();
-            mBinding.echoValue.setText(null);
-            mViewModel.echo(text);
+            final String text = binding.echoValue.getText().toString();
+            binding.echoValue.setText(null);
+            viewModel.echo(text);
         });
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        mBinding = null;
+        binding = null;
     }
 
     private void hideKeyboard() {
-        mImm.hideSoftInputFromWindow(mBinding.echoValue.getWindowToken(), 0);
+        imm.hideSoftInputFromWindow(binding.echoValue.getWindowToken(), 0);
     }
 
     private void print(final TextView view, final String text) {

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FileBrowserFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FileBrowserFragment.java
@@ -40,21 +40,21 @@ public abstract class FileBrowserFragment extends Fragment implements LoaderMana
     private static final String SIS_DATA = "data";
     private static final String SIS_URI = "uri";
 
-    private byte[] mFileContent;
-    private Uri mFileUri;
+    private byte[] fileContent;
+    private Uri fileUri;
 
-    private ActivityResultLauncher<String> mFileBrowserLauncher;
+    private ActivityResultLauncher<String> fileBrowserLauncher;
 
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         if (savedInstanceState != null) {
-            mFileContent = savedInstanceState.getByteArray(SIS_DATA);
-            mFileUri = savedInstanceState.getParcelable(SIS_URI);
+            fileContent = savedInstanceState.getByteArray(SIS_DATA);
+            fileUri = savedInstanceState.getParcelable(SIS_URI);
         }
 
-        mFileBrowserLauncher = registerForActivityResult(
+        fileBrowserLauncher = registerForActivityResult(
                 new ActivityResultContracts.GetContent(),
                 uri -> {
                     if (uri == null)
@@ -75,8 +75,8 @@ public abstract class FileBrowserFragment extends Fragment implements LoaderMana
     @Override
     public void onSaveInstanceState(@NonNull final Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putByteArray(SIS_DATA, mFileContent);
-        outState.putParcelable(SIS_URI, mFileUri);
+        outState.putByteArray(SIS_DATA, fileContent);
+        outState.putParcelable(SIS_URI, fileUri);
     }
 
     /**
@@ -86,11 +86,11 @@ public abstract class FileBrowserFragment extends Fragment implements LoaderMana
      */
     @Nullable
     byte[] getFileContent() {
-        return mFileContent;
+        return fileContent;
     }
 
     void setFileContent(@NonNull final byte[] data) {
-        mFileContent = data;
+        fileContent = data;
         onFileLoaded(data);
     }
 
@@ -98,7 +98,7 @@ public abstract class FileBrowserFragment extends Fragment implements LoaderMana
      * Releases the reference to the file content and calls {@link #onFileCleared()}.
      */
     void clearFileContent() {
-        mFileContent = null;
+        fileContent = null;
         onFileCleared();
     }
 
@@ -108,7 +108,7 @@ public abstract class FileBrowserFragment extends Fragment implements LoaderMana
      * @return True if the file has been selected, false otherwise.
      */
     boolean isFileLoaded() {
-        return mFileContent != null;
+        return fileContent != null;
     }
 
     /**
@@ -211,7 +211,7 @@ public abstract class FileBrowserFragment extends Fragment implements LoaderMana
      * @param mimeType required MIME TYPE of a file.
      */
     void selectFile(@Nullable final String mimeType) {
-        mFileBrowserLauncher.launch(mimeType);
+        fileBrowserLauncher.launch(mimeType);
     }
 
     /**
@@ -239,7 +239,7 @@ public abstract class FileBrowserFragment extends Fragment implements LoaderMana
             } finally {
                 buf.close();
             }
-            mFileContent = bytes;
+            fileContent = bytes;
             onFileLoaded(bytes);
         } catch (final IOException e) {
             Timber.e(e, "Reading file content failed");

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FilesDownloadFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FilesDownloadFragment.java
@@ -49,22 +49,22 @@ import io.runtime.mcumgr.sample.viewmodel.mcumgr.McuMgrViewModelFactory;
 public class FilesDownloadFragment extends Fragment implements Injectable {
 
     @Inject
-    McuMgrViewModelFactory mViewModelFactory;
+    McuMgrViewModelFactory viewModelFactory;
     @Inject
-    FsUtils mFsUtils;
+    FsUtils fsUtils;
 
-    private FragmentCardFilesDownloadBinding mBinding;
+    private FragmentCardFilesDownloadBinding binding;
 
-    private FilesDownloadViewModel mViewModel;
-    private InputMethodManager mImm;
-    private String mPartition;
+    private FilesDownloadViewModel viewModel;
+    private InputMethodManager imm;
+    private String partition;
 
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mViewModel = new ViewModelProvider(this, mViewModelFactory)
+        viewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(FilesDownloadViewModel.class);
-        mImm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
     }
 
     @Nullable
@@ -72,35 +72,35 @@ public class FilesDownloadFragment extends Fragment implements Injectable {
     public View onCreateView(@NonNull final LayoutInflater inflater,
                              @Nullable final ViewGroup container,
                              @Nullable final Bundle savedInstanceState) {
-        mBinding = FragmentCardFilesDownloadBinding.inflate(inflater, container, false);
-        return mBinding.getRoot();
+        binding = FragmentCardFilesDownloadBinding.inflate(inflater, container, false);
+        return binding.getRoot();
     }
 
     @Override
     public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        mBinding.fileName.addTextChangedListener(new SimpleTextWatcher() {
+        binding.fileName.addTextChangedListener(new SimpleTextWatcher() {
             @Override
             public void onTextChanged(final CharSequence s,
                                       final int start, final int before, final int count) {
-                mBinding.filePath.setText(getString(R.string.files_file_path, mPartition, s));
+                binding.filePath.setText(getString(R.string.files_file_path, partition, s));
             }
         });
 
-        mFsUtils.getPartition().observe(getViewLifecycleOwner(), partition -> {
-            mPartition = partition;
-            final String fileName = mBinding.fileName.getText().toString();
-            mBinding.filePath.setText(getString(R.string.files_file_path, partition, fileName));
+        fsUtils.getPartition().observe(getViewLifecycleOwner(), partition -> {
+            partition = partition;
+            final String fileName = binding.fileName.getText().toString();
+            binding.filePath.setText(getString(R.string.files_file_path, partition, fileName));
         });
-        mViewModel.getProgress().observe(getViewLifecycleOwner(), progress -> mBinding.progress.setProgress(progress));
-        mViewModel.getResponse().observe(getViewLifecycleOwner(), this::printContent);
-        mViewModel.getError().observe(getViewLifecycleOwner(), this::printError);
-        mViewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> mBinding.actionDownload.setEnabled(!busy));
-        mBinding.actionHistory.setOnClickListener(v -> {
+        viewModel.getProgress().observe(getViewLifecycleOwner(), progress -> binding.progress.setProgress(progress));
+        viewModel.getResponse().observe(getViewLifecycleOwner(), this::printContent);
+        viewModel.getError().observe(getViewLifecycleOwner(), this::printError);
+        viewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> binding.actionDownload.setEnabled(!busy));
+        binding.actionHistory.setOnClickListener(v -> {
             final PopupMenu popupMenu = new PopupMenu(requireContext(), v);
             final Menu menu = popupMenu.getMenu();
-            final Set<String> recents = mFsUtils.getRecents();
+            final Set<String> recents = fsUtils.getRecents();
             if (recents.isEmpty()) {
                 menu.add(R.string.files_download_recent_files_empty).setEnabled(false);
             } else {
@@ -111,20 +111,20 @@ public class FilesDownloadFragment extends Fragment implements Injectable {
                 }
             }
             popupMenu.setOnMenuItemClickListener(item -> {
-                mBinding.fileName.setError(null);
-                mBinding.fileName.setText(item.getTitle());
+                binding.fileName.setError(null);
+                binding.fileName.setText(item.getTitle());
                 return true;
             });
             popupMenu.show();
         });
-        mBinding.actionDownload.setOnClickListener(v -> {
-            final String fileName = mBinding.fileName.getText().toString();
+        binding.actionDownload.setOnClickListener(v -> {
+            final String fileName = binding.fileName.getText().toString();
             if (TextUtils.isEmpty(fileName)) {
-                mBinding.fileName.setError(getString(R.string.files_download_empty));
+                binding.fileName.setError(getString(R.string.files_download_empty));
             } else {
                 hideKeyboard();
-                mFsUtils.addRecent(fileName);
-                mViewModel.download(mBinding.filePath.getText().toString());
+                fsUtils.addRecent(fileName);
+                viewModel.download(binding.filePath.getText().toString());
             }
         });
     }
@@ -132,49 +132,49 @@ public class FilesDownloadFragment extends Fragment implements Injectable {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        mBinding = null;
+        binding = null;
     }
 
     private void hideKeyboard() {
-        mImm.hideSoftInputFromWindow(mBinding.fileName.getWindowToken(), 0);
+        imm.hideSoftInputFromWindow(binding.fileName.getWindowToken(), 0);
     }
 
     private void printContent(@Nullable final byte[] data) {
-        mBinding.divider.setVisibility(View.VISIBLE);
-        mBinding.fileResult.setVisibility(View.VISIBLE);
-        mBinding.image.setVisibility(View.VISIBLE);
-        mBinding.image.setImageDrawable(null);
+        binding.divider.setVisibility(View.VISIBLE);
+        binding.fileResult.setVisibility(View.VISIBLE);
+        binding.image.setVisibility(View.VISIBLE);
+        binding.image.setImageDrawable(null);
 
         if (data == null) {
-            mBinding.fileResult.setText(R.string.files_download_error_file_not_found);
+            binding.fileResult.setText(R.string.files_download_error_file_not_found);
         } else {
             if (data.length == 0) {
-                mBinding.fileResult.setText(R.string.files_download_file_empty);
+                binding.fileResult.setText(R.string.files_download_file_empty);
             } else {
-                final String path = mBinding.filePath.getText().toString();
+                final String path = binding.filePath.getText().toString();
                 final Bitmap bitmap = FsUtils.toBitmap(getResources(), data);
                 if (bitmap != null) {
                     final SpannableString spannable = new SpannableString(
                             getString(R.string.files_download_image, path, data.length));
                     spannable.setSpan(new StyleSpan(Typeface.BOLD),
                             0, path.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-                    mBinding.fileResult.setText(spannable);
-                    mBinding.image.setImageBitmap(bitmap);
+                    binding.fileResult.setText(spannable);
+                    binding.image.setImageBitmap(bitmap);
                 } else {
                     final String content = new String(data);
                     final SpannableString spannable = new SpannableString(
                             getString(R.string.files_download_file, path, data.length, content));
                     spannable.setSpan(new StyleSpan(Typeface.BOLD),
                             0, path.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-                    mBinding.fileResult.setText(spannable);
+                    binding.fileResult.setText(spannable);
                 }
             }
         }
     }
 
     private void printError(@Nullable final McuMgrException error) {
-        mBinding.divider.setVisibility(View.VISIBLE);
-        mBinding.fileResult.setVisibility(View.VISIBLE);
+        binding.divider.setVisibility(View.VISIBLE);
+        binding.fileResult.setVisibility(View.VISIBLE);
 
         String message = StringUtils.toString(requireContext(), error);
         if (error instanceof McuMgrErrorException) {
@@ -184,7 +184,7 @@ public class FilesDownloadFragment extends Fragment implements Injectable {
             }
         }
         if (message == null) {
-            mBinding.fileResult.setText(null);
+            binding.fileResult.setText(null);
             return;
         }
         final SpannableString spannable = new SpannableString(message);
@@ -193,7 +193,7 @@ public class FilesDownloadFragment extends Fragment implements Injectable {
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
         spannable.setSpan(new StyleSpan(Typeface.BOLD),
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-        mBinding.fileResult.setText(spannable);
+        binding.fileResult.setText(spannable);
     }
 
     private abstract static class SimpleTextWatcher implements TextWatcher {

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FilesUploadFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FilesUploadFragment.java
@@ -37,18 +37,18 @@ import io.runtime.mcumgr.sample.viewmodel.mcumgr.McuMgrViewModelFactory;
 public class FilesUploadFragment extends FileBrowserFragment implements Injectable {
 
     @Inject
-    McuMgrViewModelFactory mViewModelFactory;
+    McuMgrViewModelFactory viewModelFactory;
     @Inject
-    FsUtils mFsUtils;
+    FsUtils fsUtils;
 
-    private FragmentCardFilesUploadBinding mBinding;
+    private FragmentCardFilesUploadBinding binding;
 
-    private FilesUploadViewModel mViewModel;
+    private FilesUploadViewModel viewModel;
 
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mViewModel = new ViewModelProvider(this, mViewModelFactory)
+        viewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(FilesUploadViewModel.class);
     }
 
@@ -57,105 +57,105 @@ public class FilesUploadFragment extends FileBrowserFragment implements Injectab
     public View onCreateView(@NonNull final LayoutInflater inflater,
                              @Nullable final ViewGroup container,
                              @Nullable final Bundle savedInstanceState) {
-        mBinding = FragmentCardFilesUploadBinding.inflate(inflater, container, false);
-        return mBinding.getRoot();
+        binding = FragmentCardFilesUploadBinding.inflate(inflater, container, false);
+        return binding.getRoot();
     }
 
     @Override
     public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        mFsUtils.getPartition().observe(getViewLifecycleOwner(), partition -> {
+        fsUtils.getPartition().observe(getViewLifecycleOwner(), partition -> {
             if (isFileLoaded()) {
-                final String fileName = mBinding.fileName.getText().toString();
-                mBinding.filePath.setText(getString(R.string.files_file_path, partition, fileName));
+                final String fileName = binding.fileName.getText().toString();
+                binding.filePath.setText(getString(R.string.files_file_path, partition, fileName));
             }
         });
-        mViewModel.getState().observe(getViewLifecycleOwner(), state -> {
-            mBinding.actionUpload.setEnabled(isFileLoaded());
-            mBinding.actionCancel.setEnabled(state.canCancel());
-            mBinding.actionPauseResume.setEnabled(state.canPauseOrResume());
-            mBinding.actionPauseResume.setText(state == FilesUploadViewModel.State.PAUSED ?
+        viewModel.getState().observe(getViewLifecycleOwner(), state -> {
+            binding.actionUpload.setEnabled(isFileLoaded());
+            binding.actionCancel.setEnabled(state.canCancel());
+            binding.actionPauseResume.setEnabled(state.canPauseOrResume());
+            binding.actionPauseResume.setText(state == FilesUploadViewModel.State.PAUSED ?
                     R.string.image_action_resume : R.string.image_action_pause);
 
-            mBinding.actionSelectFile.setVisibility(state.inProgress() ? View.GONE : View.VISIBLE);
-            mBinding.actionUpload.setVisibility(state.inProgress() ? View.GONE : View.VISIBLE);
-            mBinding.actionCancel.setVisibility(state.inProgress() ? View.VISIBLE : View.GONE);
-            mBinding.actionPauseResume.setVisibility(state.inProgress() ? View.VISIBLE : View.GONE);
+            binding.actionSelectFile.setVisibility(state.inProgress() ? View.GONE : View.VISIBLE);
+            binding.actionUpload.setVisibility(state.inProgress() ? View.GONE : View.VISIBLE);
+            binding.actionCancel.setVisibility(state.inProgress() ? View.VISIBLE : View.GONE);
+            binding.actionPauseResume.setVisibility(state.inProgress() ? View.VISIBLE : View.GONE);
             // Update status
             switch (state) {
                 case UPLOADING:
-                    mBinding.status.setText(R.string.files_upload_status_uploading);
+                    binding.status.setText(R.string.files_upload_status_uploading);
                     break;
                 case PAUSED:
-                    mBinding.status.setText(R.string.files_upload_status_paused);
+                    binding.status.setText(R.string.files_upload_status_paused);
                     break;
                 case COMPLETE:
                     clearFileContent();
-                    mBinding.status.setText(R.string.files_upload_status_completed);
-                    mBinding.speed.setText(null);
+                    binding.status.setText(R.string.files_upload_status_completed);
+                    binding.speed.setText(null);
                     break;
             }
         });
-        mViewModel.getTransferSpeed().observe(getViewLifecycleOwner(), speed ->
-                mBinding.speed.setText(getString(R.string.files_upload_speed, speed))
+        viewModel.getTransferSpeed().observe(getViewLifecycleOwner(), speed ->
+                binding.speed.setText(getString(R.string.files_upload_speed, speed))
         );
-        mViewModel.getProgress().observe(getViewLifecycleOwner(), progress ->
-                mBinding.progress.setProgress(progress)
+        viewModel.getProgress().observe(getViewLifecycleOwner(), progress ->
+                binding.progress.setProgress(progress)
         );
-        mViewModel.getError().observe(getViewLifecycleOwner(), error -> {
-            mBinding.actionGenerate.setVisibility(View.VISIBLE);
-            mBinding.actionSelectFile.setVisibility(View.VISIBLE);
-            mBinding.actionUpload.setVisibility(View.VISIBLE);
-            mBinding.actionCancel.setVisibility(View.GONE);
-            mBinding.actionPauseResume.setVisibility(View.GONE);
+        viewModel.getError().observe(getViewLifecycleOwner(), error -> {
+            binding.actionGenerate.setVisibility(View.VISIBLE);
+            binding.actionSelectFile.setVisibility(View.VISIBLE);
+            binding.actionUpload.setVisibility(View.VISIBLE);
+            binding.actionCancel.setVisibility(View.GONE);
+            binding.actionPauseResume.setVisibility(View.GONE);
             printError(error);
         });
-        mViewModel.getCancelledEvent().observe(getViewLifecycleOwner(), nothing -> {
+        viewModel.getCancelledEvent().observe(getViewLifecycleOwner(), nothing -> {
             clearFileContent();
-            mBinding.fileName.setText(null);
-            mBinding.filePath.setText(null);
-            mBinding.fileSize.setText(null);
-            mBinding.status.setText(null);
-            mBinding.speed.setText(null);
-            mBinding.actionGenerate.setVisibility(View.VISIBLE);
-            mBinding.actionSelectFile.setVisibility(View.VISIBLE);
-            mBinding.actionUpload.setVisibility(View.VISIBLE);
-            mBinding.actionUpload.setEnabled(false);
-            mBinding.actionCancel.setVisibility(View.GONE);
-            mBinding.actionPauseResume.setVisibility(View.GONE);
+            binding.fileName.setText(null);
+            binding.filePath.setText(null);
+            binding.fileSize.setText(null);
+            binding.status.setText(null);
+            binding.speed.setText(null);
+            binding.actionGenerate.setVisibility(View.VISIBLE);
+            binding.actionSelectFile.setVisibility(View.VISIBLE);
+            binding.actionUpload.setVisibility(View.VISIBLE);
+            binding.actionUpload.setEnabled(false);
+            binding.actionCancel.setVisibility(View.GONE);
+            binding.actionPauseResume.setVisibility(View.GONE);
         });
-        mViewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> {
-            mBinding.actionGenerate.setEnabled(!busy);
-            mBinding.actionSelectFile.setEnabled(!busy);
-            mBinding.actionUpload.setEnabled(isFileLoaded() && !busy);
+        viewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> {
+            binding.actionGenerate.setEnabled(!busy);
+            binding.actionSelectFile.setEnabled(!busy);
+            binding.actionUpload.setEnabled(isFileLoaded() && !busy);
         });
 
         // Configure GENERATE FILE action
-        mBinding.actionGenerate.setOnClickListener(v -> {
+        binding.actionGenerate.setOnClickListener(v -> {
             final DialogFragment dialog = GenerateFileDialogFragment.getInstance();
             dialog.show(getChildFragmentManager(), null);
         });
 
         // Configure SELECT FILE action
-        mBinding.actionSelectFile.setOnClickListener(v -> selectFile("*/*"));
+        binding.actionSelectFile.setOnClickListener(v -> selectFile("*/*"));
 
         // Restore UPLOAD action state after rotation
-        mBinding.actionUpload.setEnabled(isFileLoaded());
-        mBinding.actionUpload.setOnClickListener(v -> {
-            final String fileName = mBinding.fileName.getText().toString();
-            mFsUtils.addRecent(fileName);
-            final String filePath = mBinding.filePath.getText().toString();
-            mViewModel.upload(filePath, getFileContent());
+        binding.actionUpload.setEnabled(isFileLoaded());
+        binding.actionUpload.setOnClickListener(v -> {
+            final String fileName = binding.fileName.getText().toString();
+            fsUtils.addRecent(fileName);
+            final String filePath = binding.filePath.getText().toString();
+            viewModel.upload(filePath, getFileContent());
         });
 
         // Cancel and Pause/Resume buttons
-        mBinding.actionCancel.setOnClickListener(v -> mViewModel.cancel());
-        mBinding.actionPauseResume.setOnClickListener(v -> {
-            if (mViewModel.getState().getValue() == FilesUploadViewModel.State.UPLOADING) {
-                mViewModel.pause();
+        binding.actionCancel.setOnClickListener(v -> viewModel.cancel());
+        binding.actionPauseResume.setOnClickListener(v -> {
+            if (viewModel.getState().getValue() == FilesUploadViewModel.State.UPLOADING) {
+                viewModel.pause();
             } else {
-                mViewModel.resume();
+                viewModel.resume();
             }
         });
     }
@@ -163,7 +163,7 @@ public class FilesUploadFragment extends FileBrowserFragment implements Injectab
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        mBinding = null;
+        binding = null;
     }
 
     public void onGenerateFileRequested(final int fileSize) {
@@ -173,33 +173,33 @@ public class FilesUploadFragment extends FileBrowserFragment implements Injectab
 
     @Override
     protected void onFileCleared() {
-        mBinding.actionUpload.setEnabled(false);
+        binding.actionUpload.setEnabled(false);
     }
 
     @Override
     protected void onFileSelected(@NonNull final String fileName, final int fileSize) {
-        final String partition = mFsUtils.getPartitionString();
-        mBinding.fileName.setText(fileName);
-        mBinding.filePath.setText(getString(R.string.files_file_path, partition, fileName));
-        mBinding.fileSize.setText(getString(R.string.files_upload_size_value, fileSize));
+        final String partition = fsUtils.getPartitionString();
+        binding.fileName.setText(fileName);
+        binding.filePath.setText(getString(R.string.files_file_path, partition, fileName));
+        binding.fileSize.setText(getString(R.string.files_upload_size_value, fileSize));
     }
 
     @Override
     protected void onFileLoaded(@NonNull final byte[] data) {
-        mBinding.actionUpload.setEnabled(true);
-        mBinding.status.setText(R.string.files_upload_status_ready);
+        binding.actionUpload.setEnabled(true);
+        binding.status.setText(R.string.files_upload_status_ready);
     }
 
     @Override
     protected void onFileLoadingFailed(final int error) {
-        mBinding.status.setText(error);
+        binding.status.setText(error);
     }
 
     private void printError(@Nullable final McuMgrException error) {
         final String message = StringUtils.toString(requireContext(), error);
         if (message == null) {
-            mBinding.status.setText(null);
-            mBinding.speed.setText(null);
+            binding.status.setText(null);
+            binding.speed.setText(null);
             return;
         }
         final SpannableString spannable = new SpannableString(message);
@@ -208,7 +208,7 @@ public class FilesUploadFragment extends FileBrowserFragment implements Injectab
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
         spannable.setSpan(new StyleSpan(Typeface.BOLD),
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-        mBinding.status.setText(spannable);
-        mBinding.speed.setText(null);
+        binding.status.setText(spannable);
+        binding.speed.setText(null);
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageControlFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageControlFragment.java
@@ -49,16 +49,16 @@ public class ImageControlFragment extends Fragment implements Injectable,
     private static final int REQUEST_ERASE   = 3;
 
     @Inject
-    McuMgrViewModelFactory mViewModelFactory;
+    McuMgrViewModelFactory viewModelFactory;
     
-    private FragmentCardImageControlBinding mBinding;
+    private FragmentCardImageControlBinding binding;
 
-    private ImageControlViewModel mViewModel;
+    private ImageControlViewModel viewModel;
 
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mViewModel = new ViewModelProvider(this, mViewModelFactory)
+        viewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(ImageControlViewModel.class);
     }
 
@@ -67,10 +67,10 @@ public class ImageControlFragment extends Fragment implements Injectable,
     public View onCreateView(@NonNull final LayoutInflater inflater,
                              @Nullable final ViewGroup container,
                              @Nullable final Bundle savedInstanceState) {
-        mBinding = FragmentCardImageControlBinding.inflate(inflater, container, false);
-        mBinding.toolbar.inflateMenu(R.menu.help);
-        mBinding.toolbar.setOnMenuItemClickListener(this);
-        return  mBinding.getRoot();
+        binding = FragmentCardImageControlBinding.inflate(inflater, container, false);
+        binding.toolbar.inflateMenu(R.menu.help);
+        binding.toolbar.setOnMenuItemClickListener(this);
+        return  binding.getRoot();
     }
 
     @Override
@@ -82,35 +82,35 @@ public class ImageControlFragment extends Fragment implements Injectable,
         // The view must have android:animateLayoutChanges(true) attribute set in the XML.
         ((ViewGroup) view).getLayoutTransition().enableTransitionType(LayoutTransition.CHANGING);
 
-        mViewModel.getResponse().observe(getViewLifecycleOwner(), this::printImageSlotInfo);
-        mViewModel.getError().observe(getViewLifecycleOwner(), this::printError);
-        mViewModel.getTestOperationAvailability().observe(getViewLifecycleOwner(),
-                enabled -> mBinding.actionTest.setEnabled(enabled));
-        mViewModel.getConfirmOperationAvailability().observe(getViewLifecycleOwner(),
-                enabled -> mBinding.actionConfirm.setEnabled(enabled));
-        mViewModel.getEraseOperationAvailability().observe(getViewLifecycleOwner(),
-                enabled -> mBinding.actionErase.setEnabled(enabled));
-        mViewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> {
+        viewModel.getResponse().observe(getViewLifecycleOwner(), this::printImageSlotInfo);
+        viewModel.getError().observe(getViewLifecycleOwner(), this::printError);
+        viewModel.getTestOperationAvailability().observe(getViewLifecycleOwner(),
+                enabled -> binding.actionTest.setEnabled(enabled));
+        viewModel.getConfirmOperationAvailability().observe(getViewLifecycleOwner(),
+                enabled -> binding.actionConfirm.setEnabled(enabled));
+        viewModel.getEraseOperationAvailability().observe(getViewLifecycleOwner(),
+                enabled -> binding.actionErase.setEnabled(enabled));
+        viewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> {
             if (busy) {
-                mBinding.actionRead.setEnabled(false);
-                mBinding.actionTest.setEnabled(false);
-                mBinding.actionConfirm.setEnabled(false);
-                mBinding.actionErase.setEnabled(false);
+                binding.actionRead.setEnabled(false);
+                binding.actionTest.setEnabled(false);
+                binding.actionConfirm.setEnabled(false);
+                binding.actionErase.setEnabled(false);
             } else {
-                mBinding.actionRead.setEnabled(true);
+                binding.actionRead.setEnabled(true);
                 // Other actions will be optionally enabled by other observers
             }
         });
-        mBinding.actionRead.setOnClickListener(v -> mViewModel.read());
-        mBinding.actionTest.setOnClickListener(v -> onActionClick(REQUEST_TEST));
-        mBinding.actionConfirm.setOnClickListener(v -> onActionClick(REQUEST_CONFIRM));
-        mBinding.actionErase.setOnClickListener(v -> onActionClick(REQUEST_ERASE));
+        binding.actionRead.setOnClickListener(v -> viewModel.read());
+        binding.actionTest.setOnClickListener(v -> onActionClick(REQUEST_TEST));
+        binding.actionConfirm.setOnClickListener(v -> onActionClick(REQUEST_CONFIRM));
+        binding.actionErase.setOnClickListener(v -> onActionClick(REQUEST_ERASE));
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        mBinding = null;
+        binding = null;
     }
 
     @Override
@@ -130,19 +130,19 @@ public class ImageControlFragment extends Fragment implements Injectable,
     public void onImageSelected(final int requestId, final int image) {
         switch (requestId) {
             case REQUEST_TEST:
-                mViewModel.test(image);
+                viewModel.test(image);
                 break;
             case REQUEST_CONFIRM:
-                mViewModel.confirm(image);
+                viewModel.confirm(image);
                 break;
             case REQUEST_ERASE:
-                mViewModel.erase(image);
+                viewModel.erase(image);
                 break;
         }
     }
 
     private void onActionClick(final int requestId) {
-        final int[] images = mViewModel.getValidImages();
+        final int[] images = viewModel.getValidImages();
         if (images.length > 1) {
             final DialogFragment dialog = SelectImageDialogFragment.getInstance(requestId);
             dialog.show(getChildFragmentManager(), null);
@@ -173,10 +173,10 @@ public class ImageControlFragment extends Fragment implements Injectable,
                         slot.bootable, slot.pending, slot.confirmed,
                         slot.active, slot.permanent));
             }
-            mBinding.imageControlValue.setText(builder);
-            mBinding.imageControlError.setVisibility(View.GONE);
+            binding.imageControlValue.setText(builder);
+            binding.imageControlError.setVisibility(View.GONE);
         } else {
-            mBinding.imageControlValue.setText(null);
+            binding.imageControlValue.setText(null);
         }
     }
 
@@ -192,7 +192,7 @@ public class ImageControlFragment extends Fragment implements Injectable,
             }
         }
         if (message == null) {
-            mBinding.imageControlError.setText(null);
+            binding.imageControlError.setText(null);
             return;
         }
         final SpannableString spannable = new SpannableString(message);
@@ -201,7 +201,7 @@ public class ImageControlFragment extends Fragment implements Injectable,
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
         spannable.setSpan(new StyleSpan(Typeface.BOLD),
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-        mBinding.imageControlError.setText(spannable);
-        mBinding.imageControlError.setVisibility(View.VISIBLE);
+        binding.imageControlError.setText(spannable);
+        binding.imageControlError.setVisibility(View.VISIBLE);
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageSettingsFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageSettingsFragment.java
@@ -41,16 +41,16 @@ import io.runtime.mcumgr.sample.viewmodel.mcumgr.McuMgrViewModelFactory;
 public class ImageSettingsFragment extends Fragment implements Injectable, Toolbar.OnMenuItemClickListener {
 
     @Inject
-    McuMgrViewModelFactory mViewModelFactory;
+    McuMgrViewModelFactory viewModelFactory;
     
-    private FragmentCardImageEraseSettingsBinding mBinding;
+    private FragmentCardImageEraseSettingsBinding binding;
 
-    private ImageSettingsViewModel mViewModel;
+    private ImageSettingsViewModel viewModel;
 
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mViewModel = new ViewModelProvider(this, mViewModelFactory)
+        viewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(ImageSettingsViewModel.class);
     }
 
@@ -59,10 +59,10 @@ public class ImageSettingsFragment extends Fragment implements Injectable, Toolb
     public View onCreateView(@NonNull final LayoutInflater inflater,
                              @Nullable final ViewGroup container,
                              @Nullable final Bundle savedInstanceState) {
-        mBinding = FragmentCardImageEraseSettingsBinding.inflate(inflater, container, false);
-        mBinding.toolbar.inflateMenu(R.menu.help);
-        mBinding.toolbar.setOnMenuItemClickListener(this);
-        return  mBinding.getRoot();
+        binding = FragmentCardImageEraseSettingsBinding.inflate(inflater, container, false);
+        binding.toolbar.inflateMenu(R.menu.help);
+        binding.toolbar.setOnMenuItemClickListener(this);
+        return  binding.getRoot();
     }
 
     @Override
@@ -74,18 +74,18 @@ public class ImageSettingsFragment extends Fragment implements Injectable, Toolb
         // The view must have android:animateLayoutChanges(true) attribute set in the XML.
         ((ViewGroup) view).getLayoutTransition().enableTransitionType(LayoutTransition.CHANGING);
 
-        mViewModel.getError().observe(getViewLifecycleOwner(), this::printError);
-        mViewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> {
+        viewModel.getError().observe(getViewLifecycleOwner(), this::printError);
+        viewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> {
             // Other actions will be optionally enabled by other observers
-            mBinding.actionErase.setEnabled(!busy);
+            binding.actionErase.setEnabled(!busy);
         });
-        mBinding.actionErase.setOnClickListener(v -> mViewModel.eraseSettings());
+        binding.actionErase.setOnClickListener(v -> viewModel.eraseSettings());
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        mBinding = null;
+        binding = null;
     }
 
     @Override
@@ -113,7 +113,7 @@ public class ImageSettingsFragment extends Fragment implements Injectable, Toolb
             }
         }
         if (message == null) {
-            mBinding.imageControlError.setText(null);
+            binding.imageControlError.setText(null);
             return;
         }
         final SpannableString spannable = new SpannableString(message);
@@ -122,7 +122,7 @@ public class ImageSettingsFragment extends Fragment implements Injectable, Toolb
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
         spannable.setSpan(new StyleSpan(Typeface.BOLD),
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-        mBinding.imageControlError.setText(spannable);
-        mBinding.imageControlError.setVisibility(View.VISIBLE);
+        binding.imageControlError.setText(spannable);
+        binding.imageControlError.setVisibility(View.VISIBLE);
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
@@ -40,16 +40,16 @@ import io.runtime.mcumgr.sample.viewmodel.mcumgr.McuMgrViewModelFactory;
 public class ImageUpgradeFragment extends FileBrowserFragment implements Injectable {
 
     @Inject
-    McuMgrViewModelFactory mViewModelFactory;
+    McuMgrViewModelFactory viewModelFactory;
     
-    private FragmentCardImageUpgradeBinding mBinding;
+    private FragmentCardImageUpgradeBinding binding;
 
-    private ImageUpgradeViewModel mViewModel;
+    private ImageUpgradeViewModel viewModel;
 
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mViewModel = new ViewModelProvider(this, mViewModelFactory)
+        viewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(ImageUpgradeViewModel.class);
     }
 
@@ -58,108 +58,108 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
     public View onCreateView(@NonNull final LayoutInflater inflater,
                              @Nullable final ViewGroup container,
                              @Nullable final Bundle savedInstanceState) {
-        mBinding = FragmentCardImageUpgradeBinding.inflate(inflater, container, false);
-        return mBinding.getRoot();
+        binding = FragmentCardImageUpgradeBinding.inflate(inflater, container, false);
+        return binding.getRoot();
     }
 
     @Override
     public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        mViewModel.getState().observe(getViewLifecycleOwner(), state -> {
-            mBinding.actionStart.setEnabled(isFileLoaded());
-            mBinding.actionCancel.setEnabled(state.canCancel());
-            mBinding.actionPauseResume.setEnabled(state.canPauseOrResume());
-            mBinding.actionPauseResume.setText(state == ImageUpgradeViewModel.State.PAUSED ?
+        viewModel.getState().observe(getViewLifecycleOwner(), state -> {
+            binding.actionStart.setEnabled(isFileLoaded());
+            binding.actionCancel.setEnabled(state.canCancel());
+            binding.actionPauseResume.setEnabled(state.canPauseOrResume());
+            binding.actionPauseResume.setText(state == ImageUpgradeViewModel.State.PAUSED ?
                     R.string.image_action_resume : R.string.image_action_pause);
 
-            mBinding.actionSelectFile.setVisibility(state.inProgress() ? View.GONE : View.VISIBLE);
-            mBinding.actionStart.setVisibility(state.inProgress() ? View.GONE : View.VISIBLE);
-            mBinding.actionCancel.setVisibility(state.inProgress() ? View.VISIBLE : View.GONE);
-            mBinding.actionPauseResume.setVisibility(state.inProgress() ? View.VISIBLE : View.GONE);
+            binding.actionSelectFile.setVisibility(state.inProgress() ? View.GONE : View.VISIBLE);
+            binding.actionStart.setVisibility(state.inProgress() ? View.GONE : View.VISIBLE);
+            binding.actionCancel.setVisibility(state.inProgress() ? View.VISIBLE : View.GONE);
+            binding.actionPauseResume.setVisibility(state.inProgress() ? View.VISIBLE : View.GONE);
             // Update status
             switch (state) {
                 case VALIDATING:
-                    mBinding.status.setText(R.string.image_upgrade_status_validating);
-                    mBinding.optionEraseSettings.setEnabled(false);
+                    binding.status.setText(R.string.image_upgrade_status_validating);
+                    binding.optionEraseSettings.setEnabled(false);
                     break;
                 case UPLOADING:
-                    mBinding.status.setText(R.string.image_upgrade_status_uploading);
+                    binding.status.setText(R.string.image_upgrade_status_uploading);
                     break;
                 case PAUSED:
-                    mBinding.status.setText(R.string.image_upgrade_status_paused);
+                    binding.status.setText(R.string.image_upgrade_status_paused);
                     break;
                 case TESTING:
-                    mBinding.status.setText(R.string.image_upgrade_status_testing);
-                    mBinding.speed.setText(null);
+                    binding.status.setText(R.string.image_upgrade_status_testing);
+                    binding.speed.setText(null);
                     break;
                 case CONFIRMING:
-                    mBinding.status.setText(R.string.image_upgrade_status_confirming);
-                    mBinding.speed.setText(null);
+                    binding.status.setText(R.string.image_upgrade_status_confirming);
+                    binding.speed.setText(null);
                     break;
                 case RESETTING:
-                    mBinding.status.setText(R.string.image_upgrade_status_resetting);
-                    mBinding.speed.setText(null);
+                    binding.status.setText(R.string.image_upgrade_status_resetting);
+                    binding.speed.setText(null);
                     break;
                 case COMPLETE:
                     clearFileContent();
-                    mBinding.status.setText(R.string.image_upgrade_status_completed);
-                    mBinding.speed.setText(null);
-                    mBinding.optionEraseSettings.setEnabled(true);
+                    binding.status.setText(R.string.image_upgrade_status_completed);
+                    binding.speed.setText(null);
+                    binding.optionEraseSettings.setEnabled(true);
                     break;
             }
         });
-        mViewModel.getTransferSpeed().observe(getViewLifecycleOwner(), speed ->
-                mBinding.speed.setText(getString(R.string.image_upgrade_speed, speed))
+        viewModel.getTransferSpeed().observe(getViewLifecycleOwner(), speed ->
+                binding.speed.setText(getString(R.string.image_upgrade_speed, speed))
         );
-        mViewModel.getProgress().observe(getViewLifecycleOwner(), progress ->
-                mBinding.progress.setProgress(progress)
+        viewModel.getProgress().observe(getViewLifecycleOwner(), progress ->
+                binding.progress.setProgress(progress)
         );
-        mViewModel.getError().observe(getViewLifecycleOwner(), error -> {
-            mBinding.actionSelectFile.setVisibility(View.VISIBLE);
-            mBinding.actionStart.setVisibility(View.VISIBLE);
-            mBinding.actionCancel.setVisibility(View.GONE);
-            mBinding.actionPauseResume.setVisibility(View.GONE);
-            mBinding.optionEraseSettings.setEnabled(true);
+        viewModel.getError().observe(getViewLifecycleOwner(), error -> {
+            binding.actionSelectFile.setVisibility(View.VISIBLE);
+            binding.actionStart.setVisibility(View.VISIBLE);
+            binding.actionCancel.setVisibility(View.GONE);
+            binding.actionPauseResume.setVisibility(View.GONE);
+            binding.optionEraseSettings.setEnabled(true);
             printError(error);
         });
-        mViewModel.getCancelledEvent().observe(getViewLifecycleOwner(), nothing -> {
+        viewModel.getCancelledEvent().observe(getViewLifecycleOwner(), nothing -> {
             clearFileContent();
-            mBinding.fileName.setText(null);
-            mBinding.fileSize.setText(null);
-            mBinding.fileHash.setText(null);
-            mBinding.status.setText(null);
-            mBinding.speed.setText(null);
-            mBinding.actionSelectFile.setVisibility(View.VISIBLE);
-            mBinding.actionStart.setVisibility(View.VISIBLE);
-            mBinding.actionStart.setEnabled(false);
-            mBinding.actionCancel.setVisibility(View.GONE);
-            mBinding.actionPauseResume.setVisibility(View.GONE);
-            mBinding.optionEraseSettings.setEnabled(true);
+            binding.fileName.setText(null);
+            binding.fileSize.setText(null);
+            binding.fileHash.setText(null);
+            binding.status.setText(null);
+            binding.speed.setText(null);
+            binding.actionSelectFile.setVisibility(View.VISIBLE);
+            binding.actionStart.setVisibility(View.VISIBLE);
+            binding.actionStart.setEnabled(false);
+            binding.actionCancel.setVisibility(View.GONE);
+            binding.actionPauseResume.setVisibility(View.GONE);
+            binding.optionEraseSettings.setEnabled(true);
         });
-        mViewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> {
-            mBinding.actionSelectFile.setEnabled(!busy);
-            mBinding.actionStart.setEnabled(isFileLoaded() && !busy);
+        viewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> {
+            binding.actionSelectFile.setEnabled(!busy);
+            binding.actionStart.setEnabled(isFileLoaded() && !busy);
         });
 
         // Configure SELECT FILE action
-        mBinding.actionSelectFile.setOnClickListener(v -> selectFile("application/*"));
+        binding.actionSelectFile.setOnClickListener(v -> selectFile("application/*"));
 
         // Restore START action state after rotation
-        mBinding.actionStart.setEnabled(isFileLoaded());
-        mBinding.actionStart.setOnClickListener(v -> {
+        binding.actionStart.setEnabled(isFileLoaded());
+        binding.actionStart.setOnClickListener(v -> {
             // Show a mode picker. When mode is selected, the upgrade(Mode) method will be called.
             final DialogFragment dialog = FirmwareUpgradeModeDialogFragment.getInstance();
             dialog.show(getChildFragmentManager(), null);
         });
 
         // Cancel and Pause/Resume buttons
-        mBinding.actionCancel.setOnClickListener(v -> mViewModel.cancel());
-        mBinding.actionPauseResume.setOnClickListener(v -> {
-            if (mViewModel.getState().getValue() == ImageUpgradeViewModel.State.UPLOADING) {
-                mViewModel.pause();
+        binding.actionCancel.setOnClickListener(v -> viewModel.cancel());
+        binding.actionPauseResume.setOnClickListener(v -> {
+            if (viewModel.getState().getValue() == ImageUpgradeViewModel.State.UPLOADING) {
+                viewModel.pause();
             } else {
-                mViewModel.resume();
+                viewModel.resume();
             }
         });
     }
@@ -167,7 +167,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        mBinding = null;
+        binding = null;
     }
 
     /**
@@ -175,18 +175,18 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
      */
     @SuppressWarnings("ConstantConditions")
     public void start(@NonNull final FirmwareUpgradeManager.Mode mode) {
-        mViewModel.upgrade(getFileContent(), mode, mBinding.optionEraseSettings.isChecked());
+        viewModel.upgrade(getFileContent(), mode, binding.optionEraseSettings.isChecked());
     }
 
     @Override
     protected void onFileCleared() {
-        mBinding.actionStart.setEnabled(false);
+        binding.actionStart.setEnabled(false);
     }
 
     @Override
     protected void onFileSelected(@NonNull final String fileName, final int fileSize) {
-        mBinding.fileName.setText(fileName);
-        mBinding.fileSize.setText(getString(R.string.image_upgrade_size_value, fileSize));
+        binding.fileName.setText(fileName);
+        binding.fileSize.setText(getString(R.string.image_upgrade_size_value, fileSize));
     }
 
     @Override
@@ -194,9 +194,9 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
         try {
             // Try parsing BIN file for single/main core (core0) update.
             final byte[] hash = McuMgrImage.getHash(data);
-            mBinding.fileHash.setText(StringUtils.toHex(hash));
-            mBinding.actionStart.setEnabled(true);
-            mBinding.status.setText(R.string.image_upgrade_status_ready);
+            binding.fileHash.setText(StringUtils.toHex(hash));
+            binding.actionStart.setEnabled(true);
+            binding.status.setText(R.string.image_upgrade_status_ready);
         } catch (final McuMgrException e) {
             // For multi-core devices images are bundled in a ZIP file.
             try {
@@ -227,10 +227,10 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
                 }
                 hashBuilder.setLength(hashBuilder.length() - 1);
                 sizeBuilder.setLength(sizeBuilder.length() - 1);
-                mBinding.fileHash.setText(hashBuilder.toString());
-                mBinding.fileSize.setText(sizeBuilder.toString());
-                mBinding.actionStart.setEnabled(true);
-                mBinding.status.setText(R.string.image_upgrade_status_ready);
+                binding.fileHash.setText(hashBuilder.toString());
+                binding.fileSize.setText(sizeBuilder.toString());
+                binding.actionStart.setEnabled(true);
+                binding.status.setText(R.string.image_upgrade_status_ready);
             } catch (final Exception e1) {
                 clearFileContent();
                 onFileLoadingFailed(R.string.image_error_file_not_valid);
@@ -240,14 +240,14 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
 
     @Override
     protected void onFileLoadingFailed(final int error) {
-        mBinding.status.setText(error);
+        binding.status.setText(error);
     }
 
     private void printError(@Nullable final McuMgrException error) {
         final String message = StringUtils.toString(requireContext(), error);
         if (message == null) {
-            mBinding.status.setText(null);
-            mBinding.speed.setText(null);
+            binding.status.setText(null);
+            binding.speed.setText(null);
             return;
         }
         final SpannableString spannable = new SpannableString(message);
@@ -256,7 +256,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
         spannable.setSpan(new StyleSpan(Typeface.BOLD),
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-        mBinding.status.setText(spannable);
-        mBinding.speed.setText(null);
+        binding.status.setText(spannable);
+        binding.speed.setText(null);
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUploadFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUploadFragment.java
@@ -42,16 +42,16 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
     private static final int REQUEST_UPLOAD = 0;
 
     @Inject
-    McuMgrViewModelFactory mViewModelFactory;
+    McuMgrViewModelFactory viewModelFactory;
 
-    private FragmentCardImageUploadBinding mBinding;
+    private FragmentCardImageUploadBinding binding;
 
-    private ImageUploadViewModel mViewModel;
+    private ImageUploadViewModel viewModel;
 
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mViewModel = new ViewModelProvider(this, mViewModelFactory)
+        viewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(ImageUploadViewModel.class);
     }
 
@@ -60,93 +60,93 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
     public View onCreateView(@NonNull final LayoutInflater inflater,
                              @Nullable final ViewGroup container,
                              @Nullable final Bundle savedInstanceState) {
-        mBinding = FragmentCardImageUploadBinding.inflate(inflater, container, false);
-        mBinding.toolbar.inflateMenu(R.menu.help);
-        mBinding.toolbar.setOnMenuItemClickListener(this);
-        return mBinding.getRoot();
+        binding = FragmentCardImageUploadBinding.inflate(inflater, container, false);
+        binding.toolbar.inflateMenu(R.menu.help);
+        binding.toolbar.setOnMenuItemClickListener(this);
+        return binding.getRoot();
     }
 
     @Override
     public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        mViewModel.getState().observe(getViewLifecycleOwner(), state -> {
-            mBinding.actionUpload.setEnabled(isFileLoaded());
-            mBinding.actionCancel.setEnabled(state.canCancel());
-            mBinding.actionPauseResume.setEnabled(state.canPauseOrResume());
-            mBinding.actionPauseResume.setText(state == ImageUploadViewModel.State.PAUSED ?
+        viewModel.getState().observe(getViewLifecycleOwner(), state -> {
+            binding.actionUpload.setEnabled(isFileLoaded());
+            binding.actionCancel.setEnabled(state.canCancel());
+            binding.actionPauseResume.setEnabled(state.canPauseOrResume());
+            binding.actionPauseResume.setText(state == ImageUploadViewModel.State.PAUSED ?
                     R.string.image_action_resume : R.string.image_action_pause);
 
-            mBinding.actionSelectFile.setVisibility(state.inProgress() ? View.GONE : View.VISIBLE);
-            mBinding.actionUpload.setVisibility(state.inProgress() ? View.GONE : View.VISIBLE);
-            mBinding.actionCancel.setVisibility(state.inProgress() ? View.VISIBLE : View.GONE);
-            mBinding.actionPauseResume.setVisibility(state.inProgress() ? View.VISIBLE : View.GONE);
+            binding.actionSelectFile.setVisibility(state.inProgress() ? View.GONE : View.VISIBLE);
+            binding.actionUpload.setVisibility(state.inProgress() ? View.GONE : View.VISIBLE);
+            binding.actionCancel.setVisibility(state.inProgress() ? View.VISIBLE : View.GONE);
+            binding.actionPauseResume.setVisibility(state.inProgress() ? View.VISIBLE : View.GONE);
             // Update status
             switch (state) {
                 case VALIDATING:
-                    mBinding.status.setText(R.string.image_upload_status_validating);
+                    binding.status.setText(R.string.image_upload_status_validating);
                     break;
                 case UPLOADING:
-                    mBinding.status.setText(R.string.image_upload_status_uploading);
+                    binding.status.setText(R.string.image_upload_status_uploading);
                     break;
                 case PAUSED:
-                    mBinding.status.setText(R.string.image_upload_status_paused);
+                    binding.status.setText(R.string.image_upload_status_paused);
                     break;
                 case COMPLETE:
                     clearFileContent();
-                    mBinding.status.setText(R.string.image_upload_status_completed);
-                    mBinding.speed.setText(null);
+                    binding.status.setText(R.string.image_upload_status_completed);
+                    binding.speed.setText(null);
                     break;
             }
         });
-        mViewModel.getTransferSpeed().observe(getViewLifecycleOwner(), speed ->
-                mBinding.speed.setText(getString(R.string.image_upload_speed, speed))
+        viewModel.getTransferSpeed().observe(getViewLifecycleOwner(), speed ->
+                binding.speed.setText(getString(R.string.image_upload_speed, speed))
         );
-        mViewModel.getProgress().observe(getViewLifecycleOwner(), progress ->
-                mBinding.progress.setProgress(progress)
+        viewModel.getProgress().observe(getViewLifecycleOwner(), progress ->
+                binding.progress.setProgress(progress)
         );
-        mViewModel.getError().observe(getViewLifecycleOwner(), error -> {
-            mBinding.actionSelectFile.setVisibility(View.VISIBLE);
-            mBinding.actionUpload.setVisibility(View.VISIBLE);
-            mBinding.actionCancel.setVisibility(View.GONE);
-            mBinding.actionPauseResume.setVisibility(View.GONE);
+        viewModel.getError().observe(getViewLifecycleOwner(), error -> {
+            binding.actionSelectFile.setVisibility(View.VISIBLE);
+            binding.actionUpload.setVisibility(View.VISIBLE);
+            binding.actionCancel.setVisibility(View.GONE);
+            binding.actionPauseResume.setVisibility(View.GONE);
             printError(error);
         });
-        mViewModel.getCancelledEvent().observe(getViewLifecycleOwner(), nothing -> {
+        viewModel.getCancelledEvent().observe(getViewLifecycleOwner(), nothing -> {
             clearFileContent();
-            mBinding.fileName.setText(null);
-            mBinding.fileSize.setText(null);
-            mBinding.fileHash.setText(null);
-            mBinding.status.setText(null);
-            mBinding.speed.setText(null);
-            mBinding.actionSelectFile.setVisibility(View.VISIBLE);
-            mBinding.actionUpload.setVisibility(View.VISIBLE);
-            mBinding.actionUpload.setEnabled(false);
-            mBinding.actionCancel.setVisibility(View.GONE);
-            mBinding.actionPauseResume.setVisibility(View.GONE);
+            binding.fileName.setText(null);
+            binding.fileSize.setText(null);
+            binding.fileHash.setText(null);
+            binding.status.setText(null);
+            binding.speed.setText(null);
+            binding.actionSelectFile.setVisibility(View.VISIBLE);
+            binding.actionUpload.setVisibility(View.VISIBLE);
+            binding.actionUpload.setEnabled(false);
+            binding.actionCancel.setVisibility(View.GONE);
+            binding.actionPauseResume.setVisibility(View.GONE);
         });
-        mViewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> {
-            mBinding.actionSelectFile.setEnabled(!busy);
-            mBinding.actionUpload.setEnabled(isFileLoaded() && !busy);
+        viewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> {
+            binding.actionSelectFile.setEnabled(!busy);
+            binding.actionUpload.setEnabled(isFileLoaded() && !busy);
         });
 
         // Configure SELECT FILE action
-        mBinding.actionSelectFile.setOnClickListener(v -> selectFile("application/*"));
+        binding.actionSelectFile.setOnClickListener(v -> selectFile("application/*"));
 
         // Restore UPLOAD action state after rotation
-        mBinding.actionUpload.setEnabled(isFileLoaded());
-        mBinding.actionUpload.setOnClickListener(v -> {
+        binding.actionUpload.setEnabled(isFileLoaded());
+        binding.actionUpload.setOnClickListener(v -> {
             final DialogFragment dialog = SelectImageDialogFragment.getInstance(REQUEST_UPLOAD);
             dialog.show(getChildFragmentManager(), null);
         });
 
         // Cancel and Pause/Resume buttons
-        mBinding.actionCancel.setOnClickListener(v -> mViewModel.cancel());
-        mBinding.actionPauseResume.setOnClickListener(v -> {
-            if (mViewModel.getState().getValue() == ImageUploadViewModel.State.UPLOADING) {
-                mViewModel.pause();
+        binding.actionCancel.setOnClickListener(v -> viewModel.cancel());
+        binding.actionPauseResume.setOnClickListener(v -> {
+            if (viewModel.getState().getValue() == ImageUploadViewModel.State.UPLOADING) {
+                viewModel.pause();
             } else {
-                mViewModel.resume();
+                viewModel.resume();
             }
         });
     }
@@ -154,7 +154,7 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        mBinding = null;
+        binding = null;
     }
 
     @Override
@@ -172,22 +172,22 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
 
     @Override
     protected void onFileCleared() {
-        mBinding.actionUpload.setEnabled(false);
+        binding.actionUpload.setEnabled(false);
     }
 
     @Override
     protected void onFileSelected(@NonNull final String fileName, final int fileSize) {
-        mBinding.fileName.setText(fileName);
-        mBinding.fileSize.setText(getString(R.string.image_upgrade_size_value, fileSize));
+        binding.fileName.setText(fileName);
+        binding.fileSize.setText(getString(R.string.image_upgrade_size_value, fileSize));
     }
 
     @Override
     protected void onFileLoaded(@NonNull final byte[] data) {
         try {
             final byte[] hash = McuMgrImage.getHash(data);
-            mBinding.fileHash.setText(StringUtils.toHex(hash));
-            mBinding.actionUpload.setEnabled(true);
-            mBinding.status.setText(R.string.image_upgrade_status_ready);
+            binding.fileHash.setText(StringUtils.toHex(hash));
+            binding.actionUpload.setEnabled(true);
+            binding.status.setText(R.string.image_upgrade_status_ready);
         } catch (final McuMgrException e) {
             clearFileContent();
             onFileLoadingFailed(R.string.image_error_file_not_valid);
@@ -196,19 +196,19 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
 
     @Override
     protected void onFileLoadingFailed(final int error) {
-        mBinding.status.setText(error);
+        binding.status.setText(error);
     }
 
     @Override
     public void onImageSelected(final int requestId, final int image) {
-        mViewModel.upload(getFileContent(), image);
+        viewModel.upload(getFileContent(), image);
     }
 
     private void printError(@Nullable final McuMgrException error) {
         final String message = StringUtils.toString(requireContext(), error);
         if (message == null) {
-            mBinding.status.setText(null);
-            mBinding.speed.setText(null);
+            binding.status.setText(null);
+            binding.speed.setText(null);
             return;
         }
         final SpannableString spannable = new SpannableString(message);
@@ -217,7 +217,7 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
         spannable.setSpan(new StyleSpan(Typeface.BOLD),
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-        mBinding.status.setText(spannable);
-        mBinding.speed.setText(null);
+        binding.status.setText(spannable);
+        binding.speed.setText(null);
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ResetFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ResetFragment.java
@@ -26,16 +26,16 @@ import io.runtime.mcumgr.sample.viewmodel.mcumgr.ResetViewModel;
 public class ResetFragment extends Fragment implements Injectable {
 
     @Inject
-    McuMgrViewModelFactory mViewModelFactory;
+    McuMgrViewModelFactory viewModelFactory;
     
-    private FragmentCardResetBinding mBinding;
+    private FragmentCardResetBinding binding;
 
-    private ResetViewModel mViewModel;
+    private ResetViewModel viewModel;
 
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mViewModel = new ViewModelProvider(this, mViewModelFactory)
+        viewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(ResetViewModel.class);
     }
 
@@ -44,22 +44,22 @@ public class ResetFragment extends Fragment implements Injectable {
     public View onCreateView(@NonNull final LayoutInflater inflater,
                              @Nullable final ViewGroup container,
                              @Nullable final Bundle savedInstanceState) {
-        mBinding = FragmentCardResetBinding.inflate(inflater, container, false);
-        return mBinding.getRoot();
+        binding = FragmentCardResetBinding.inflate(inflater, container, false);
+        return binding.getRoot();
     }
 
     @Override
     public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        mViewModel.getError().observe(getViewLifecycleOwner(), s -> mBinding.resetError.setText(s));
-        mViewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> mBinding.actionReset.setEnabled(!busy));
-        mBinding.actionReset.setOnClickListener(v -> mViewModel.reset());
+        viewModel.getError().observe(getViewLifecycleOwner(), s -> binding.resetError.setText(s));
+        viewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> binding.actionReset.setEnabled(!busy));
+        binding.actionReset.setOnClickListener(v -> viewModel.reset());
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        mBinding = null;
+        binding = null;
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/StatsFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/StatsFragment.java
@@ -41,16 +41,16 @@ import io.runtime.mcumgr.sample.viewmodel.mcumgr.StatsViewModel;
 public class StatsFragment extends Fragment implements Injectable {
 
     @Inject
-    McuMgrViewModelFactory mViewModelFactory;
+    McuMgrViewModelFactory viewModelFactory;
 
-    private FragmentCardStatsBinding mBinding;
+    private FragmentCardStatsBinding binding;
 
-    private StatsViewModel mViewModel;
+    private StatsViewModel viewModel;
 
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mViewModel = new ViewModelProvider(this, mViewModelFactory)
+        viewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(StatsViewModel.class);
     }
 
@@ -59,8 +59,8 @@ public class StatsFragment extends Fragment implements Injectable {
     public View onCreateView(@NonNull final LayoutInflater inflater,
                              @Nullable final ViewGroup container,
                              @Nullable final Bundle savedInstanceState) {
-        mBinding = FragmentCardStatsBinding.inflate(inflater, container, false);
-        return mBinding.getRoot();
+        binding = FragmentCardStatsBinding.inflate(inflater, container, false);
+        return binding.getRoot();
     }
 
     @Override
@@ -72,16 +72,16 @@ public class StatsFragment extends Fragment implements Injectable {
         // The view must have android:animateLayoutChanges(true) attribute set in the XML.
         ((ViewGroup) view).getLayoutTransition().enableTransitionType(LayoutTransition.CHANGING);
 
-        mViewModel.getResponse().observe(getViewLifecycleOwner(), this::printStats);
-        mViewModel.getError().observe(getViewLifecycleOwner(), this::printError);
-        mViewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> mBinding.actionRefresh.setEnabled(!busy));
-        mBinding.actionRefresh.setOnClickListener(v -> mViewModel.readStats());
+        viewModel.getResponse().observe(getViewLifecycleOwner(), this::printStats);
+        viewModel.getError().observe(getViewLifecycleOwner(), this::printError);
+        viewModel.getBusyState().observe(getViewLifecycleOwner(), busy -> binding.actionRefresh.setEnabled(!busy));
+        binding.actionRefresh.setOnClickListener(v -> viewModel.readStats());
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        mBinding = null;
+        binding = null;
     }
 
     private void printStats(@NonNull final List<McuMgrStatResponse> responses) {
@@ -97,13 +97,13 @@ public class StatsFragment extends Fragment implements Injectable {
                         entry.getKey(), entry.getValue())).append("\n");
             }
         }
-        mBinding.statsValue.setText(builder);
+        binding.statsValue.setText(builder);
     }
 
     private void printError(@Nullable final McuMgrException error) {
         final String message = StringUtils.toString(requireContext(), error);
         if (message == null) {
-            mBinding.imageControlError.setText(null);
+            binding.imageControlError.setText(null);
             return;
         }
         final SpannableString spannable = new SpannableString(message);
@@ -112,7 +112,7 @@ public class StatsFragment extends Fragment implements Injectable {
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
         spannable.setSpan(new StyleSpan(Typeface.BOLD),
                 0, message.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-        mBinding.imageControlError.setText(spannable);
-        mBinding.imageControlError.setVisibility(View.VISIBLE);
+        binding.imageControlError.setText(spannable);
+        binding.imageControlError.setVisibility(View.VISIBLE);
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/observable/ObservableMcuMgrBleTransport.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/observable/ObservableMcuMgrBleTransport.java
@@ -18,8 +18,8 @@ import io.runtime.mcumgr.ble.McuMgrBleTransport;
 import no.nordicsemi.android.ble.observer.BondingObserver;
 
 public class ObservableMcuMgrBleTransport extends McuMgrBleTransport {
-    private final MutableLiveData<ConnectionState> mConnectionState;
-    private final MutableLiveData<BondingState> mBondingState;
+    private final MutableLiveData<ConnectionState> connectionState;
+    private final MutableLiveData<BondingState> bondingState;
 
     /**
      * Construct a McuMgrBleTransport object.
@@ -33,62 +33,62 @@ public class ObservableMcuMgrBleTransport extends McuMgrBleTransport {
                                         @NonNull final Handler handler) {
         super(context, device, handler);
 
-        mConnectionState = new MutableLiveData<>(ConnectionState.of(context, device));
+        connectionState = new MutableLiveData<>(ConnectionState.of(context, device));
         setConnectionObserver(new no.nordicsemi.android.ble.observer.ConnectionObserver() {
             @Override
             public void onDeviceConnecting(@NonNull final BluetoothDevice device) {
-                mConnectionState.postValue(ConnectionState.CONNECTING);
+                connectionState.postValue(ConnectionState.CONNECTING);
             }
 
             @Override
             public void onDeviceConnected(@NonNull final BluetoothDevice device) {
-                mConnectionState.postValue(ConnectionState.INITIALIZING);
+                connectionState.postValue(ConnectionState.INITIALIZING);
             }
 
             @Override
             public void onDeviceFailedToConnect(@NonNull final BluetoothDevice device, final int reason) {
                 if (reason == no.nordicsemi.android.ble.observer.ConnectionObserver.REASON_TIMEOUT) {
-                    mConnectionState.postValue(ConnectionState.TIMEOUT);
+                    connectionState.postValue(ConnectionState.TIMEOUT);
                 } else {
-                    mConnectionState.postValue(ConnectionState.DISCONNECTED);
+                    connectionState.postValue(ConnectionState.DISCONNECTED);
                 }
             }
 
             @Override
             public void onDeviceReady(@NonNull final BluetoothDevice device) {
-                mConnectionState.postValue(ConnectionState.READY);
+                connectionState.postValue(ConnectionState.READY);
             }
 
             @Override
             public void onDeviceDisconnecting(@NonNull final BluetoothDevice device) {
-                mConnectionState.postValue(ConnectionState.DISCONNECTING);
+                connectionState.postValue(ConnectionState.DISCONNECTING);
             }
 
             @Override
             public void onDeviceDisconnected(@NonNull final BluetoothDevice device, final int reason) {
                 if (reason == no.nordicsemi.android.ble.observer.ConnectionObserver.REASON_NOT_SUPPORTED) {
-                    mConnectionState.postValue(ConnectionState.NOT_SUPPORTED);
+                    connectionState.postValue(ConnectionState.NOT_SUPPORTED);
                 } else {
-                    mConnectionState.postValue(ConnectionState.DISCONNECTED);
+                    connectionState.postValue(ConnectionState.DISCONNECTED);
                 }
             }
         });
 
-        mBondingState = new MutableLiveData<>(BondingState.of(device));
+        bondingState = new MutableLiveData<>(BondingState.of(device));
         setBondingObserver(new BondingObserver() {
             @Override
             public void onBondingRequired(@NonNull final BluetoothDevice device) {
-                mBondingState.postValue(BondingState.BONDING);
+                bondingState.postValue(BondingState.BONDING);
             }
 
             @Override
             public void onBonded(@NonNull final BluetoothDevice device) {
-                mBondingState.postValue(BondingState.BONDED);
+                bondingState.postValue(BondingState.BONDED);
             }
 
             @Override
             public void onBondingFailed(@NonNull final BluetoothDevice device) {
-                mBondingState.postValue(BondingState.NOT_BONDED);
+                bondingState.postValue(BondingState.NOT_BONDED);
             }
         });
         setLoggingEnabled(true);
@@ -96,11 +96,11 @@ public class ObservableMcuMgrBleTransport extends McuMgrBleTransport {
 
     @Nullable
     public LiveData<ConnectionState> getState() {
-        return mConnectionState;
+        return connectionState;
     }
 
     @Nullable
     public LiveData<BondingState> getBondingState() {
-        return mBondingState;
+        return bondingState;
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/utils/FsUtils.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/utils/FsUtils.java
@@ -24,15 +24,15 @@ public class FsUtils {
     private static final String PREFS_PARTITION = "partition";
     private static final String PARTITION_DEFAULT = "lfs";
 
-    private final SharedPreferences mPreferences;
-    private final MutableLiveData<String> mPartitionLiveData = new MutableLiveData<>();
-    private final Set<String> mRecents;
+    private final SharedPreferences preferences;
+    private final MutableLiveData<String> partitionLiveData = new MutableLiveData<>();
+    private final Set<String> recents;
 
     public FsUtils(@NonNull final SharedPreferences preferences) {
-        mPreferences = preferences;
-        mPartitionLiveData.setValue(getPartitionString());
+        this.preferences = preferences;
+        this.partitionLiveData.setValue(getPartitionString());
 
-        mRecents = preferences.getStringSet(PREFS_RECENTS, new ArraySet<>());
+        this. recents = preferences.getStringSet(PREFS_RECENTS, new ArraySet<>());
     }
 
     /**
@@ -42,7 +42,7 @@ public class FsUtils {
      */
     @NonNull
     public LiveData<String> getPartition() {
-        return mPartitionLiveData;
+        return partitionLiveData;
     }
 
     /**
@@ -62,7 +62,7 @@ public class FsUtils {
      */
     @NonNull
     public String getPartitionString() {
-        return mPreferences.getString(PREFS_PARTITION, PARTITION_DEFAULT);
+        return preferences.getString(PREFS_PARTITION, PARTITION_DEFAULT);
     }
 
     /**
@@ -71,8 +71,8 @@ public class FsUtils {
      * @param partition The new partition name.
      */
     public void setPartition(@NonNull final String partition) {
-        mPreferences.edit().putString(PREFS_PARTITION, partition).apply();
-        mPartitionLiveData.postValue(partition);
+        preferences.edit().putString(PREFS_PARTITION, partition).apply();
+        partitionLiveData.postValue(partition);
     }
 
     /**
@@ -81,8 +81,8 @@ public class FsUtils {
      * @param fileName the file name.
      */
     public void addRecent(@NonNull final String fileName) {
-        mRecents.add(fileName);
-        mPreferences.edit().putStringSet(PREFS_RECENTS, mRecents).apply();
+        recents.add(fileName);
+        preferences.edit().putStringSet(PREFS_RECENTS, recents).apply();
     }
 
     /**
@@ -91,7 +91,7 @@ public class FsUtils {
      * @return A set of file names added using {@link #addRecent(String)}.
      */
     public Set<String> getRecents() {
-        return mRecents;
+        return recents;
     }
 
     /**

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/MainViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/MainViewModel.java
@@ -12,9 +12,9 @@ import io.runtime.mcumgr.McuMgrTransport;
 
 public class MainViewModel extends AndroidViewModel {
     @Inject
-    McuMgrTransport mMcuMgrTransport;
+    McuMgrTransport mcuMgrTransport;
     @Inject
-    HandlerThread mHandlerThread;
+    HandlerThread handlerThread;
 
     @Inject
     public MainViewModel(@NonNull final Application application) {
@@ -25,7 +25,7 @@ public class MainViewModel extends AndroidViewModel {
     protected void onCleared() {
         super.onCleared();
 
-        mMcuMgrTransport.release();
-        mHandlerThread.quitSafely();
+        mcuMgrTransport.release();
+        handlerThread.quitSafely();
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/ScannerStateLiveData.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/ScannerStateLiveData.java
@@ -13,15 +13,15 @@ import androidx.lifecycle.LiveData;
  */
 @SuppressWarnings("unused")
 public class ScannerStateLiveData extends LiveData<ScannerStateLiveData> {
-    private boolean mScanningStarted;
-    private boolean mHasRecords;
-    private boolean mBluetoothEnabled;
-    private boolean mLocationEnabled;
+    private boolean scanningStarted;
+    private boolean hasRecords;
+    private boolean bluetoothEnabled;
+    private boolean locationEnabled;
 
     /* package */ ScannerStateLiveData(final boolean bluetoothEnabled, final boolean locationEnabled) {
-        mScanningStarted = false;
-        mBluetoothEnabled = bluetoothEnabled;
-        mLocationEnabled = locationEnabled;
+        this.scanningStarted = false;
+        this.bluetoothEnabled = bluetoothEnabled;
+        this.locationEnabled = locationEnabled;
     }
 
     /* package */ void refresh() {
@@ -29,29 +29,29 @@ public class ScannerStateLiveData extends LiveData<ScannerStateLiveData> {
     }
 
     /* package */ void scanningStarted() {
-        mScanningStarted = true;
+        scanningStarted = true;
         postValue(this);
     }
 
     /* package */ void scanningStopped() {
-        mScanningStarted = false;
+        scanningStarted = false;
         postValue(this);
     }
 
     /* package */ void bluetoothEnabled() {
-        mBluetoothEnabled = true;
+        bluetoothEnabled = true;
         postValue(this);
     }
 
     /* package */
     synchronized void bluetoothDisabled() {
-        mBluetoothEnabled = false;
-        mHasRecords = false;
+        bluetoothEnabled = false;
+        hasRecords = false;
         postValue(this);
     }
 
     /* package */ void setLocationEnabled(final boolean enabled) {
-        mLocationEnabled = enabled;
+        locationEnabled = enabled;
         postValue(this);
     }
 
@@ -59,8 +59,8 @@ public class ScannerStateLiveData extends LiveData<ScannerStateLiveData> {
      * Notifies observers that a record has been found.
      */
     /* package */ void recordFound() {
-        if (!mHasRecords) {
-            mHasRecords = true;
+        if (!hasRecords) {
+            hasRecords = true;
             postValue(this);
         }
     }
@@ -69,8 +69,8 @@ public class ScannerStateLiveData extends LiveData<ScannerStateLiveData> {
      * Notifies observers that scanner has no records to show.
      */
     /* package */ void clearRecords() {
-        if (mHasRecords) {
-            mHasRecords = false;
+        if (hasRecords) {
+            hasRecords = false;
             postValue(this);
         }
     }
@@ -79,27 +79,27 @@ public class ScannerStateLiveData extends LiveData<ScannerStateLiveData> {
      * Returns whether scanning is in progress.
      */
     public boolean isScanning() {
-        return mScanningStarted;
+        return scanningStarted;
     }
 
     /**
      * Returns whether any records matching filter criteria has been found.
      */
     public boolean hasRecords() {
-        return mHasRecords;
+        return hasRecords;
     }
 
     /**
      * Returns whether Bluetooth adapter is enabled.
      */
     public boolean isBluetoothEnabled() {
-        return mBluetoothEnabled;
+        return bluetoothEnabled;
     }
 
     /**
      * Returns whether Location is enabled.
      */
     public boolean isLocationEnabled() {
-        return mLocationEnabled;
+        return locationEnabled;
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/SingleLiveEvent.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/SingleLiveEvent.java
@@ -29,7 +29,7 @@ import timber.log.Timber;
 @SuppressWarnings("unused")
 public class SingleLiveEvent<T> extends MutableLiveData<T> {
 
-    private final AtomicBoolean mPending = new AtomicBoolean(false);
+    private final AtomicBoolean pending = new AtomicBoolean(false);
 
     @MainThread
     public void observe(@NonNull final LifecycleOwner owner, @NonNull final Observer<? super T> observer) {
@@ -40,7 +40,7 @@ public class SingleLiveEvent<T> extends MutableLiveData<T> {
 
         // Observe the internal MutableLiveData
         super.observe(owner, t -> {
-            if (mPending.compareAndSet(true, false)) {
+            if (pending.compareAndSet(true, false)) {
                 observer.onChanged(t);
             }
         });
@@ -48,7 +48,7 @@ public class SingleLiveEvent<T> extends MutableLiveData<T> {
 
     @MainThread
     public void setValue(@Nullable final T t) {
-        mPending.set(true);
+        pending.set(true);
         super.setValue(t);
     }
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/DeviceStatusViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/DeviceStatusViewModel.java
@@ -18,8 +18,8 @@ import io.runtime.mcumgr.sample.observable.ConnectionState;
 import io.runtime.mcumgr.sample.observable.ObservableMcuMgrBleTransport;
 
 public class DeviceStatusViewModel extends McuMgrViewModel {
-    private final LiveData<ConnectionState> mConnectionStateLiveData;
-    private final LiveData<BondingState> mBondStateLiveData;
+    private final LiveData<ConnectionState> connectionStateLiveData;
+    private final LiveData<BondingState> bondStateLiveData;
 
     @Inject
     DeviceStatusViewModel(final McuMgrTransport transport,
@@ -27,32 +27,32 @@ public class DeviceStatusViewModel extends McuMgrViewModel {
         super(state);
 
         if (transport instanceof ObservableMcuMgrBleTransport) {
-            mConnectionStateLiveData = ((ObservableMcuMgrBleTransport) transport).getState();
-            mBondStateLiveData = ((ObservableMcuMgrBleTransport) transport).getBondingState();
+            connectionStateLiveData = ((ObservableMcuMgrBleTransport) transport).getState();
+            bondStateLiveData = ((ObservableMcuMgrBleTransport) transport).getBondingState();
         } else {
-            final MutableLiveData<ConnectionState> connectionStateLiveData = new MutableLiveData<>();
+            final MutableLiveData<ConnectionState> liveData = new MutableLiveData<>();
             transport.addObserver(new McuMgrTransport.ConnectionObserver() {
                 @Override
                 public void onConnected() {
-                    connectionStateLiveData.postValue(ConnectionState.READY);
+                    liveData.postValue(ConnectionState.READY);
                 }
 
                 @Override
                 public void onDisconnected() {
-                    connectionStateLiveData.postValue(ConnectionState.DISCONNECTED);
+                    liveData.postValue(ConnectionState.DISCONNECTED);
                 }
             });
-            mConnectionStateLiveData = connectionStateLiveData;
-            mBondStateLiveData = new MutableLiveData<>(BondingState.NOT_BONDED);
+            connectionStateLiveData = liveData;
+            bondStateLiveData = new MutableLiveData<>(BondingState.NOT_BONDED);
         }
     }
 
     public LiveData<ConnectionState> getConnectionState() {
-        return mConnectionStateLiveData;
+        return connectionStateLiveData;
     }
 
     public LiveData<BondingState> getBondState() {
-        return mBondStateLiveData;
+        return bondStateLiveData;
     }
 
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/EchoViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/EchoViewModel.java
@@ -18,47 +18,47 @@ import io.runtime.mcumgr.managers.DefaultManager;
 import io.runtime.mcumgr.response.dflt.McuMgrEchoResponse;
 
 public class EchoViewModel extends McuMgrViewModel {
-    private final DefaultManager mManager;
+    private final DefaultManager manager;
 
-    private final MutableLiveData<String> mRequestLiveData = new MutableLiveData<>();
-    private final MutableLiveData<String> mResponseLiveData = new MutableLiveData<>();
-    private final MutableLiveData<McuMgrException> mErrorLiveData = new MutableLiveData<>();
+    private final MutableLiveData<String> requestLiveData = new MutableLiveData<>();
+    private final MutableLiveData<String> responseLiveData = new MutableLiveData<>();
+    private final MutableLiveData<McuMgrException> errorLiveData = new MutableLiveData<>();
 
     @Inject
     EchoViewModel(final DefaultManager manager,
                   @Named("busy") final MutableLiveData<Boolean> state) {
         super(state);
-        mManager = manager;
+        this.manager = manager;
     }
 
     @NonNull
     public LiveData<String> getRequest() {
-        return mRequestLiveData;
+        return requestLiveData;
     }
 
     @NonNull
     public LiveData<String> getResponse() {
-        return mResponseLiveData;
+        return responseLiveData;
     }
 
     @NonNull
     public LiveData<McuMgrException> getError() {
-        return mErrorLiveData;
+        return errorLiveData;
     }
 
     public void echo(final String echo) {
         setBusy();
-        mRequestLiveData.postValue(echo);
-        mManager.echo(echo, new McuMgrCallback<McuMgrEchoResponse>() {
+        requestLiveData.postValue(echo);
+        manager.echo(echo, new McuMgrCallback<McuMgrEchoResponse>() {
             @Override
             public void onResponse(@NonNull final McuMgrEchoResponse response) {
-                mResponseLiveData.postValue(response.r);
+                responseLiveData.postValue(response.r);
                 postReady();
             }
 
             @Override
             public void onError(@NonNull final McuMgrException error) {
-                mErrorLiveData.postValue(error);
+                errorLiveData.postValue(error);
                 postReady();
             }
         });

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/FilesDownloadViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/FilesDownloadViewModel.java
@@ -23,55 +23,55 @@ import no.nordicsemi.android.ble.ConnectionPriorityRequest;
 
 @SuppressWarnings("unused")
 public class FilesDownloadViewModel extends McuMgrViewModel implements DownloadCallback {
-    private final FsManager mManager;
-    private TransferController mController;
+    private final FsManager manager;
+    private TransferController controller;
 
-    private final MutableLiveData<Integer> mProgressLiveData = new MutableLiveData<>();
-    private final MutableLiveData<byte[]> mResponseLiveData = new MutableLiveData<>();
-    private final MutableLiveData<McuMgrException> mErrorLiveData = new MutableLiveData<>();
-    private final SingleLiveEvent<Void> mCancelledEvent = new SingleLiveEvent<>();
+    private final MutableLiveData<Integer> progressLiveData = new MutableLiveData<>();
+    private final MutableLiveData<byte[]> responseLiveData = new MutableLiveData<>();
+    private final MutableLiveData<McuMgrException> errorLiveData = new MutableLiveData<>();
+    private final SingleLiveEvent<Void> cancelledEvent = new SingleLiveEvent<>();
 
     @Inject
     FilesDownloadViewModel(final FsManager manager,
                            @Named("busy") final MutableLiveData<Boolean> state) {
         super(state);
-        mManager = manager;
+        this.manager = manager;
     }
 
     @NonNull
     public LiveData<Integer> getProgress() {
-        return mProgressLiveData;
+        return progressLiveData;
     }
 
     @NonNull
     public LiveData<byte[]> getResponse() {
-        return mResponseLiveData;
+        return responseLiveData;
     }
 
     @NonNull
     public LiveData<McuMgrException> getError() {
-        return mErrorLiveData;
+        return errorLiveData;
     }
 
     @NonNull
     public LiveData<Void> getCancelledEvent() {
-        return mCancelledEvent;
+        return cancelledEvent;
     }
 
     public void download(final String path) {
-        if (mController != null) {
+        if (controller != null) {
             return;
         }
         setBusy();
-        final McuMgrTransport transport = mManager.getTransporter();
+        final McuMgrTransport transport = manager.getTransporter();
         if (transport instanceof McuMgrBleTransport) {
             ((McuMgrBleTransport) transport).requestConnPriority(ConnectionPriorityRequest.CONNECTION_PRIORITY_HIGH);
         }
-        mController = mManager.fileDownload(path, this);
+        controller = manager.fileDownload(path, this);
     }
 
     public void pause() {
-        final TransferController controller = mController;
+        final TransferController controller = this.controller;
         if (controller != null) {
             controller.pause();
             setReady();
@@ -79,7 +79,7 @@ public class FilesDownloadViewModel extends McuMgrViewModel implements DownloadC
     }
 
     public void resume() {
-        final TransferController controller = mController;
+        final TransferController controller = this.controller;
         if (controller != null) {
             setBusy();
             controller.resume();
@@ -87,7 +87,7 @@ public class FilesDownloadViewModel extends McuMgrViewModel implements DownloadC
     }
 
     public void cancel() {
-        final TransferController controller = mController;
+        final TransferController controller = this.controller;
         if (controller != null) {
             controller.cancel();
         }
@@ -96,30 +96,30 @@ public class FilesDownloadViewModel extends McuMgrViewModel implements DownloadC
     @Override
     public void onDownloadProgressChanged(final int current, final int total, final long timestamp) {
         // Convert to percent
-        mProgressLiveData.postValue((int) (current * 100.f / total));
+        progressLiveData.postValue((int) (current * 100.f / total));
     }
 
     @Override
     public void onDownloadFailed(@NonNull final McuMgrException error) {
-        mController = null;
-        mProgressLiveData.postValue(0);
-        mErrorLiveData.postValue(error);
+        controller = null;
+        progressLiveData.postValue(0);
+        errorLiveData.postValue(error);
         postReady();
     }
 
     @Override
     public void onDownloadCanceled() {
-        mController = null;
-        mProgressLiveData.postValue(0);
-        mCancelledEvent.post();
+        controller = null;
+        progressLiveData.postValue(0);
+        cancelledEvent.post();
         postReady();
     }
 
     @Override
     public void onDownloadCompleted(@NonNull final byte[] data) {
-        mController = null;
-        mProgressLiveData.postValue(0);
-        mResponseLiveData.postValue(data);
+        controller = null;
+        progressLiveData.postValue(0);
+        responseLiveData.postValue(data);
         postReady();
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageSettingsViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageSettingsViewModel.java
@@ -18,35 +18,35 @@ import io.runtime.mcumgr.managers.BasicManager;
 import io.runtime.mcumgr.response.McuMgrResponse;
 
 public class ImageSettingsViewModel extends McuMgrViewModel {
-    private final BasicManager mManager;
+    private final BasicManager manager;
 
-    private final MutableLiveData<McuMgrException> mErrorLiveData = new MutableLiveData<>();
+    private final MutableLiveData<McuMgrException> errorLiveData = new MutableLiveData<>();
 
     @Inject
 	ImageSettingsViewModel(final BasicManager manager,
 						   @Named("busy") final MutableLiveData<Boolean> state) {
         super(state);
-        mManager = manager;
+        this.manager = manager;
     }
 
     @NonNull
     public LiveData<McuMgrException> getError() {
-        return mErrorLiveData;
+        return errorLiveData;
     }
 
     public void eraseSettings() {
         setBusy();
-        mErrorLiveData.setValue(null);
-        mManager.eraseStorage(new McuMgrCallback<McuMgrResponse>() {
+        errorLiveData.setValue(null);
+        manager.eraseStorage(new McuMgrCallback<McuMgrResponse>() {
             @Override
             public void onResponse(@NonNull final McuMgrResponse response) {
-                mErrorLiveData.postValue(null);
+                errorLiveData.postValue(null);
                 postReady();
             }
 
             @Override
             public void onError(@NonNull final McuMgrException error) {
-                mErrorLiveData.postValue(error);
+                errorLiveData.postValue(error);
                 postReady();
             }
         });

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/McuMgrViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/McuMgrViewModel.java
@@ -15,31 +15,31 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
 public class McuMgrViewModel extends ViewModel {
-    private final MutableLiveData<Boolean> mBusyStateLiveData;
+    private final MutableLiveData<Boolean> busyStateLiveData;
 
     @Inject
     McuMgrViewModel(@Named("busy") final MutableLiveData<Boolean> state) {
-        mBusyStateLiveData = state;
+        busyStateLiveData = state;
     }
 
     @NonNull
     public LiveData<Boolean> getBusyState() {
-        return mBusyStateLiveData;
+        return busyStateLiveData;
     }
 
     void setBusy() {
-        mBusyStateLiveData.setValue(true);
+        busyStateLiveData.setValue(true);
     }
 
     void postBusy() {
-        mBusyStateLiveData.postValue(true);
+        busyStateLiveData.postValue(true);
     }
 
     void setReady() {
-        mBusyStateLiveData.setValue(false);
+        busyStateLiveData.setValue(false);
     }
 
     void postReady() {
-        mBusyStateLiveData.postValue(false);
+        busyStateLiveData.postValue(false);
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ResetViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ResetViewModel.java
@@ -19,28 +19,28 @@ import io.runtime.mcumgr.managers.DefaultManager;
 import io.runtime.mcumgr.response.McuMgrResponse;
 
 public class ResetViewModel extends McuMgrViewModel {
-    private final DefaultManager mManager;
+    private final DefaultManager manager;
 
-    private final MutableLiveData<String> mErrorLiveData = new MutableLiveData<>();
+    private final MutableLiveData<String> errorLiveData = new MutableLiveData<>();
 
     @Inject
     ResetViewModel(final DefaultManager manager,
                    @Named("busy") final MutableLiveData<Boolean> state) {
         super(state);
-        mManager = manager;
+        this.manager = manager;
     }
 
     @NonNull
     public LiveData<String> getError() {
-        return mErrorLiveData;
+        return errorLiveData;
     }
 
     public void reset() {
         setBusy();
-        mManager.reset(new McuMgrCallback<McuMgrResponse>() {
+        manager.reset(new McuMgrCallback<McuMgrResponse>() {
             @Override
             public void onResponse(@NonNull final McuMgrResponse response) {
-                mManager.getTransporter().addObserver(new McuMgrTransport.ConnectionObserver() {
+                manager.getTransporter().addObserver(new McuMgrTransport.ConnectionObserver() {
                     @Override
                     public void onConnected() {
                         // ignore
@@ -48,7 +48,7 @@ public class ResetViewModel extends McuMgrViewModel {
 
                     @Override
                     public void onDisconnected() {
-                        mManager.getTransporter().removeObserver(this);
+                        manager.getTransporter().removeObserver(this);
                         postReady();
                     }
                 });
@@ -56,7 +56,7 @@ public class ResetViewModel extends McuMgrViewModel {
 
             @Override
             public void onError(@NonNull final McuMgrException error) {
-                mErrorLiveData.postValue(error.getMessage());
+                errorLiveData.postValue(error.getMessage());
                 postReady();
             }
         });

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/StatsViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/StatsViewModel.java
@@ -22,48 +22,48 @@ import io.runtime.mcumgr.response.stat.McuMgrStatListResponse;
 import io.runtime.mcumgr.response.stat.McuMgrStatResponse;
 
 public class StatsViewModel extends McuMgrViewModel {
-    private final StatsManager mManager;
+    private final StatsManager manager;
 
-    private final MutableLiveData<List<McuMgrStatResponse>> mResponseLiveData = new MutableLiveData<>();
-    private final MutableLiveData<McuMgrException> mErrorLiveData = new MutableLiveData<>();
+    private final MutableLiveData<List<McuMgrStatResponse>> responseLiveData = new MutableLiveData<>();
+    private final MutableLiveData<McuMgrException> errorLiveData = new MutableLiveData<>();
 
     @Inject
     StatsViewModel(final StatsManager manager,
                    @Named("busy") final MutableLiveData<Boolean> state) {
         super(state);
-        mManager = manager;
+        this.manager = manager;
     }
 
     public LiveData<List<McuMgrStatResponse>> getResponse() {
-        return mResponseLiveData;
+        return responseLiveData;
     }
 
     @NonNull
     public LiveData<McuMgrException> getError() {
-        return mErrorLiveData;
+        return errorLiveData;
     }
 
     public void readStats() {
         setBusy();
-        mErrorLiveData.setValue(null);
-        mManager.list(new McuMgrCallback<McuMgrStatListResponse>() {
+        errorLiveData.setValue(null);
+        manager.list(new McuMgrCallback<McuMgrStatListResponse>() {
             @Override
             public void onResponse(@NonNull final McuMgrStatListResponse listResponse) {
                 final List<McuMgrStatResponse> list = new ArrayList<>(listResponse.stat_list.length);
 
                 // Request stats for each module
                 for (final String module : listResponse.stat_list) {
-                    mManager.read(module, new McuMgrCallback<McuMgrStatResponse>() {
+                    manager.read(module, new McuMgrCallback<McuMgrStatResponse>() {
                         @Override
                         public void onResponse(@NonNull final McuMgrStatResponse response) {
                             list.add(response);
-                            mResponseLiveData.postValue(list);
+                            responseLiveData.postValue(list);
                             postReady();
                         }
 
                         @Override
                         public void onError(@NonNull final McuMgrException error) {
-                            mErrorLiveData.postValue(error);
+                            errorLiveData.postValue(error);
                             postReady();
                         }
                     });
@@ -72,7 +72,7 @@ public class StatsViewModel extends McuMgrViewModel {
 
             @Override
             public void onError(@NonNull final McuMgrException error) {
-                mErrorLiveData.postValue(error);
+                errorLiveData.postValue(error);
                 postReady();
             }
         });


### PR DESCRIPTION
This PR, like the name suggests, migrates the sample app from Hungarian notation to normal naming convention.
E.g. 
```java
private Fragment mDeviceFragment;
```
will be now:
```java
private Fragment deviceFragment;
```