### PR TITLE
Sending non-empty CBOR message

### DIFF
--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -578,10 +578,12 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
         private final byte[] READ_MCU_MGR_PARAMS = new byte[] {
                 0x00, // McuManager.OP_READ
                 0x00, // Flags
-                0x00, 0x00, // Len
+                0x00, 0x01, // Len
                 0x00, 0x00, // McuManager.GROUP_DEFAULT
                 0x00, // Seq
                 0x06, // DefaultManager.ID_MCUMGR_PARAMS
+                (byte) 0xA0, // Empty map(0) - an empty CBOR may be required for some implementations,
+                             // otherwise the request is ignored and no notification is replied.
         };
 
         // Determines whether the device supports the SMP Service


### PR DESCRIPTION
There was an issue with NCS 1.9.1 and perhaps few earlier versions, where a SMP command with no CBOR payload was ignored and no notification was replied.
As all commands created using `McuManager` always have a CBOR payload (e.g. [0xBF-FF](https://cbor.me/?bytes=BF(FF))), only the hardcoded message had to be changed. Without the change the request times out after a second instead succeeding on a notification when tested with fw from NCS 1.9.1.

CBOR message is no longer needed in NCS 2.0+ with zcbor implementation.