### PR TITLE
Performance optimizations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ buildscript {
         classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.github.gradle-nexus:publish-plugin:$gradle_nexus_publish_plugin"
-        classpath 'com.hiya:jacoco-android:0.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.github.gradle-nexus:publish-plugin:$gradle_nexus_publish_plugin"
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip

--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -54,8 +54,3 @@ if (rootProject.file('gradle/publish-module.gradle').exists()) {
     }
     apply from: rootProject.file('gradle/publish-module.gradle')
 }
-// === JaCoCo configuration ===
-// https://www.eclemma.org/jacoco/
-if (rootProject.file('gradle/jacoco-android.gradle').exists()) {
-    apply from: rootProject.file('gradle/jacoco-android.gradle')
-}

--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -70,9 +70,6 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
     private final static UUID SMP_CHAR_UUID =
             UUID.fromString("DA2E7828-FBCE-4E01-AE9E-261174997C48");
 
-    final static UUID CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR_UUID =
-            UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
-
     // Use a separate characteristic object for writes vs notifications.
     //
     // We must clone the characteristic object in order to ensure no race
@@ -607,6 +604,9 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
     // The characteristic is cloned, and data sent and received do not share the same value,
     // which otherwise could lead to race conditions.
     //*******************************************************************************************
+
+    private final static UUID CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR_UUID =
+            UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
 
     private static BluetoothGattDescriptor getNotifyCccd(@NonNull final BluetoothGattCharacteristic characteristic) {
         // Check characteristic property

--- a/mcumgr-core/build.gradle
+++ b/mcumgr-core/build.gradle
@@ -56,8 +56,3 @@ if (rootProject.file('gradle/publish-module.gradle').exists()) {
     }
     apply from: rootProject.file('gradle/publish-module.gradle')
 }
-// === JaCoCo configuration ===
-// https://www.eclemma.org/jacoco/
-if (rootProject.file('gradle/jacoco-android.gradle').exists()) {
-    apply from: rootProject.file('gradle/jacoco-android.gradle')
-}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
@@ -314,7 +314,8 @@ public abstract class McuManager {
             payloadMapCopy.remove(HEADER_KEY);
 
             // Get the length
-            int len = CBOR.toBytes(payloadMapCopy).length;
+            byte[] cborPayload = CBOR.toBytes(payloadMapCopy);
+            int len = cborPayload.length;
 
             // Build header
             byte[] header = McuMgrHeader.build(op, flags, len, groupId, sequenceNum, commandId);
@@ -328,7 +329,6 @@ public abstract class McuManager {
                 packet = CBOR.toBytes(payloadMap);
             } else {
                 // Standard scheme appends the CBOR payload to the header.
-                byte[] cborPayload = CBOR.toBytes(payloadMap);
                 packet = new byte[header.length + cborPayload.length];
                 System.arraycopy(header, 0, packet, 0, header.length);
                 System.arraycopy(cborPayload, 0, packet, header.length, cborPayload.length);

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/FsManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/FsManager.java
@@ -603,26 +603,34 @@ public class FsManager extends TransferManager {
                 }
             };
 
-    // TODO more precise overhead calculations
     private int calculatePacketOverhead(@NotNull String name, byte @NotNull [] data, int offset) {
-        HashMap<String, Object> overheadTestMap = new HashMap<>();
-        overheadTestMap.put("name", name);
-        overheadTestMap.put("data", new byte[0]);
-        overheadTestMap.put("off", offset);
-        if (offset == 0) {
-            overheadTestMap.put("len", data.length);
-        }
         try {
             if (getScheme().isCoap()) {
+                HashMap<String, Object> overheadTestMap = new HashMap<>();
+                overheadTestMap.put("name", name);
+                overheadTestMap.put("data", new byte[0]);
+                overheadTestMap.put("off", offset);
+                if (offset == 0) {
+                    overheadTestMap.put("len", data.length);
+                }
                 byte[] header = {0, 0, 0, 0, 0, 0, 0, 0};
                 overheadTestMap.put("_h", header);
                 byte[] cborData = CBOR.toBytes(overheadTestMap);
                 // 20 byte estimate of CoAP Header; 5 bytes for good measure
                 return cborData.length + 20 + 5;
             } else {
-                byte[] cborData = CBOR.toBytes(overheadTestMap);
-                // 8 bytes for McuMgr header; 2 bytes for data length
-                return cborData.length + 8 + 2;
+                // The code below removes the need of calling an expensive method CBOR.toBytes(..)
+                // by calculating the overhead manually. Mind, that the data itself are not added.
+                int size = 0;
+                size += 2; // map: 0xBF at the beginning and 0xFF at the end
+                size += 5 + 2 + name.getBytes().length; // "name": 0x646E616D65 + 2 for name length (assuming > 23 bytes, but <= 256) + name
+                size += 5 + 3; // "data": 0x6464617461 + 3 for encoding length (as 16-bin positive int, worse case scenario) + NO DATA
+                size += 4 + 3; // "off": 0x636F6666 + 3 bytes for the offset (as 16-bin positive int, worse case scenario)
+                if (offset == 0) {
+                    size -= 2; // (offset = 0 requires just 1 byte, and we added 3 above)
+                    size += 4 + 5; // "len": 0x636C656E + len (as 32-bit positive integer, worse case scenario)
+                }
+                return size + 8; // 8 additional bytes for the SMP header
             }
         } catch (IOException e) {
             LOG.error("Error while calculating packet overhead", e);

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -16,7 +16,7 @@ android {
         targetSdkVersion 31
         versionCode getVersionCodeFromTags()
         versionName getVersionNameFromTags()
-        resConfigs "en"
+        resConfigs 'en'
 
         vectorDrawables.useSupportLibrary = true
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -55,10 +55,10 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.preference:preference:1.1.1'
-    implementation 'androidx.core:core-splashscreen:1.0.0-alpha02'
-    implementation 'com.google.android.material:material:1.6.0-alpha01'
+    implementation 'androidx.core:core-splashscreen:1.0.0-beta01'
+    implementation 'com.google.android.material:material:1.6.0-alpha02'
 
     // Dagger 2
     implementation 'com.google.dagger:dagger:2.40.4'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -51,12 +51,12 @@ android {
 
 dependencies {
     implementation 'androidx.activity:activity:1.4.0'
-    implementation 'androidx.fragment:fragment:1.4.0'
+    implementation 'androidx.fragment:fragment:1.4.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'androidx.preference:preference:1.2.0'
     implementation 'androidx.core:core-splashscreen:1.0.0-beta01'
     implementation 'com.google.android.material:material:1.6.0-alpha02'
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/ScannerActivity.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/ScannerActivity.java
@@ -96,7 +96,7 @@ public class ScannerActivity extends AppCompatActivity
                     // Keep the splash screen on-screen for longer periods.
                     // Handle the splash screen transition.
                     final long then = System.currentTimeMillis();
-                    splashScreen.setKeepVisibleCondition(() -> {
+                    splashScreen.setKeepOnScreenCondition(() -> {
                         final long now = System.currentTimeMillis();
                         return now < then + 900;
                     });

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/FilesDownloadViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/FilesDownloadViewModel.java
@@ -63,16 +63,15 @@ public class FilesDownloadViewModel extends McuMgrViewModel implements DownloadC
             return;
         }
         setBusy();
-        final McuMgrTransport transport = manager.getTransporter();
-        if (transport instanceof McuMgrBleTransport) {
-            ((McuMgrBleTransport) transport).requestConnPriority(ConnectionPriorityRequest.CONNECTION_PRIORITY_HIGH);
-        }
+        requestHighConnectionPriority();
+        setLoggingEnabled(false);
         controller = manager.fileDownload(path, this);
     }
 
     public void pause() {
         final TransferController controller = this.controller;
         if (controller != null) {
+            setLoggingEnabled(true);
             controller.pause();
             setReady();
         }
@@ -82,6 +81,7 @@ public class FilesDownloadViewModel extends McuMgrViewModel implements DownloadC
         final TransferController controller = this.controller;
         if (controller != null) {
             setBusy();
+            setLoggingEnabled(false);
             controller.resume();
         }
     }
@@ -104,6 +104,7 @@ public class FilesDownloadViewModel extends McuMgrViewModel implements DownloadC
         controller = null;
         progressLiveData.postValue(0);
         errorLiveData.postValue(error);
+        setLoggingEnabled(true);
         postReady();
     }
 
@@ -112,6 +113,7 @@ public class FilesDownloadViewModel extends McuMgrViewModel implements DownloadC
         controller = null;
         progressLiveData.postValue(0);
         cancelledEvent.post();
+        setLoggingEnabled(true);
         postReady();
     }
 
@@ -120,6 +122,23 @@ public class FilesDownloadViewModel extends McuMgrViewModel implements DownloadC
         controller = null;
         progressLiveData.postValue(0);
         responseLiveData.postValue(data);
+        setLoggingEnabled(true);
         postReady();
+    }
+
+    private void requestHighConnectionPriority() {
+        final McuMgrTransport transporter = manager.getTransporter();
+        if (transporter instanceof McuMgrBleTransport) {
+            final McuMgrBleTransport bleTransporter = (McuMgrBleTransport) transporter;
+            bleTransporter.requestConnPriority(ConnectionPriorityRequest.CONNECTION_PRIORITY_HIGH);
+        }
+    }
+
+    private void setLoggingEnabled(final boolean enabled) {
+        final McuMgrTransport transporter = manager.getTransporter();
+        if (transporter instanceof McuMgrBleTransport) {
+            final McuMgrBleTransport bleTransporter = (McuMgrBleTransport) transporter;
+            bleTransporter.setLoggingEnabled(enabled);
+        }
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/FilesUploadViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/FilesUploadViewModel.java
@@ -95,10 +95,8 @@ public class FilesUploadViewModel extends McuMgrViewModel implements UploadCallb
         }
         setBusy();
         stateLiveData.setValue(State.UPLOADING);
-        final McuMgrTransport transport = manager.getTransporter();
-        if (transport instanceof McuMgrBleTransport) {
-            ((McuMgrBleTransport) transport).requestConnPriority(ConnectionPriorityRequest.CONNECTION_PRIORITY_HIGH);
-        }
+        requestHighConnectionPriority();
+        setLoggingEnabled(false);
         initialBytes = 0;
         controller = manager.fileUpload(path, data, this);
     }
@@ -107,6 +105,7 @@ public class FilesUploadViewModel extends McuMgrViewModel implements UploadCallb
         final TransferController controller = this.controller;
         if (controller != null) {
             stateLiveData.setValue(State.PAUSED);
+            setLoggingEnabled(true);
             controller.pause();
             setReady();
         }
@@ -118,6 +117,7 @@ public class FilesUploadViewModel extends McuMgrViewModel implements UploadCallb
             stateLiveData.setValue(State.UPLOADING);
             setBusy();
             initialBytes = 0;
+            setLoggingEnabled(false);
             controller.resume();
         }
     }
@@ -149,6 +149,7 @@ public class FilesUploadViewModel extends McuMgrViewModel implements UploadCallb
         controller = null;
         progressLiveData.postValue(0);
         errorLiveData.postValue(error);
+        setLoggingEnabled(true);
         postReady();
     }
 
@@ -158,6 +159,7 @@ public class FilesUploadViewModel extends McuMgrViewModel implements UploadCallb
         progressLiveData.postValue(0);
         stateLiveData.postValue(State.IDLE);
         cancelledEvent.post();
+        setLoggingEnabled(true);
         postReady();
     }
 
@@ -166,6 +168,23 @@ public class FilesUploadViewModel extends McuMgrViewModel implements UploadCallb
         controller = null;
         progressLiveData.postValue(0);
         stateLiveData.postValue(State.COMPLETE);
+        setLoggingEnabled(true);
         postReady();
+    }
+
+    private void requestHighConnectionPriority() {
+        final McuMgrTransport transporter = manager.getTransporter();
+        if (transporter instanceof McuMgrBleTransport) {
+            final McuMgrBleTransport bleTransporter = (McuMgrBleTransport) transporter;
+            bleTransporter.requestConnPriority(ConnectionPriorityRequest.CONNECTION_PRIORITY_HIGH);
+        }
+    }
+
+    private void setLoggingEnabled(final boolean enabled) {
+        final McuMgrTransport transporter = manager.getTransporter();
+        if (transporter instanceof McuMgrBleTransport) {
+            final McuMgrBleTransport bleTransporter = (McuMgrBleTransport) transporter;
+            bleTransporter.setLoggingEnabled(enabled);
+        }
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -139,10 +139,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
             }
         }
         try {
-            final McuMgrTransport transport = manager.getTransporter();
-            if (transport instanceof McuMgrBleTransport) {
-                ((McuMgrBleTransport) transport).requestConnPriority(ConnectionPriorityRequest.CONNECTION_PRIORITY_HIGH);
-            }
+            requestHighConnectionPriority();
             manager.setMode(mode);
             manager.start(images, eraseSettings);
         } catch (final McuMgrException e) {
@@ -183,7 +180,10 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
     }
 
     @Override
-    public void onStateChanged(final FirmwareUpgradeManager.State prevState, final FirmwareUpgradeManager.State newState) {
+    public void onStateChanged(
+            final FirmwareUpgradeManager.State prevState,
+            final FirmwareUpgradeManager.State newState)
+    {
         setLoggingEnabled(newState != FirmwareUpgradeManager.State.UPLOAD);
         switch (newState) {
             case UPLOAD:
@@ -247,9 +247,15 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
         postReady();
     }
 
-    private void setLoggingEnabled(final boolean enabled) {
-        super.postReady();
+    private void requestHighConnectionPriority() {
+        final McuMgrTransport transporter = manager.getTransporter();
+        if (transporter instanceof McuMgrBleTransport) {
+            final McuMgrBleTransport bleTransporter = (McuMgrBleTransport) transporter;
+            bleTransporter.requestConnPriority(ConnectionPriorityRequest.CONNECTION_PRIORITY_HIGH);
+        }
+    }
 
+    private void setLoggingEnabled(final boolean enabled) {
         final McuMgrTransport transporter = manager.getTransporter();
         if (transporter instanceof McuMgrBleTransport) {
             final McuMgrBleTransport bleTransporter = (McuMgrBleTransport) transporter;


### PR DESCRIPTION
This PR greatly improves upload performance using this library, both for Image Manager and FS Manager.
This is done by:
- Limiting number of `CBOR.toObject(...)` calls, as expensive
- Removing unnecessary object creation
- Disabling logging during upload and download (sample app only)
- Calculating CBOR overhead without creating CBOR packet

All those features allow to build and send the next SMP packet ~20 ms quicker than before saving one connection interval for each packet.

The PR also migrates the project to Android Studio Bumblebee stable version.