### PR TITLE
Allowing expanding McuMgrBleTransport with support for extra services

### DIFF
--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -515,6 +515,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
      *
      * @param gatt The Bluetooth GATT object with services discovered.
      * @return True if any additional services were found; false otherwise.
+     * @since 1.1
      */
     protected boolean isAdditionalServiceSupported(@NonNull BluetoothGatt gatt) {
         // By default no extra services are supported.
@@ -524,6 +525,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
     /**
      * This method should initialize additional services. The SMP services requests have already
      * been enqueued.
+     * @since 1.1
      */
     protected void initializeAdditionalServices() {
         // Empty default implementation.
@@ -536,6 +538,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
      * device has disconnected, Service Changed indication was received, or
      * {@link BleManager#refreshDeviceCache()} request was executed, which has invalidated cached
      * services.
+     * @since 1.1
      */
     protected void onServicesInvalidated() {
         // Empty default implementation.

--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -47,7 +47,6 @@ import io.runtime.mcumgr.exception.McuMgrTimeoutException;
 import io.runtime.mcumgr.response.McuMgrResponse;
 import io.runtime.mcumgr.util.CBOR;
 import no.nordicsemi.android.ble.BleManager;
-import no.nordicsemi.android.ble.Request;
 import no.nordicsemi.android.ble.annotation.ConnectionPriority;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.data.DataMerger;
@@ -56,9 +55,15 @@ import no.nordicsemi.android.ble.error.GattError;
 /**
  * The McuMgrBleTransport is an implementation for the {@link McuMgrScheme#BLE} transport scheme.
  * This class extends {@link BleManager}, which handles the BLE state machine and owns the
- * {@link BluetoothGatt} object that executes BLE actions. If you wish to integrate McuManager an
- * existing BLE implementation, you may simply implement {@link McuMgrTransport} or use this class
- * to perform your BLE actions by calling {@link BleManager#enqueue(Request)}.
+ * {@link BluetoothGatt} object that executes BLE actions.
+ * <p>
+ * Starting from version 1.1 it is possible to extend the functionality to support additional
+ * services. For that extend the following methods:
+ * <ul>
+ *     <li>{@link #isAdditionalServiceSupported(BluetoothGatt)}</li>
+ *     <li>{@link #initializeAdditionalServices()}</li>
+ *     <li>{@link #onServicesInvalidated()}</li>
+ * </ul>
  */
 @SuppressWarnings("unused")
 public class McuMgrBleTransport extends BleManager implements McuMgrTransport {


### PR DESCRIPTION
This PR fixes #40 and https://github.com/NordicSemiconductor/Android-BLE-Library/issues/361

## Usage

Extend `McuMgrBleTransport` and override 3 new methods:
   - `isAdditionalServiceSupported(BluetoothGatt)` - this method should obtain references to characteristics and/or descriptors and return *true* if all required services were discovered.
   - `initializeAdditionalServices()` - this method should initialize the additional services, e.g. enable notifications and set notification callbacks.
   - `onServicesInvalidated()` - this method should release references to characteristics and/or descriptors.