### PR TITLE
Option to set a per-command timeout

### DIFF
--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -316,10 +316,11 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
     @NonNull
     @Override
     public <T extends McuMgrResponse> T send(@NonNull final byte[] payload,
+                                             long timeout,
                                              @NonNull final Class<T> responseType)
             throws McuMgrException {
         final ResultCondition<T> condition = new ResultCondition<>(false);
-        send(payload, responseType, new McuMgrCallback<T>() {
+        send(payload, timeout, responseType, new McuMgrCallback<T>() {
             @Override
             public void onResponse(@NonNull T response) {
                 condition.open(response);
@@ -335,6 +336,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
 
     @Override
     public <T extends McuMgrResponse> void send(@NonNull final byte[] payload,
+                                                final long timeout,
                                                 @NonNull final Class<T> responseType,
                                                 @NonNull final McuMgrCallback<T> callback) {
 
@@ -356,7 +358,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
 
                     // Send a new transaction to the protocol layer
                     final SmpProtocolSession session = mSmpProtocol;
-                    session.send(payload, new SmpTransaction() {
+                    session.send(payload, timeout, new SmpTransaction() {
                         @Override
                         public void send(@NonNull byte[] data) {
                             if (getMinLogPriority() <= Log.INFO) {
@@ -510,7 +512,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
      * Calling this method with priority {@link BluetoothGatt#CONNECTION_PRIORITY_HIGH} may
      * improve file transfer speed.
      * <p>
-     * Similarly to {@link #send(byte[], Class)}, this method will connect automatically
+     * Similarly to {@link #send(byte[], long, Class)}, this method will connect automatically
      * to the device if not connected.
      *
      * @param priority one of: {@link BluetoothGatt#CONNECTION_PRIORITY_HIGH},

--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -36,6 +36,7 @@ import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.ble.callback.SmpMerger;
 import io.runtime.mcumgr.ble.callback.SmpProtocolSession;
 import io.runtime.mcumgr.ble.callback.SmpTransaction;
+import io.runtime.mcumgr.ble.callback.TransactionTimeoutException;
 import io.runtime.mcumgr.ble.exception.McuMgrBluetoothDisabledException;
 import io.runtime.mcumgr.ble.exception.McuMgrDisconnectedException;
 import io.runtime.mcumgr.ble.exception.McuMgrNotSupportedException;
@@ -404,6 +405,8 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                         public void onFailure(@NonNull Throwable e) {
                             if (e instanceof McuMgrException) {
                                 callback.onError((McuMgrException) e);
+                            } else if (e instanceof TransactionTimeoutException) {
+                                callback.onError(new McuMgrTimeoutException(e));
                             } else {
                                 callback.onError(new McuMgrException(e));
                             }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/McuMgrTransport.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/McuMgrTransport.java
@@ -80,13 +80,16 @@ public interface McuMgrTransport {
      * response has been received or a error has occurred.
      *
      * @param payload      the request packet data to send to the device.
+     * @param timeout      the timeout for receiving a response for the packet, in milliseconds.
      * @param responseType the response type.
      * @param <T>          the response type.
      * @return The response.
      * @throws McuMgrException thrown on error. Set the cause of the error if caused by a different
      *                         type of exception.
      */
-    @NotNull <T extends McuMgrResponse> T send(byte @NotNull [] payload, @NotNull Class<T> responseType)
+    @NotNull <T extends McuMgrResponse> T send(byte @NotNull [] payload,
+                                               long timeout,
+                                               @NotNull Class<T> responseType)
             throws McuMgrException;
 
     /**
@@ -95,11 +98,14 @@ public interface McuMgrTransport {
      * be called.
      *
      * @param payload      the request packet data to send to the device.
+     * @param timeout      the timeout for receiving a response for the packet, in milliseconds.
      * @param responseType the response type.
      * @param callback     the callback to call on response or error.
      * @param <T>          the response type.
      */
-    <T extends McuMgrResponse> void send(byte @NotNull [] payload, @NotNull Class<T> responseType,
+    <T extends McuMgrResponse> void send(byte @NotNull [] payload,
+                                         long timeout,
+                                         @NotNull Class<T> responseType,
                                          @NotNull McuMgrCallback<T> callback);
 
     /**

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/McuMgrTimeoutException.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/McuMgrTimeoutException.java
@@ -11,4 +11,11 @@ package io.runtime.mcumgr.exception;
  * time run out.
  */
 public class McuMgrTimeoutException extends McuMgrException {
+
+	public McuMgrTimeoutException() {
+	}
+
+	public McuMgrTimeoutException(Throwable cause) {
+		super(cause);
+	}
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/BasicManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/BasicManager.java
@@ -39,7 +39,7 @@ public class BasicManager extends McuManager {
      * @param callback the asynchronous callback.
      */
     public void eraseStorage(@NotNull McuMgrCallback<McuMgrResponse> callback) {
-        send(OP_WRITE, ID_ERASE_STORAGE, null, McuMgrResponse.class, callback);
+        send(OP_WRITE, ID_ERASE_STORAGE, null, DEFAULT_TIMEOUT, McuMgrResponse.class, callback);
     }
 
     /**
@@ -50,6 +50,6 @@ public class BasicManager extends McuManager {
      */
     @NotNull
     public McuMgrResponse eraseStorage() throws McuMgrException {
-        return send(OP_WRITE, ID_ERASE_STORAGE, null, McuMgrResponse.class);
+        return send(OP_WRITE, ID_ERASE_STORAGE, null, DEFAULT_TIMEOUT, McuMgrResponse.class);
     }
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ConfigManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ConfigManager.java
@@ -45,7 +45,7 @@ public class ConfigManager extends McuManager {
                      @NotNull McuMgrCallback<McuMgrConfigReadResponse> callback) {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("name", name);
-        send(OP_READ, ID_CONFIG, payloadMap, McuMgrConfigReadResponse.class, callback);
+        send(OP_READ, ID_CONFIG, payloadMap, SHORT_TIMEOUT, McuMgrConfigReadResponse.class, callback);
     }
 
     /**
@@ -59,7 +59,7 @@ public class ConfigManager extends McuManager {
     public McuMgrConfigReadResponse read(@Nullable String name) throws McuMgrException {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("name", name);
-        return send(OP_READ, ID_CONFIG, payloadMap, McuMgrConfigReadResponse.class);
+        return send(OP_READ, ID_CONFIG, payloadMap, SHORT_TIMEOUT, McuMgrConfigReadResponse.class);
     }
 
     /**
@@ -77,7 +77,7 @@ public class ConfigManager extends McuManager {
         payloadMap.put("name", name);
         payloadMap.put("val", value);
         payloadMap.put("save", save);
-        send(OP_WRITE, ID_CONFIG, payloadMap, McuMgrResponse.class, callback);
+        send(OP_WRITE, ID_CONFIG, payloadMap, SHORT_TIMEOUT, McuMgrResponse.class, callback);
     }
 
     /**
@@ -97,6 +97,6 @@ public class ConfigManager extends McuManager {
         payloadMap.put("name", name);
         payloadMap.put("val", value);
         payloadMap.put("save", save);
-        return send(OP_WRITE, ID_CONFIG, payloadMap, McuMgrResponse.class);
+        return send(OP_WRITE, ID_CONFIG, payloadMap, SHORT_TIMEOUT, McuMgrResponse.class);
     }
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/CrashManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/CrashManager.java
@@ -61,7 +61,7 @@ public class CrashManager extends McuManager {
     public McuMgrResponse test(@NotNull Test test) throws McuMgrException {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("t", test.toString());
-        return send(OP_WRITE, ID_CRASH_TEST, payloadMap, McuMgrConfigReadResponse.class);
+        return send(OP_WRITE, ID_CRASH_TEST, payloadMap, SHORT_TIMEOUT, McuMgrConfigReadResponse.class);
     }
 
     /**
@@ -72,6 +72,6 @@ public class CrashManager extends McuManager {
     public void test(@NotNull Test test, @NotNull McuMgrCallback<McuMgrResponse> callback) {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("t", test.toString());
-        send(OP_WRITE, ID_CRASH_TEST, payloadMap, McuMgrResponse.class, callback);
+        send(OP_WRITE, ID_CRASH_TEST, payloadMap, SHORT_TIMEOUT, McuMgrResponse.class, callback);
     }
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/DefaultManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/DefaultManager.java
@@ -62,7 +62,7 @@ public class DefaultManager extends McuManager {
     public void echo(@Nullable String echo, @NotNull McuMgrCallback<McuMgrEchoResponse> callback) {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("d", echo);
-        send(OP_WRITE, ID_ECHO, payloadMap, McuMgrEchoResponse.class, callback);
+        send(OP_WRITE, ID_ECHO, payloadMap, SHORT_TIMEOUT, McuMgrEchoResponse.class, callback);
     }
 
     /**
@@ -76,7 +76,7 @@ public class DefaultManager extends McuManager {
     public McuMgrEchoResponse echo(@Nullable String echo) throws McuMgrException {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("d", echo);
-        return send(OP_WRITE, ID_ECHO, payloadMap, McuMgrEchoResponse.class);
+        return send(OP_WRITE, ID_ECHO, payloadMap, SHORT_TIMEOUT, McuMgrEchoResponse.class);
     }
 
     /**
@@ -88,7 +88,7 @@ public class DefaultManager extends McuManager {
     public void consoleEcho(boolean echo, @NotNull McuMgrCallback<McuMgrResponse> callback) {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("echo", echo);
-        send(OP_WRITE, ID_CONS_ECHO_CTRL, payloadMap, McuMgrResponse.class, callback);
+        send(OP_WRITE, ID_CONS_ECHO_CTRL, payloadMap, SHORT_TIMEOUT, McuMgrResponse.class, callback);
     }
 
     /**
@@ -102,7 +102,7 @@ public class DefaultManager extends McuManager {
     public McuMgrResponse consoleEcho(boolean echo) throws McuMgrException {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("echo", echo);
-        return send(OP_WRITE, ID_CONS_ECHO_CTRL, payloadMap, McuMgrResponse.class);
+        return send(OP_WRITE, ID_CONS_ECHO_CTRL, payloadMap, SHORT_TIMEOUT, McuMgrResponse.class);
     }
 
     /**
@@ -111,7 +111,7 @@ public class DefaultManager extends McuManager {
      * @param callback the asynchronous callback.
      */
     public void taskstats(@NotNull McuMgrCallback<McuMgrTaskStatResponse> callback) {
-        send(OP_READ, ID_TASKSTATS, null, McuMgrTaskStatResponse.class, callback);
+        send(OP_READ, ID_TASKSTATS, null, SHORT_TIMEOUT, McuMgrTaskStatResponse.class, callback);
     }
 
     /**
@@ -122,7 +122,7 @@ public class DefaultManager extends McuManager {
      */
     @NotNull
     public McuMgrTaskStatResponse taskstats() throws McuMgrException {
-        return send(OP_READ, ID_TASKSTATS, null, McuMgrTaskStatResponse.class);
+        return send(OP_READ, ID_TASKSTATS, null, SHORT_TIMEOUT, McuMgrTaskStatResponse.class);
     }
 
     /**
@@ -131,7 +131,7 @@ public class DefaultManager extends McuManager {
      * @param callback the asynchronous callback.
      */
     public void mpstat(@NotNull McuMgrCallback<McuMgrMpStatResponse> callback) {
-        send(OP_READ, ID_MPSTATS, null, McuMgrMpStatResponse.class, callback);
+        send(OP_READ, ID_MPSTATS, null, SHORT_TIMEOUT, McuMgrMpStatResponse.class, callback);
     }
 
     /**
@@ -142,7 +142,7 @@ public class DefaultManager extends McuManager {
      */
     @NotNull
     public McuMgrMpStatResponse mpstat() throws McuMgrException {
-        return send(OP_READ, ID_MPSTATS, null, McuMgrMpStatResponse.class);
+        return send(OP_READ, ID_MPSTATS, null, SHORT_TIMEOUT, McuMgrMpStatResponse.class);
     }
 
     /**
@@ -151,7 +151,7 @@ public class DefaultManager extends McuManager {
      * @param callback the asynchronous callback.
      */
     public void readDatetime(@NotNull McuMgrCallback<McuMgrReadDateTimeResponse> callback) {
-        send(OP_READ, ID_DATETIME_STR, null, McuMgrReadDateTimeResponse.class, callback);
+        send(OP_READ, ID_DATETIME_STR, null, SHORT_TIMEOUT, McuMgrReadDateTimeResponse.class, callback);
     }
 
     /**
@@ -162,7 +162,7 @@ public class DefaultManager extends McuManager {
      */
     @NotNull
     public McuMgrReadDateTimeResponse readDatetime() throws McuMgrException {
-        return send(OP_READ, ID_DATETIME_STR, null, McuMgrReadDateTimeResponse.class);
+        return send(OP_READ, ID_DATETIME_STR, null, SHORT_TIMEOUT, McuMgrReadDateTimeResponse.class);
     }
 
     /**
@@ -178,7 +178,7 @@ public class DefaultManager extends McuManager {
                               @NotNull McuMgrCallback<McuMgrResponse> callback) {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("datetime", dateToString(date, timeZone));
-        send(OP_WRITE, ID_DATETIME_STR, payloadMap, McuMgrResponse.class, callback);
+        send(OP_WRITE, ID_DATETIME_STR, payloadMap, SHORT_TIMEOUT, McuMgrResponse.class, callback);
     }
 
     /**
@@ -196,7 +196,7 @@ public class DefaultManager extends McuManager {
             throws McuMgrException {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("datetime", dateToString(date, timeZone));
-        return send(OP_WRITE, ID_DATETIME_STR, payloadMap, McuMgrResponse.class);
+        return send(OP_WRITE, ID_DATETIME_STR, payloadMap, SHORT_TIMEOUT, McuMgrResponse.class);
     }
 
     /**
@@ -205,7 +205,7 @@ public class DefaultManager extends McuManager {
      * @param callback the asynchronous callback.
      */
     public void reset(@NotNull McuMgrCallback<McuMgrResponse> callback) {
-        send(OP_WRITE, ID_RESET, null, McuMgrResponse.class, callback);
+        send(OP_WRITE, ID_RESET, null, SHORT_TIMEOUT, McuMgrResponse.class, callback);
     }
 
     /**
@@ -216,7 +216,7 @@ public class DefaultManager extends McuManager {
      */
     @NotNull
     public McuMgrResponse reset() throws McuMgrException {
-        return send(OP_WRITE, ID_RESET, null, McuMgrResponse.class);
+        return send(OP_WRITE, ID_RESET, null, SHORT_TIMEOUT, McuMgrResponse.class);
     }
 
     /**
@@ -225,7 +225,7 @@ public class DefaultManager extends McuManager {
      * @param callback the asynchronous callback.
      */
     public void params(@NotNull McuMgrCallback<McuMgrParamsResponse> callback) {
-        send(OP_READ, ID_MCUMGR_PARAMS, null, McuMgrParamsResponse.class, callback);
+        send(OP_READ, ID_MCUMGR_PARAMS, null, SHORT_TIMEOUT, McuMgrParamsResponse.class, callback);
     }
 
     /**
@@ -236,6 +236,6 @@ public class DefaultManager extends McuManager {
      */
     @NotNull
     public McuMgrResponse params() throws McuMgrException {
-        return send(OP_READ, ID_MCUMGR_PARAMS, null, McuMgrParamsResponse.class);
+        return send(OP_READ, ID_MCUMGR_PARAMS, null, SHORT_TIMEOUT, McuMgrParamsResponse.class);
     }
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/FsManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/FsManager.java
@@ -64,7 +64,7 @@ public class FsManager extends TransferManager {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("name", name);
         payloadMap.put("off", offset);
-        send(OP_READ, ID_FILE, payloadMap, McuMgrFsDownloadResponse.class, callback);
+        send(OP_READ, ID_FILE, payloadMap, SHORT_TIMEOUT, McuMgrFsDownloadResponse.class, callback);
     }
 
     /**
@@ -84,7 +84,7 @@ public class FsManager extends TransferManager {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("name", name);
         payloadMap.put("off", offset);
-        return send(OP_READ, ID_FILE, payloadMap, McuMgrFsDownloadResponse.class);
+        return send(OP_READ, ID_FILE, payloadMap, SHORT_TIMEOUT, McuMgrFsDownloadResponse.class);
     }
 
     /**
@@ -106,7 +106,7 @@ public class FsManager extends TransferManager {
     public void upload(@NotNull String name, byte @NotNull [] data, int offset,
                        @NotNull McuMgrCallback<McuMgrFsUploadResponse> callback) {
         HashMap<String, Object> payloadMap = buildUploadPayload(name, data, offset);
-        send(OP_WRITE, ID_FILE, payloadMap, McuMgrFsUploadResponse.class, callback);
+        send(OP_WRITE, ID_FILE, payloadMap, SHORT_TIMEOUT, McuMgrFsUploadResponse.class, callback);
     }
 
     /**
@@ -129,7 +129,7 @@ public class FsManager extends TransferManager {
     public McuMgrFsUploadResponse upload(@NotNull String name, byte @NotNull [] data, int offset)
             throws McuMgrException {
         HashMap<String, Object> payloadMap = buildUploadPayload(name, data, offset);
-        return send(OP_WRITE, ID_FILE, payloadMap, McuMgrFsUploadResponse.class);
+        return send(OP_WRITE, ID_FILE, payloadMap, SHORT_TIMEOUT, McuMgrFsUploadResponse.class);
     }
 
     /*

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
@@ -51,7 +51,7 @@ import io.runtime.mcumgr.util.CBOR;
  *
  * @see FirmwareUpgradeManager
  */
-@SuppressWarnings({"unused", "WeakerAccess", "deprecation", "DeprecatedIsStillUsed"})
+@SuppressWarnings({"unused", "WeakerAccess"})
 public class ImageManager extends TransferManager {
 
     private final static Logger LOG = LoggerFactory.getLogger(ImageManager.class);
@@ -85,7 +85,7 @@ public class ImageManager extends TransferManager {
      * @param callback the asynchronous callback.
      */
     public void list(@NotNull McuMgrCallback<McuMgrImageStateResponse> callback) {
-        send(OP_READ, ID_STATE, null, McuMgrImageStateResponse.class, callback);
+        send(OP_READ, ID_STATE, null, SHORT_TIMEOUT, McuMgrImageStateResponse.class, callback);
     }
 
     /**
@@ -98,7 +98,7 @@ public class ImageManager extends TransferManager {
      */
     @NotNull
     public McuMgrImageStateResponse list() throws McuMgrException {
-        return send(OP_READ, ID_STATE, null, McuMgrImageStateResponse.class);
+        return send(OP_READ, ID_STATE, null, SHORT_TIMEOUT, McuMgrImageStateResponse.class);
     }
 
     /**
@@ -145,7 +145,7 @@ public class ImageManager extends TransferManager {
     public void upload(byte @NotNull [] data, int offset, int image,
                        @NotNull McuMgrCallback<McuMgrImageUploadResponse> callback) {
         HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, image);
-        send(OP_WRITE, ID_UPLOAD, payloadMap, McuMgrImageUploadResponse.class, callback);
+        send(OP_WRITE, ID_UPLOAD, payloadMap, SHORT_TIMEOUT, McuMgrImageUploadResponse.class, callback);
     }
 
     /**
@@ -191,7 +191,7 @@ public class ImageManager extends TransferManager {
     public McuMgrImageUploadResponse upload(byte @NotNull [] data, int offset, int image)
             throws McuMgrException {
         HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, image);
-        return send(OP_WRITE, ID_UPLOAD, payloadMap, McuMgrImageUploadResponse.class);
+        return send(OP_WRITE, ID_UPLOAD, payloadMap, SHORT_TIMEOUT, McuMgrImageUploadResponse.class);
     }
 
     /*
@@ -248,7 +248,7 @@ public class ImageManager extends TransferManager {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("hash", hash);
         payloadMap.put("confirm", false);
-        send(OP_WRITE, ID_STATE, payloadMap, McuMgrImageStateResponse.class, callback);
+        send(OP_WRITE, ID_STATE, payloadMap, SHORT_TIMEOUT, McuMgrImageStateResponse.class, callback);
     }
 
     /**
@@ -266,7 +266,7 @@ public class ImageManager extends TransferManager {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("hash", hash);
         payloadMap.put("confirm", false);
-        return send(OP_WRITE, ID_STATE, payloadMap, McuMgrImageStateResponse.class);
+        return send(OP_WRITE, ID_STATE, payloadMap, SHORT_TIMEOUT, McuMgrImageStateResponse.class);
     }
 
     /**
@@ -285,7 +285,7 @@ public class ImageManager extends TransferManager {
         if (hash != null) {
             payloadMap.put("hash", hash);
         }
-        send(OP_WRITE, ID_STATE, payloadMap, McuMgrImageStateResponse.class, callback);
+        send(OP_WRITE, ID_STATE, payloadMap, SHORT_TIMEOUT, McuMgrImageStateResponse.class, callback);
     }
 
     /**
@@ -306,7 +306,7 @@ public class ImageManager extends TransferManager {
         if (hash != null) {
             payloadMap.put("hash", hash);
         }
-        return send(OP_WRITE, ID_STATE, payloadMap, McuMgrImageStateResponse.class);
+        return send(OP_WRITE, ID_STATE, payloadMap, SHORT_TIMEOUT, McuMgrImageStateResponse.class);
     }
 
     /**
@@ -330,7 +330,7 @@ public class ImageManager extends TransferManager {
             payloadMap = new HashMap<>();
             payloadMap.put("image", image);
         }
-        send(OP_WRITE, ID_ERASE, payloadMap, McuMgrResponse.class, callback);
+        send(OP_WRITE, ID_ERASE, payloadMap, DEFAULT_TIMEOUT, McuMgrResponse.class, callback);
     }
 
     /**
@@ -358,7 +358,7 @@ public class ImageManager extends TransferManager {
             payloadMap = new HashMap<>();
             payloadMap.put("image", image);
         }
-        return send(OP_WRITE, ID_ERASE, payloadMap, McuMgrResponse.class);
+        return send(OP_WRITE, ID_ERASE, payloadMap, DEFAULT_TIMEOUT, McuMgrResponse.class);
     }
 
     /**
@@ -382,7 +382,7 @@ public class ImageManager extends TransferManager {
             payloadMap = new HashMap<>();
             payloadMap.put("image", image);
         }
-        send(OP_WRITE, ID_ERASE_STATE, payloadMap, McuMgrResponse.class, callback);
+        send(OP_WRITE, ID_ERASE_STATE, payloadMap, DEFAULT_TIMEOUT, McuMgrResponse.class, callback);
     }
 
     /**
@@ -410,7 +410,7 @@ public class ImageManager extends TransferManager {
             payloadMap = new HashMap<>();
             payloadMap.put("image", image);
         }
-        return send(OP_WRITE, ID_ERASE_STATE, payloadMap, McuMgrResponse.class);
+        return send(OP_WRITE, ID_ERASE_STATE, payloadMap, SHORT_TIMEOUT, McuMgrResponse.class);
     }
 
     /**
@@ -423,7 +423,7 @@ public class ImageManager extends TransferManager {
      * @param callback the asynchronous callback.
      */
     public void coreList(@NotNull McuMgrCallback<McuMgrResponse> callback) {
-        send(OP_READ, ID_CORELIST, null, McuMgrResponse.class, callback);
+        send(OP_READ, ID_CORELIST, null, SHORT_TIMEOUT, McuMgrResponse.class, callback);
     }
 
     /**
@@ -438,7 +438,7 @@ public class ImageManager extends TransferManager {
      */
     @NotNull
     public McuMgrResponse coreList() throws McuMgrException {
-        return send(OP_READ, ID_CORELIST, null, McuMgrResponse.class);
+        return send(OP_READ, ID_CORELIST, null, SHORT_TIMEOUT, McuMgrResponse.class);
     }
 
     /**
@@ -450,7 +450,7 @@ public class ImageManager extends TransferManager {
     public void coreLoad(int offset, @NotNull McuMgrCallback<McuMgrCoreLoadResponse> callback) {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("off", offset);
-        send(OP_READ, ID_CORELOAD, payloadMap, McuMgrCoreLoadResponse.class, callback);
+        send(OP_READ, ID_CORELOAD, payloadMap, SHORT_TIMEOUT, McuMgrCoreLoadResponse.class, callback);
     }
 
     /**
@@ -464,7 +464,7 @@ public class ImageManager extends TransferManager {
     public McuMgrCoreLoadResponse coreLoad(int offset) throws McuMgrException {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("off", offset);
-        return send(OP_READ, ID_CORELOAD, payloadMap, McuMgrCoreLoadResponse.class);
+        return send(OP_READ, ID_CORELOAD, payloadMap, SHORT_TIMEOUT, McuMgrCoreLoadResponse.class);
     }
 
     /**
@@ -473,7 +473,7 @@ public class ImageManager extends TransferManager {
      * @param callback the asynchronous callback.
      */
     public void coreErase(@NotNull McuMgrCallback<McuMgrResponse> callback) {
-        send(OP_WRITE, ID_CORELOAD, null, McuMgrResponse.class, callback);
+        send(OP_WRITE, ID_CORELOAD, null, DEFAULT_TIMEOUT, McuMgrResponse.class, callback);
     }
 
     /**
@@ -484,7 +484,7 @@ public class ImageManager extends TransferManager {
      */
     @NotNull
     public McuMgrResponse coreErase() throws McuMgrException {
-        return send(OP_WRITE, ID_CORELOAD, null, McuMgrResponse.class);
+        return send(OP_WRITE, ID_CORELOAD, null, DEFAULT_TIMEOUT, McuMgrResponse.class);
     }
 
     //******************************************************************
@@ -596,6 +596,7 @@ public class ImageManager extends TransferManager {
     private int mUploadState = STATE_NONE;
     private int mUploadOffset = 0;
     private byte[] mImageData;
+    @SuppressWarnings("deprecation")
     private ImageUploadCallback mUploadCallback;
 
 
@@ -609,6 +610,7 @@ public class ImageManager extends TransferManager {
      * @return True, if the upload has stared, false otherwise.
      * @deprecated Use the new transfer implementation's imageUpload(...) method
      */
+    @SuppressWarnings("deprecation")
     @Deprecated
     public synchronized boolean upload(byte @NotNull [] data, @NotNull ImageUploadCallback callback) {
         if (mUploadState == STATE_NONE) {
@@ -641,6 +643,7 @@ public class ImageManager extends TransferManager {
      * Cancel an image upload. Does nothing if an image upload is not in progress.
      * @deprecated Use the new transfer implementation's imageUpload(...) method
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     public synchronized void cancelUpload() {
         if (mUploadState == STATE_NONE) {
@@ -687,9 +690,11 @@ public class ImageManager extends TransferManager {
         if (mUploadCallback != null) {
             mUploadCallback.onUploadFailed(error);
         }
+        //noinspection deprecation
         cancelUpload();
     }
 
+    @SuppressWarnings("deprecation")
     private synchronized void restartUpload() {
         if (mImageData == null || mUploadCallback == null) {
             LOG.error("Could not restart upload: image data or callback is null!");
@@ -847,6 +852,7 @@ public class ImageManager extends TransferManager {
      * Callback for upload command.
      * @deprecated Use the new transfer implementation's UploadCallback
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     public interface ImageUploadCallback {
 

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/LogManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/LogManager.java
@@ -88,7 +88,7 @@ public class LogManager extends McuManager {
                 payloadMap.put("ts", dateToString(minTimestamp, null));
             }
         }
-        send(OP_READ, ID_READ, payloadMap, McuMgrLogResponse.class, callback);
+        send(OP_READ, ID_READ, payloadMap, SHORT_TIMEOUT, McuMgrLogResponse.class, callback);
     }
 
     /**
@@ -124,7 +124,7 @@ public class LogManager extends McuManager {
                 payloadMap.put("ts", dateToString(minTimestamp, null));
             }
         }
-        return send(OP_READ, ID_READ, payloadMap, McuMgrLogResponse.class);
+        return send(OP_READ, ID_READ, payloadMap, SHORT_TIMEOUT, McuMgrLogResponse.class);
     }
 
     /**
@@ -133,7 +133,7 @@ public class LogManager extends McuManager {
      * @param callback the response callback.
      */
     public void clear(@NotNull McuMgrCallback<McuMgrResponse> callback) {
-        send(OP_WRITE, ID_CLEAR, null, McuMgrResponse.class, callback);
+        send(OP_WRITE, ID_CLEAR, null, DEFAULT_TIMEOUT, McuMgrResponse.class, callback);
     }
 
     /**
@@ -144,7 +144,7 @@ public class LogManager extends McuManager {
      */
     @NotNull
     public McuMgrResponse clear() throws McuMgrException {
-        return send(OP_WRITE, ID_CLEAR, null, McuMgrResponse.class);
+        return send(OP_WRITE, ID_CLEAR, null, DEFAULT_TIMEOUT, McuMgrResponse.class);
     }
 
     /**
@@ -155,7 +155,7 @@ public class LogManager extends McuManager {
      * @param callback the response callback.
      */
     public void moduleList(@NotNull McuMgrCallback<McuMgrModuleListResponse> callback) {
-        send(OP_READ, ID_MODULE_LIST, null, McuMgrModuleListResponse.class, callback);
+        send(OP_READ, ID_MODULE_LIST, null, SHORT_TIMEOUT, McuMgrModuleListResponse.class, callback);
     }
 
     /**
@@ -168,7 +168,7 @@ public class LogManager extends McuManager {
      */
     @NotNull
     public McuMgrModuleListResponse moduleList() throws McuMgrException {
-        return send(OP_READ, ID_MODULE_LIST, null, McuMgrModuleListResponse.class);
+        return send(OP_READ, ID_MODULE_LIST, null, SHORT_TIMEOUT, McuMgrModuleListResponse.class);
     }
 
     /**
@@ -177,7 +177,7 @@ public class LogManager extends McuManager {
      * @param callback the response callback.
      */
     public void levelList(@NotNull McuMgrCallback<McuMgrLevelListResponse> callback) {
-        send(OP_READ, ID_LEVEL_LIST, null, McuMgrLevelListResponse.class, callback);
+        send(OP_READ, ID_LEVEL_LIST, null, SHORT_TIMEOUT, McuMgrLevelListResponse.class, callback);
     }
 
     /**
@@ -188,7 +188,7 @@ public class LogManager extends McuManager {
      */
     @NotNull
     public McuMgrLevelListResponse levelList() throws McuMgrException {
-        return send(OP_READ, ID_LEVEL_LIST, null, McuMgrLevelListResponse.class);
+        return send(OP_READ, ID_LEVEL_LIST, null, SHORT_TIMEOUT, McuMgrLevelListResponse.class);
     }
 
     /**
@@ -199,7 +199,7 @@ public class LogManager extends McuManager {
      * @param callback the response callback.
      */
     public void logsList(@NotNull McuMgrCallback<McuMgrLogListResponse> callback) {
-        send(OP_READ, ID_LOGS_LIST, null, McuMgrLogListResponse.class, callback);
+        send(OP_READ, ID_LOGS_LIST, null, SHORT_TIMEOUT, McuMgrLogListResponse.class, callback);
     }
 
     /**
@@ -212,7 +212,7 @@ public class LogManager extends McuManager {
      */
     @NotNull
     public McuMgrLogListResponse logsList() throws McuMgrException {
-        return send(OP_READ, ID_LOGS_LIST, null, McuMgrLogListResponse.class);
+        return send(OP_READ, ID_LOGS_LIST, null, SHORT_TIMEOUT, McuMgrLogListResponse.class);
     }
 
     /**
@@ -226,7 +226,7 @@ public class LogManager extends McuManager {
         try {
             // Get available logs
             McuMgrLogListResponse logListResponse = logsList();
-            LOG.debug("Available logs: {}", logListResponse.toString());
+            LOG.debug("Available logs: {}", logListResponse);
 
             if (logListResponse.log_list == null) {
                 LOG.warn("No logs available on this device");

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ShellManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ShellManager.java
@@ -42,6 +42,22 @@ public class ShellManager extends McuManager {
 	 */
 	public void exec(@NotNull String cmd, @Nullable String[] argv,
 					 @NotNull McuMgrCallback<McuMgrExecResponse> callback) {
+		exec(cmd, argv, DEFAULT_TIMEOUT, callback);
+	}
+
+	/**
+	 * The command allows to execute command line in a similar way to typing
+	 * it into a shell, but both a request and a response are transported with use of SMP
+	 * (asynchronous).
+	 *
+	 * @param cmd      the command to be executed.
+	 * @param argv     an array consisting arguments of the command.
+	 * @param timeout  the operation timeout in milliseconds.
+	 * @param callback the asynchronous callback.
+	 */
+	public void exec(@NotNull String cmd, @Nullable String[] argv,
+					 long timeout,
+					 @NotNull McuMgrCallback<McuMgrExecResponse> callback) {
 		HashMap<String, Object> payloadMap = new HashMap<>();
 		if (argv == null || argv.length == 0) {
 			payloadMap.put("argv", new String[] { cmd });
@@ -51,7 +67,7 @@ public class ShellManager extends McuManager {
 			System.arraycopy(argv, 0, a, 1, argv.length);
 			payloadMap.put("argv", a);
 		}
-		send(OP_WRITE, ID_EXEC, payloadMap, McuMgrExecResponse.class, callback);
+		send(OP_WRITE, ID_EXEC, payloadMap, timeout, McuMgrExecResponse.class, callback);
 	}
 
 	/**
@@ -66,6 +82,21 @@ public class ShellManager extends McuManager {
 	 */
 	@NotNull
 	public McuMgrExecResponse exec(@NotNull String cmd, @Nullable String[] argv) throws McuMgrException {
+		return exec(cmd, argv, DEFAULT_TIMEOUT);
+	}
+
+	/**
+	 * The command allows to execute command line in a similar way to typing
+	 * it into a shell, but both a request and a response are transported with use of SMP
+	 * (synchronous).
+	 *
+	 * @param cmd  the command to be executed.
+	 * @param argv an array consisting arguments of the command.
+	 * @return The response.
+	 * @throws McuMgrException Transport error. See cause.
+	 */
+	@NotNull
+	public McuMgrExecResponse exec(@NotNull String cmd, @Nullable String[] argv, long timeout) throws McuMgrException {
 		HashMap<String, Object> payloadMap = new HashMap<>();
 		if (argv == null || argv.length == 0) {
 			payloadMap.put("argv", new String[] { cmd });
@@ -75,7 +106,7 @@ public class ShellManager extends McuManager {
 			System.arraycopy(argv, 0, a, 1, argv.length);
 			payloadMap.put("argv", a);
 		}
-		return send(OP_WRITE, ID_EXEC, payloadMap, McuMgrExecResponse.class);
+		return send(OP_WRITE, ID_EXEC, payloadMap, timeout, McuMgrExecResponse.class);
 	}
 
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/StatsManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/StatsManager.java
@@ -46,7 +46,7 @@ public class StatsManager extends McuManager {
     public void read(@Nullable String module, @NotNull McuMgrCallback<McuMgrStatResponse> callback) {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("name", module);
-        send(OP_READ, ID_READ, payloadMap, McuMgrStatResponse.class, callback);
+        send(OP_READ, ID_READ, payloadMap, SHORT_TIMEOUT, McuMgrStatResponse.class, callback);
     }
 
     /**
@@ -60,7 +60,7 @@ public class StatsManager extends McuManager {
     public McuMgrStatResponse read(@Nullable String module) throws McuMgrException {
         HashMap<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("name", module);
-        return send(OP_READ, ID_READ, payloadMap, McuMgrStatResponse.class);
+        return send(OP_READ, ID_READ, payloadMap, SHORT_TIMEOUT, McuMgrStatResponse.class);
     }
 
     /**
@@ -69,7 +69,7 @@ public class StatsManager extends McuManager {
      * @param callback the asynchronous callback.
      */
     public void list(@NotNull McuMgrCallback<McuMgrStatListResponse> callback) {
-        send(OP_READ, ID_LIST, null, McuMgrStatListResponse.class, callback);
+        send(OP_READ, ID_LIST, null, SHORT_TIMEOUT, McuMgrStatListResponse.class, callback);
     }
 
     /**
@@ -80,6 +80,6 @@ public class StatsManager extends McuManager {
      */
     @NotNull
     public McuMgrStatListResponse list() throws McuMgrException {
-        return send(OP_READ, ID_LIST, null, McuMgrStatListResponse.class);
+        return send(OP_READ, ID_LIST, null, SHORT_TIMEOUT, McuMgrStatListResponse.class);
     }
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ImageUploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ImageUploader.kt
@@ -146,7 +146,7 @@ internal class ImageUploader(
 private fun ImageManager.uploadAsync(
     requestMap: Map<String, Any>,
     callback: (UploadResult) -> Unit
-) = send(OP_WRITE, ID_UPLOAD, requestMap, UploadResponse::class.java,
+) = send(OP_WRITE, ID_UPLOAD, requestMap, 1000, UploadResponse::class.java,
     object : McuMgrCallback<UploadResponse> {
         override fun onResponse(response: UploadResponse) {
             callback(UploadResult.Response(response, response.returnCode))


### PR DESCRIPTION
This PR adds an option to specify per-command timeout. 
Some commands, like `erase` may take a long time, as the notification is sent after the secondary slots are erased, which may take many seconds.
On the other hand, when uploading an image, each chunk should be acknowledged almost immediately, so there is no need to wait 30 seconds. Thanks to this PR, the chunk will will be repeated after a second.

This should fix #58 and #18, hopefully, as the packets will quickly be repeated if needed.