### PR TITLE
Migration to BLE Library 2.4.0-beta01

### DIFF
--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     api project(':mcumgr-core')
 
     // Import the BLE Library
-    api 'no.nordicsemi.android:ble:2.3.1'
+    api 'no.nordicsemi.android:ble:2.4.0-beta01'
 
     // Logging
     implementation 'org.slf4j:slf4j-api:1.7.35'

--- a/sample/src/main/java/io/runtime/mcumgr/sample/observable/ObservableMcuMgrBleTransport.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/observable/ObservableMcuMgrBleTransport.java
@@ -101,6 +101,14 @@ public class ObservableMcuMgrBleTransport extends McuMgrBleTransport {
         setLoggingEnabled(true);
     }
 
+    @Override
+    public int getMinLogPriority() {
+        // Uncomment to get the previous logging details.
+        // return Log.VERBOSE;
+        // The new default min log priority increases DFU speed, but is bad for debugging.
+        return super.getMinLogPriority();
+    }
+
     @Nullable
     public LiveData<ConnectionState> getState() {
         return connectionState;


### PR DESCRIPTION
This PR migrates the `mcumgr-ble` module to Android BLE Library 2.4.0-beta01 version.
Useful changes:
- option to disable low level BLE logs improve upload speed
- bugs fixed