### PR TITLE
Pause and Resume

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
@@ -153,16 +153,13 @@ abstract class Uploader(
         callback: suspend (UploadResult) -> Unit
     ): Chunk {
         val resultChannel: Channel<UploadResult> = Channel(1)
-        val map = prepareWrite(chunk.data, chunk.offset)
-        log.debug(map.toString())
-        write(map) {
-            resultChannel.trySend(it)
+        write(prepareWrite(chunk.data, chunk.offset)) { result ->
+            resultChannel.trySend(result)
         }
 
         return if (chunk.offset == 0) {
             // Send the first chunk synchronously, to get the last offset.
             val result = resultChannel.receive()
-            log.debug("Result received: $result")
             callback(result)
 
             result.onSuccess {
@@ -217,6 +214,9 @@ abstract class Uploader(
         "data" to data,
         "off" to offset
     ).also {
+        if (offset == 0) {
+            it["len"] = this.data.size // NOT data.size, as data is just a chunk of this.data
+        }
         getAdditionalData(data, offset, it)
     }
 
@@ -246,10 +246,18 @@ abstract class Uploader(
         // Size of the string "off" plus the length of the offset integer
         val offsetSize = cborStringLength("off") + cborUIntLength(offset)
 
+        // Size of the string "len" plus the length of the data size integer
+        // "len" is sent only in the initial packet.
+        val lengthSize = if (offset == 0) {
+            cborStringLength("len") + cborUIntLength(data.size)
+        } else {
+            0
+        }
+
         // Implementation specific size
         val implSpecificSize = getAdditionalSize(offset)
 
-        val combinedSize = headerSize + mapSize + offsetSize + implSpecificSize + dataStringSize
+        val combinedSize = headerSize + mapSize + offsetSize + lengthSize + implSpecificSize + dataStringSize
 
         // Now we calculate the max amount of data that we can fit given the MTU.
         val maxDataLength = mtu - combinedSize
@@ -265,6 +273,7 @@ abstract class Uploader(
 
     /**
      * This method should add additional parameters to the map.
+     * The "data", "len" and "off" parameters are already added.
      */
     internal open fun getAdditionalData(
         data: ByteArray,
@@ -276,7 +285,8 @@ abstract class Uploader(
 
     /**
      * This method should return an additional size of the CBOR payload, which will be placed to the
-     * packet with the given offset. By default only "data" and "off" are added.
+     * packet with the given offset.
+     * The "data", "len" and "off" parameters are already calculated.
      */
     internal open fun getAdditionalSize(offset: Int) = 0
 }


### PR DESCRIPTION
This PR adds Pause and Resume to DFU manager, where `windowCapacity` is set to 2+. Before, the implementation was throwing an error.
It also improves a bit `Uploader` implementation by moving the common "len" parameter to the base class, letting the implementation only care about additional parameters like "sha" and "image".