### PR TITLE
Dependencies update and migration to BLE Library 2.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.github.gradle-nexus:publish-plugin:$gradle_nexus_publish_plugin"
     }

--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -31,13 +31,13 @@ dependencies {
     api project(':mcumgr-core')
 
     // Import the BLE Library
-    api 'no.nordicsemi.android:ble:2.5.0'
+    api 'no.nordicsemi.android:ble:2.5.1'
 
     // Logging
     implementation 'org.slf4j:slf4j-api:1.7.35'
 
     // Kotlin
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"

--- a/mcumgr-core/build.gradle
+++ b/mcumgr-core/build.gradle
@@ -27,18 +27,18 @@ android {
 
 dependencies {
     // Annotations
-    implementation 'org.jetbrains:annotations:22.0.0'
+    implementation 'org.jetbrains:annotations:23.0.0'
 
     // Logging
     implementation 'org.slf4j:slf4j-api:1.7.35'
 
     // Kotlin
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2'
 
     // Import CBOR parser
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.4'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.12.4'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.4'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.3'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.13.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
 
     // Test
     testImplementation 'junit:junit:4.13.2'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -61,11 +61,11 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0-alpha02'
 
     // Dagger 2
-    implementation 'com.google.dagger:dagger:2.40.5'
-    implementation 'com.google.dagger:dagger-android:2.40.5'
-    implementation 'com.google.dagger:dagger-android-support:2.40.5'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.40.5'
-    annotationProcessor 'com.google.dagger:dagger-android-processor:2.40.5'
+    implementation 'com.google.dagger:dagger:2.42'
+    implementation 'com.google.dagger:dagger-android:2.42'
+    implementation 'com.google.dagger:dagger-android-support:2.42'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.42'
+    annotationProcessor 'com.google.dagger:dagger-android-processor:2.42'
 
     // Brings the new BluetoothLeScanner API to older platforms
     implementation 'no.nordicsemi.android.support.v18:scanner:1.6.0'
@@ -78,7 +78,7 @@ dependencies {
     implementation project(':mcumgr-ble')
 
     // GSON
-    implementation 'com.google.code.gson:gson:2.8.9'
+    implementation 'com.google.code.gson:gson:2.9.0'
 
     // Test
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'


### PR DESCRIPTION
This PR updates dependencies.

The Android BLE Library in version 2.5.1 fixed an issue, where `onConnectionUpdated` callback was being removed by proguard. Because of that, the "additional throughput info" added in 1.3 of nRF Connect Device Manager were not available in production release.