### PR TITLE
Throughtput graph

### DIFF
--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -31,13 +31,13 @@ dependencies {
     api project(':mcumgr-core')
 
     // Import the BLE Library
-    api 'no.nordicsemi.android:ble:2.4.1'
+    api 'no.nordicsemi.android:ble:2.5.0'
 
     // Logging
     implementation 'org.slf4j:slf4j-api:1.7.35'
 
     // Kotlin
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"

--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -518,13 +518,14 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
      *                 {@link BluetoothGatt#CONNECTION_PRIORITY_LOW_POWER}.
      */
     public void requestConnPriority(@ConnectionPriority final int priority) {
-        connect(mDevice).done(device -> {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                McuMgrBleTransport.super.requestConnectionPriority(priority).enqueue();
-            } // else ignore... :(
-        })
-        .retry(3, 500)
-        .enqueue();
+        connect(mDevice)
+                .retry(3, 500)
+                .done(device -> {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        McuMgrBleTransport.super.requestConnectionPriority(priority).enqueue();
+                    } // else ignore... :(
+                })
+                .enqueue();
     }
 
     //*******************************************************************************************

--- a/mcumgr-core/build.gradle
+++ b/mcumgr-core/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.35'
 
     // Kotlin
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1"
 
     // Import CBOR parser
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.4'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.preference:preference:1.2.0'
     implementation 'androidx.core:core-splashscreen:1.0.0-rc01'
-    implementation 'com.google.android.material:material:1.7.0-alpha01'
+    implementation 'com.google.android.material:material:1.7.0-alpha02'
 
     // Dagger 2
     implementation 'com.google.dagger:dagger:2.40.5'

--- a/sample/src/main/java/io/runtime/mcumgr/sample/observable/ConnectionParameters.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/observable/ConnectionParameters.java
@@ -1,0 +1,117 @@
+package io.runtime.mcumgr.sample.observable;
+
+import no.nordicsemi.android.ble.annotation.PhyValue;
+
+public class ConnectionParameters {
+	private final int interval;
+	private final int latency;
+	private final int timeout;
+	private final int mtu;
+	private final int bufferSize;
+	private final int txPhy, rxPhy;
+
+	public ConnectionParameters(
+			final int interval, final int latency, final int timeout,
+			final int mtu, final int bufferSize,
+			final int txPhy, final int rxPhy) {
+		this.interval = interval;
+		this.latency = latency;
+		this.timeout = timeout;
+		this.mtu = mtu;
+		this.bufferSize = bufferSize;
+		this.txPhy = txPhy;
+		this.rxPhy = rxPhy;
+	}
+
+	/**
+	 * Connection interval used on this connection, 1.25ms unit.
+	 * Valid range is from 6 (7.5ms) to 3200 (4000ms).
+	 *
+	 * @return The connection interval in 1.25ms units.
+	 */
+	public int getInterval() {
+		return interval;
+	}
+
+	/**
+	 * Returns the connection interval in milliseconds.
+	 * Valid range is from 7.5ms to 4000ms.
+	 *
+	 * @return The connection interval in milliseconds.
+	 */
+	public float getIntervalInMs() {
+		return (float) interval * 1.25f; // ms
+	}
+
+	/**
+	 * Returns the slave latency for the connection in number of connection events.
+	 * Valid range is from 0 to 499.
+	 *
+	 * @return The slave latency value.
+	 */
+	public int getLatency() {
+		return latency;
+	}
+
+	/**
+	 * Returns the supervision timeout for this connection, in 10ms unit.
+	 * Valid range is from 10 (100 ms = 0.1s) to 3200 (32s).
+	 *
+	 * @return Supervision timeout for this connection, in 10ms unit.
+	 */
+	public int getTimeout() {
+		return timeout;
+	}
+
+	/**
+	 * Returns the supervision timeout for this connection, in milliseconds.
+	 * Valid range is from 100 ms 32s.
+	 *
+	 * @return Supervision timeout for this connection, in 10ms unit.
+	 */
+	public long getTimeoutInMs() {
+		return timeout * 10L; // ms
+	}
+
+	/**
+	 * Returns the current MTU. The maximum number of bytes that can be sent in a single GATT
+	 * operation is MTU-3, as 3 bytes are used for handle number and operation.
+	 *
+	 * @return The MTU.
+	 */
+	public int getMtu() {
+		return mtu;
+	}
+
+	/**
+	 * Returns the current McuMgr buffer size used in this connection.
+	 * The buffer allows to send longer SMP packets than MTU using the SAR mechanism (Segmentation
+	 * and Reassembly).
+	 *
+	 * @return The buffers size in bytes. If SAR is not supported (pre-NCS 2.0 devices) this is
+	 *         equal to MTU.
+	 */
+	public int getBufferSize() {
+		return bufferSize;
+	}
+
+	/**
+	 * Returns the current TX PHY.
+	 *
+	 * @return The current TX PHY.
+	 */
+	@PhyValue
+	public int getTxPhy() {
+		return txPhy;
+	}
+
+	/**
+	 * Returns the current RX PHY.
+	 *
+	 * @return The current RX PHY.
+	 */
+	@PhyValue
+	public int getRxPhy() {
+		return rxPhy;
+	}
+}

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -6,8 +6,12 @@
 
 package io.runtime.mcumgr.sample.viewmodel.mcumgr;
 
+import android.os.Build;
 import android.util.Pair;
 
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.SystemClock;
 import java.util.Collections;
 import java.util.List;
 
@@ -15,6 +19,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import io.runtime.mcumgr.McuMgrTransport;
@@ -24,9 +29,10 @@ import io.runtime.mcumgr.dfu.FirmwareUpgradeController;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.image.McuMgrImage;
+import io.runtime.mcumgr.sample.observable.ConnectionParameters;
+import io.runtime.mcumgr.sample.observable.ObservableMcuMgrBleTransport;
 import io.runtime.mcumgr.sample.utils.ZipPackage;
 import io.runtime.mcumgr.sample.viewmodel.SingleLiveEvent;
-import kotlin.Triple;
 import no.nordicsemi.android.ble.ConnectionPriorityRequest;
 import timber.log.Timber;
 
@@ -56,41 +62,38 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
 
     public static class ThroughputData {
         public int progress;
-        public float instantaneousThroughput;
         public float averageThroughput;
 
-        public ThroughputData(final int progress, final float instantaneousThroughput, final float averageThroughput) {
+        public ThroughputData(final int progress, final float averageThroughput) {
             this.progress = progress;
-            this.instantaneousThroughput = instantaneousThroughput;
             this.averageThroughput = averageThroughput;
         }
     }
 
     private final FirmwareUpgradeManager manager;
+	private final Handler handler;
 
     private final MutableLiveData<State> stateLiveData = new MutableLiveData<>();
     private final MutableLiveData<ThroughputData> progressLiveData = new MutableLiveData<>();
     private final MutableLiveData<Boolean> advancedSettingsExpanded = new MutableLiveData<>();
-    private final SingleLiveEvent<McuMgrException> errorLiveData = new SingleLiveEvent<>();
+    private final MutableLiveData<McuMgrException> errorLiveData = new MutableLiveData<>();
     private final SingleLiveEvent<Void> cancelledEvent = new SingleLiveEvent<>();
 
-    private long uploadStartTimestamp, lastProgressChangeTimestamp;
-    private int initialBytesSent, lastProgressChangeBytesSent, lastProgress;
+    private long uploadStartTimestamp;
+	private int imageSize, bytesSent, bytesSentSinceUploadStated, lastProgress;
     /** A value indicating that the upload has not been started before. */
     private final static int NOT_STARTED = -1;
-    /**
-     * The minimum time interval prevents from sharp peaks on the throughput graph.
-     * Otherwise it may happen that the bytes are sent in a single connection interval and the
-     * time, for which we divide the number of bytes, is very low and the throughput skyrockets.
-     */
-    private static final float MIN_INTERVAL = 36.0f;
+	/** How often the throughput data should be sent to the graph. */
+	private final static long REFRESH_RATE = 100L; /* ms */
 
     @Inject
-    ImageUpgradeViewModel(final FirmwareUpgradeManager manager,
-                          @Named("busy") final MutableLiveData<Boolean> state) {
+    ImageUpgradeViewModel(@NonNull final FirmwareUpgradeManager manager,
+						  @NonNull final HandlerThread thread,
+                          @NonNull @Named("busy") final MutableLiveData<Boolean> state) {
         super(state);
         this.manager = manager;
         this.manager.setFirmwareUpgradeCallback(this);
+        this.handler = new Handler(thread.getLooper());
 
         stateLiveData.setValue(State.IDLE);
         progressLiveData.setValue(null);
@@ -122,6 +125,15 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
     @NonNull
     public LiveData<ThroughputData> getProgress() {
         return progressLiveData;
+    }
+
+    @Nullable
+    public LiveData<ConnectionParameters> getConnectionParameters() {
+        final McuMgrTransport transport = manager.getTransporter();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && transport instanceof ObservableMcuMgrBleTransport) {
+            return ((ObservableMcuMgrBleTransport) transport).getConnectionParameters();
+        }
+        return null;
     }
 
     @NonNull
@@ -186,6 +198,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
 
     public void pause() {
         if (manager.isInProgress()) {
+            handler.removeCallbacks(graphUpdater);
             stateLiveData.postValue(State.PAUSED);
             manager.pause();
             Timber.i("Upload paused");
@@ -199,7 +212,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
             setBusy();
             stateLiveData.postValue(State.UPLOADING);
             Timber.i("Upload resumed");
-            initialBytesSent = NOT_STARTED;
+            bytesSentSinceUploadStated = NOT_STARTED;
             setLoggingEnabled(false);
             manager.resume();
         }
@@ -225,13 +238,15 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
         switch (newState) {
             case UPLOAD:
                 Timber.i("Uploading firmware...");
-                initialBytesSent = NOT_STARTED;
+                bytesSentSinceUploadStated = NOT_STARTED;
                 stateLiveData.postValue(State.UPLOADING);
                 break;
             case TEST:
+                handler.removeCallbacks(graphUpdater);
                 stateLiveData.postValue(State.TESTING);
                 break;
             case CONFIRM:
+                handler.removeCallbacks(graphUpdater);
                 stateLiveData.postValue(State.CONFIRMING);
                 break;
             case RESET:
@@ -240,69 +255,74 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
         }
     }
 
+    private final Runnable graphUpdater = new Runnable() {
+        @Override
+        public void run() {
+            if (manager.getState() != FirmwareUpgradeManager.State.UPLOAD || manager.isPaused()) {
+                return;
+            }
+
+            final long timestamp = SystemClock.uptimeMillis();
+            // Calculate the current upload progress.
+            final int progress = (int) (bytesSent * 100.f /* % */ / imageSize);
+            if (lastProgress != progress) {
+                lastProgress = progress;
+
+                // Calculate the average throughout.
+                // This is done by diving number of bytes sent since upload has been started (or resumed)
+                // by the time since that moment. The minimum time of MIN_INTERVAL ms prevents from
+                // graph peaks that may happen when .
+                final float bytesSentSinceUploadStarted = bytesSent - bytesSentSinceUploadStated;
+                final float timeSinceUploadStarted = timestamp - uploadStartTimestamp;
+                final float averageThroughput = bytesSentSinceUploadStarted / timeSinceUploadStarted; // bytes / ms = KB/s
+
+                progressLiveData.postValue(new ThroughputData(progress, averageThroughput));
+            }
+
+            if (manager.getState() == FirmwareUpgradeManager.State.UPLOAD && !manager.isPaused()) {
+                handler.postAtTime(this, timestamp + REFRESH_RATE);
+            }
+        }
+    };
+
     @Override
     public void onUploadProgressChanged(final int bytesSent, final int imageSize, final long timestamp) {
-        // Calculate the current upload progress.
-        final int progress = (int) (bytesSent * 100.f / imageSize);
+        this.imageSize = imageSize;
+        this.bytesSent = bytesSent;
 
-        float averageThroughput = 0.0f;
-        float instantaneousThroughput = 0.0f;
+        final long uptimeMillis = SystemClock.uptimeMillis();
 
         // Check if this is the first time this method is called since:
         // - the start of an upload
         // - after resume
-        if (initialBytesSent == NOT_STARTED) {
+        if (bytesSentSinceUploadStated == NOT_STARTED) {
+            lastProgress = NOT_STARTED;
+
             // If a new image started being sending, clear the progress graph.
-            if (lastProgress > progress) {
-                progressLiveData.postValue(null);
-            }
-            lastProgress = progress;
+            progressLiveData.postValue(null);
 
             // To calculate the throughput it is necessary to store the initial timestamp and
             // the number of bytes sent so far. Mind, that the upload may be resumed from any point,
             // not necessarily from the beginning.
-            uploadStartTimestamp = timestamp;
-            initialBytesSent = bytesSent;
-            // The instantaneous throughput is calculated each time the integer percentage value
-            // of the progress changes.
-            lastProgressChangeTimestamp = timestamp;
-            lastProgressChangeBytesSent = bytesSent;
-        } else {
-            // Calculate the average throughout.
-            // This is done by diving number of bytes sent since upload has been started (or resumed)
-            // by the time since that moment. The minimum time of MIN_INTERVAL ms prevents from
-            // graph peaks that are not seen in reality during tests.
-            final float bytesSentSinceUploadStarted = bytesSent - initialBytesSent;
-            final float timeSinceUploadStarted = Math.max(MIN_INTERVAL, timestamp - uploadStartTimestamp);
-            averageThroughput = bytesSentSinceUploadStarted / timeSinceUploadStarted; // bytes / ms = KB/s
+            uploadStartTimestamp = uptimeMillis;
+            bytesSentSinceUploadStated = bytesSent;
 
-            // If the progress has changed, calculate the instantaneous throughput.
-            if (lastProgress != progress) {
-                lastProgress = progress;
-
-                // Just like for the average throughput, this is calculated by diving number of
-                // bytes sent since last progress change by the time since the change.
-                final float bytesSentSinceProgressChanged = bytesSent - lastProgressChangeBytesSent;
-                final float timeSinceProgressChanged = Math.max(MIN_INTERVAL, timestamp - lastProgressChangeTimestamp);
-                instantaneousThroughput = bytesSentSinceProgressChanged / timeSinceProgressChanged; // bytes / ms = KB/s
-
-                // And reset the counters.
-                lastProgressChangeTimestamp = timestamp;
-                lastProgressChangeBytesSent = bytesSent;
-
-                progressLiveData.postValue(new ThroughputData(progress, instantaneousThroughput, averageThroughput));
-            }
+            // Begin updating the graph.
+            handler.removeCallbacks(graphUpdater);
+            handler.postAtTime(graphUpdater, uptimeMillis + REFRESH_RATE);
         }
         // When done, reset the counter.
         if (bytesSent == imageSize) {
             Timber.i("Image (%d bytes) sent in %d ms (avg speed: %f kB/s)",
-                    imageSize - initialBytesSent,
-                    timestamp - uploadStartTimestamp,
-                    (float) (imageSize - initialBytesSent) / (float) (timestamp - uploadStartTimestamp)
+                    imageSize - bytesSentSinceUploadStated,
+                    uptimeMillis - uploadStartTimestamp,
+                    (float) (imageSize - bytesSentSinceUploadStated) / (float) (uptimeMillis - uploadStartTimestamp)
             );
+            // Finish the graph.
+            graphUpdater.run();
             // Reset the initial bytes counter, so if there is a next image uploaded afterwards,
             // it will start the throughput calculations again.
-            initialBytesSent = NOT_STARTED;
+            bytesSentSinceUploadStated = NOT_STARTED;
         }
     }
 
@@ -316,6 +336,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
 
     @Override
     public void onUpgradeCanceled(final FirmwareUpgradeManager.State state) {
+        handler.removeCallbacks(graphUpdater);
         progressLiveData.postValue(null);
         stateLiveData.postValue(State.IDLE);
         cancelledEvent.post();
@@ -326,7 +347,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
 
     @Override
     public void onUpgradeFailed(final FirmwareUpgradeManager.State state, final McuMgrException error) {
-        progressLiveData.postValue(null);
+        handler.removeCallbacks(graphUpdater);
         errorLiveData.postValue(error);
         setLoggingEnabled(true);
         Timber.e(error, "Upgrade failed");

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -168,7 +168,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
             // (https://github.com/zephyrproject-rtos/zephyr/blob/bd4ddec0c8c822bbdd420bd558b62c1d1a532c16/subsys/mgmt/mcumgr/Kconfig#L550)
             // parameter in KConfig in NCS / Zephyr configuration and should also be supported
             // on Mynewt devices.
-            // Mind, that in Zephyr, before https://github.com/zephyrproject-rtos/zephyr/pull/41959
+            // Mind, that in Zephyr,  before https://github.com/zephyrproject-rtos/zephyr/pull/41959
             // was merged, the device required data to be sent with memory alignment. Otherwise,
             // the device would ignore uneven bytes and reply with lower than expected offset
             // causing multiple packets to be sent again dropping the speed instead of increasing it.

--- a/sample/src/main/res/layout/fragment_card_image_upgrade.xml
+++ b/sample/src/main/res/layout/fragment_card_image_upgrade.xml
@@ -152,6 +152,9 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:hint="@string/image_upgrade_swap_time"
+            app:suffixText="seconds"
+            app:suffixTextColor="@color/colorSecondary"
+            android:importantForAutofill="no"
             app:layout_constraintEnd_toStartOf="@+id/advanced_swap_time_info"
             app:layout_constraintStart_toStartOf="@+id/file_name_label"
             app:layout_constraintTop_toBottomOf="@+id/advanced_erase_settings">
@@ -181,6 +184,8 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:hint="@string/image_upgrade_pipeline"
+            android:importantForAutofill="no"
+            android:layout_marginTop="8dp"
             app:layout_constraintEnd_toStartOf="@+id/advanced_swap_time_info"
             app:layout_constraintStart_toStartOf="@+id/file_name_label"
             app:layout_constraintTop_toBottomOf="@+id/advanced_swap_time_layout">
@@ -211,6 +216,7 @@
             android:layout_height="wrap_content"
             android:hint="@string/image_upgrade_memory_alignment"
             android:paddingBottom="16dp"
+            android:layout_marginTop="8dp"
             app:layout_constraintEnd_toStartOf="@+id/advanced_memory_alignment_info"
             app:layout_constraintStart_toStartOf="@+id/file_name_label"
             app:layout_constraintTop_toBottomOf="@+id/advanced_pipeline_layout">

--- a/sample/src/main/res/values-night/colors.xml
+++ b/sample/src/main/res/values-night/colors.xml
@@ -22,7 +22,8 @@
     <color name="colorDestructiveDisabled">#8800</color>
 
     <color name="colorGraphGrid">#8888</color>
-    <color name="colorInstantaneousThroughput">@color/nordicBlue</color>
+    <color name="colorParams">@color/lightGray</color>
     <color name="colorAverageThroughput">@color/white</color>
+    <color name="colorInstantaneousThroughput">@color/nordicDarkGray</color>
 
 </resources>

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -21,8 +21,9 @@
     <color name="colorDestructive">#CC0000</color>
     <color name="colorDestructiveDisabled">#CCAAAA</color>
 
-    <color name="colorGraphGrid">#88CFD8DC</color>
-    <color name="colorInstantaneousThroughput">@color/nordicLightGray</color>
+    <color name="colorGraphGrid">#8888</color>
+    <color name="colorParams">@color/nordicBlue</color>
     <color name="colorAverageThroughput">@color/darkGray</color>
+    <color name="colorInstantaneousThroughput">@color/nordicLightGray</color>
 
 </resources>

--- a/sample/src/main/res/values/colors_nordic.xml
+++ b/sample/src/main/res/values/colors_nordic.xml
@@ -12,6 +12,11 @@
     <color name="nordicBlueDark">#FF0090B0</color>
     <color name="nordicLake">#FF0077C8</color>
     <color name="nordicRed">#FFEE2F4E</color>
+    <color name="nordicBlueslate">#FF0033a0</color>
+    <color name="nordicSky">#ff6ad1e3</color>
+    <color name="nordicSun">#FFffcd00</color>
+    <color name="nordicGrass">#FFd0df00</color>
+    <color name="nordicFall">#FFf58220</color>
     <color name="nordicLightGray">#FFD9E1E2</color>
     <color name="nordicDarkGray">#FF333F48</color>
 

--- a/sample/src/main/res/values/strings_image_upgrade.xml
+++ b/sample/src/main/res/values/strings_image_upgrade.xml
@@ -13,9 +13,11 @@
     <string name="image_upgrade_hash">Hash:</string>
     <string name="image_upgrade_status">State:</string>
     <string name="image_upgrade_speed">%.1f kB/s</string>
+    <string name="image_upgrade_ci">MTU: %d\nPHY: %s\nINTV: %.2f ms</string>
+    <string name="image_upgrade_ci_sar">MTU: %d (SAR: %d B)\nPHY: %s\nINTV: %.2f ms</string>
     <string name="image_upgrade_erase_storage">Erase application settings</string>
     <string name="image_upgrade_erase_storage_descr">About erase application settings feature</string>
-    <string name="image_upgrade_swap_time">Estimated swap time (in seconds)</string>
+    <string name="image_upgrade_swap_time">Estimated swap time</string>
     <string name="image_upgrade_swap_time_descr">About estimated swap time</string>
     <string name="image_upgrade_pipeline">Number of mcumgr buffers</string>
     <string name="image_upgrade_pipeline_descr">About pipelining</string>


### PR DESCRIPTION
This PR adds the throughput graph to Firmware Upgrade screen.

Features: 
1. Displays the average throughput in kB/s since the upload was started or resumed.
2. When clicked, shows additional information (available on Android 8+ only).

![obraz](https://user-images.githubusercontent.com/6576580/171875546-fd714287-0fb3-41ca-af77-f60d34a38411.png)

### Note

The calculated throughput is based on notifications received from the device being updated. Each notification contains an acknowledgement with number of bytes received so far. The sampling is done every 100 ms and there the graph shows up to 101 samples (one point per upload percent 0-100%).