### PR TITLE
Memory leaks fixed

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrActivitiesModule.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrActivitiesModule.java
@@ -9,10 +9,12 @@ package io.runtime.mcumgr.sample.di.module;
 import dagger.Module;
 import dagger.android.ContributesAndroidInjector;
 import io.runtime.mcumgr.sample.MainActivity;
+import io.runtime.mcumgr.sample.di.McuMgrScope;
 
 @SuppressWarnings("unused")
 @Module
 public abstract class McuMgrActivitiesModule {
+    @McuMgrScope
     @ContributesAndroidInjector
     abstract MainActivity contributeMainActivity();
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrFragmentBuildersModule.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrFragmentBuildersModule.java
@@ -8,6 +8,7 @@ package io.runtime.mcumgr.sample.di.module;
 
 import dagger.Module;
 import dagger.android.ContributesAndroidInjector;
+import io.runtime.mcumgr.sample.di.McuMgrScope;
 import io.runtime.mcumgr.sample.dialog.PartitionDialogFragment;
 import io.runtime.mcumgr.sample.fragment.ImageFragment;
 import io.runtime.mcumgr.sample.fragment.mcumgr.DeviceStatusFragment;
@@ -24,28 +25,51 @@ import io.runtime.mcumgr.sample.fragment.mcumgr.StatsFragment;
 @SuppressWarnings("unused")
 @Module
 public abstract class McuMgrFragmentBuildersModule {
+    @McuMgrScope
     @ContributesAndroidInjector
     abstract DeviceStatusFragment contributeDeviceStatusFragment();
+
+    @McuMgrScope
     @ContributesAndroidInjector
     abstract EchoFragment contributeEchoFragment();
+
+    @McuMgrScope
     @ContributesAndroidInjector
     abstract ResetFragment contributeResetFragment();
+
+    @McuMgrScope
     @ContributesAndroidInjector
     abstract StatsFragment contributeStatsFragment();
+
+    @McuMgrScope
     @ContributesAndroidInjector
     abstract ImageFragment contributeImageFragment();
+
+    @McuMgrScope
     @ContributesAndroidInjector
     abstract ImageUpgradeFragment contributeImageUpgradeFragment();
+
+    @McuMgrScope
     @ContributesAndroidInjector
     abstract ImageUploadFragment contributeImageUploadFragment();
+
+    @McuMgrScope
     @ContributesAndroidInjector
     abstract ImageControlFragment contributeImageControlFragment();
+
+    @McuMgrScope
     @ContributesAndroidInjector
     abstract ImageSettingsFragment contributeImageSettingsFragment();
+
+    @McuMgrScope
     @ContributesAndroidInjector
     abstract PartitionDialogFragment contributePartitionDialogFragment();
+
+    @McuMgrScope
     @ContributesAndroidInjector
     abstract FilesDownloadFragment contributeFileDownloadFragment();
+
+    @McuMgrScope
     @ContributesAndroidInjector
     abstract FilesUploadFragment contributeFilesUploadFragment();
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrManagerModule.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrManagerModule.java
@@ -17,46 +17,55 @@ import io.runtime.mcumgr.managers.FsManager;
 import io.runtime.mcumgr.managers.ImageManager;
 import io.runtime.mcumgr.managers.LogManager;
 import io.runtime.mcumgr.managers.StatsManager;
+import io.runtime.mcumgr.sample.di.McuMgrScope;
 
 @Module
 public class McuMgrManagerModule {
 
     @Provides
+    @McuMgrScope
     static ConfigManager provideConfigManager(final McuMgrTransport transport) {
         return new ConfigManager(transport);
     }
 
     @Provides
+    @McuMgrScope
     static DefaultManager provideDefaultManager(final McuMgrTransport transport) {
         return new DefaultManager(transport);
     }
 
     @Provides
+    @McuMgrScope
     static FsManager provideFsManager(final McuMgrTransport transport) {
         return new FsManager(transport);
     }
 
     @Provides
+    @McuMgrScope
     static LogManager provideLogManager(final McuMgrTransport transport) {
         return new LogManager(transport);
     }
 
     @Provides
+    @McuMgrScope
     static ImageManager provideImageManager(final McuMgrTransport transport) {
         return new ImageManager(transport);
     }
 
     @Provides
+    @McuMgrScope
     static BasicManager provideBasicManager(final McuMgrTransport transport) {
         return new BasicManager(transport);
     }
 
     @Provides
+    @McuMgrScope
     static StatsManager provideStatsManager(final McuMgrTransport transport) {
         return new StatsManager(transport);
     }
 
     @Provides
+    @McuMgrScope
     static FirmwareUpgradeManager provideFirmwareUpgradeManager(final McuMgrTransport transport) {
         return new FirmwareUpgradeManager(transport);
     }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrTransportModule.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrTransportModule.java
@@ -26,8 +26,11 @@ public class McuMgrTransportModule {
     @NonNull
     static McuMgrTransport provideMcuMgrTransport(@NonNull final Context context,
                                                   @NonNull final BluetoothDevice device,
-                                                  @NonNull final Handler handler) {
-        return new ObservableMcuMgrBleTransport(context, device, handler);
+                                                  @NonNull final HandlerThread handlerThread) {
+        final Handler handler = new Handler(handlerThread.getLooper());
+        final ObservableMcuMgrBleTransport transport = new ObservableMcuMgrBleTransport(context, device, handler);
+        transport.setOnReleasedCallback(handlerThread::quitSafely);
+        return transport;
     }
 
     @Provides
@@ -37,12 +40,5 @@ public class McuMgrTransportModule {
         final HandlerThread handlerThread = new HandlerThread("McuMgrTransport");
         handlerThread.start(); // The handler thread is stopped in MainViewModel#onCleard().
         return handlerThread;
-    }
-
-    @Provides
-    @McuMgrScope
-    @NonNull
-    static Handler provideTransportHandler(@NonNull final HandlerThread handlerThread) {
-        return new Handler(handlerThread.getLooper());
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrViewModelModule.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrViewModelModule.java
@@ -32,7 +32,8 @@ public class McuMgrViewModelModule {
     @Provides
     @McuMgrScope
     static McuMgrViewModelFactory provideMcuMgrViewModelFactory(
-            final McuMgrViewModelSubComponent.Builder viewModelSubComponent) {
+            final McuMgrViewModelSubComponent.Builder viewModelSubComponent
+    ) {
         return new McuMgrViewModelFactory(viewModelSubComponent.build());
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/MainViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/MainViewModel.java
@@ -26,6 +26,5 @@ public class MainViewModel extends AndroidViewModel {
         super.onCleared();
 
         mcuMgrTransport.release();
-        handlerThread.quitSafely();
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -87,6 +87,12 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
         progressLiveData.setValue(0);
     }
 
+    @Override
+    protected void onCleared() {
+        super.onCleared();
+        manager.setFirmwareUpgradeCallback(null);
+    }
+
     @NonNull
     public LiveData<State> getState() {
         return stateLiveData;


### PR DESCRIPTION
This PR fixes 2 detected memory leaks:
1. `ImageUpgradeViewModel` was set as a callback for `DeviceFirmwareUpgradeManager` and was never released when quitting the app. It is now cleared in `onCleared()`.
2. `HandlerThread` used by the `BleManager` and underneath by `BluetoothGatt` was quit before the connection got disconnected, so the `BluetoothGatt` object was retained and was producing warnings in LogCat. Now, the thread is safely quit after the device is released.
3. Multiple objects have been scoped to the correct scope to avoid duplications.