### PR TITLE
SMP segmentation

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/DefaultManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/DefaultManager.java
@@ -21,6 +21,7 @@ import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.response.McuMgrResponse;
 import io.runtime.mcumgr.response.dflt.McuMgrEchoResponse;
 import io.runtime.mcumgr.response.dflt.McuMgrMpStatResponse;
+import io.runtime.mcumgr.response.dflt.McuMgrParamsResponse;
 import io.runtime.mcumgr.response.dflt.McuMgrReadDateTimeResponse;
 import io.runtime.mcumgr.response.dflt.McuMgrTaskStatResponse;
 
@@ -37,6 +38,7 @@ public class DefaultManager extends McuManager {
     private final static int ID_MPSTATS = 3;
     private final static int ID_DATETIME_STR = 4;
     private final static int ID_RESET = 5;
+    private final static int ID_MCUMGR_PARAMS = 6;
 
     /**
      * Construct an default manager.
@@ -215,5 +217,25 @@ public class DefaultManager extends McuManager {
     @NotNull
     public McuMgrResponse reset() throws McuMgrException {
         return send(OP_WRITE, ID_RESET, null, McuMgrResponse.class);
+    }
+
+    /**
+     * Reads McuMgr parameters (asynchronous).
+     *
+     * @param callback the asynchronous callback.
+     */
+    public void params(@NotNull McuMgrCallback<McuMgrParamsResponse> callback) {
+        send(OP_READ, ID_MCUMGR_PARAMS, null, McuMgrParamsResponse.class, callback);
+    }
+
+    /**
+     * Reads McuMgr parameters (synchronous).
+     *
+     * @return The response.
+     * @throws McuMgrException Transport error. See cause.
+     */
+    @NotNull
+    public McuMgrResponse params() throws McuMgrException {
+        return send(OP_READ, ID_MCUMGR_PARAMS, null, McuMgrParamsResponse.class);
     }
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrParamsResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrParamsResponse.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Intellinium SAS, 2014-present
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.runtime.mcumgr.response.dflt;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.runtime.mcumgr.response.McuMgrResponse;
+
+public class McuMgrParamsResponse extends McuMgrResponse {
+    /** The McuMgr buffer size. */
+    @JsonProperty("buf_size")
+    public int bufSize;
+
+    /** Number of McuMgr buffers. */
+    @JsonProperty("buf_count")
+    public int bufCount;
+
+    @JsonCreator
+    public McuMgrParamsResponse() {}
+}


### PR DESCRIPTION
This PR improves the upload speed even more. 

It requires this PR: https://github.com/zephyrproject-rtos/zephyr/pull/44643 implemented on the fw side, which allows to obtain the buffer size automatically. Without it, the max size can be set using
https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/blob/11883cf3d756e18c86d4f9d3ae7ea9df3a0faff0/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java#L234

Each SMP packet, which contains 8-byte SMP header and the CBOR message, can be sent split into multiple BLE packets and reassembled on the device side. That significantly increases number of payload bytes sent per second. Measured DFU speed:
1. Without pipelining (window capacity set to 1): **2-4 kB/s**
2. With pipelining (window capacity set to 3): **16-20 kB/s**
3. With SMP segmentation/reassembly and pipelining (window capacity set to 3): **36 kB/s**