### PR TITLE
Bug fix: Crash when number of mcumgr buffers is set to 0

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
@@ -303,6 +303,8 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
         int windowCapacity;
         try {
             windowCapacity = Integer.parseInt(binding.advancedWindowCapacity.getText().toString());
+            if (windowCapacity < 1 || windowCapacity > 25)
+                throw new NumberFormatException();
             binding.advancedPipelineLayout.setError(null);
         } catch (final NumberFormatException e) {
             binding.advancedPipelineLayout.setError(getText(R.string.image_upgrade_error));
@@ -321,7 +323,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
         viewModel.upgrade(getFileContent(), mode,
                 eraseAppSettings,
                 swapTimeSeconds * 1000,
-                windowCapacity,
+                Math.max(1, windowCapacity - 1), // 1 buffer is used for sending responses.
                 memoryAlignment
         );
     }


### PR DESCRIPTION
This PR fixes a crash caused by setting number of buffers to 0.
Also, the `windowCapacity` value set in `FirmwareUpgradeManager` is now set to number of buffers -1, as 1 buffer is needed for sending responses.