### PR TITLE
ScannerViewModel broadcast receiver unregister bug fix

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/ScannerViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/ScannerViewModel.java
@@ -221,7 +221,7 @@ public class ScannerViewModel extends AndroidViewModel {
         context.unregisterReceiver(bluetoothStateBroadcastReceiver);
 
         if (Utils.isMarshmallowOrAbove()) {
-            context.unregisterReceiver(bluetoothStateBroadcastReceiver);
+            context.unregisterReceiver(locationProviderChangedReceiver);
         }
     }
 


### PR DESCRIPTION
`bluetoothStateBroadcastReceiver` is unregistered twice, `locationProviderChangedReceiver` never.