### PR TITLE
TImeout on initial request fixed

### DIFF
--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -586,7 +586,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                 0x00, // Flags
                 0x00, 0x01, // Len
                 0x00, 0x00, // McuManager.GROUP_DEFAULT
-                0x00, // Seq
+                (byte) 0xFF, // Seq
                 0x06, // DefaultManager.ID_MCUMGR_PARAMS
                 (byte) 0xA0, // Empty map(0) - an empty CBOR may be required for some implementations,
                              // otherwise the request is ignored and no notification is replied.


### PR DESCRIPTION
Just after connection the `McuMgrBleTransport` requests McuMgr parameters from the device. This request may succeed, may fail (rc=8), or may time out (1 sec). After the timeout the library would send another requests and, as it would be the first one done using the `send` method, it would get sequence number 0. However, sometimes the response for the McuMgr params is received after 1 sec and, as it had also sequence set to 1, the library matched it with a wrong request and operation would fail. This PR ensures that the initial request has a different sequence number.