### PR TITLE
Resetting max packet length on disconnection

### DIFF
--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -722,6 +722,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
             mSmpProtocol = null;
             mSmpCharacteristicWrite = null;
             mSmpCharacteristicNotify = null;
+            mMaxPacketLength = 0;
             McuMgrBleTransport.this.onServicesInvalidated();
             runOnCallbackThread(McuMgrBleTransport.this::notifyDisconnected);
         }


### PR DESCRIPTION
This PR fixes an issue happening when the same BLE Transport is used and the device responds with different packet lengths. This usually doesn't happen, but may during development.