### PR TITLE
Connection timeout fixed

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
@@ -40,6 +40,7 @@ public abstract class McuManager {
 
     protected final static long DEFAULT_TIMEOUT = 30_000; // ms
     protected final static long SHORT_TIMEOUT = 1_000; // ms
+    protected final static long MEDIUM_TIMEOUT = 2_500; // ms
 
     // Date format
     private final static String MCUMGR_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ";

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
@@ -49,8 +49,7 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
         NONE, VALIDATE, UPLOAD, TEST, RESET, CONFIRM;
 
         public boolean isInProgress() {
-            return this == VALIDATE || this == UPLOAD || this == TEST ||
-                    this == RESET || this == CONFIRM;
+            return this != NONE;
         }
     }
 
@@ -347,8 +346,9 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      * packets, trimmed to match the memory alignment. It will then wait for corresponding
      * notifications and continue to send until the complete image is sent.
      * <p>
-     * This value should match MCUMGR_BUF_COUNT (https://github.com/zephyrproject-rtos/zephyr/blob/bd4ddec0c8c822bbdd420bd558b62c1d1a532c16/subsys/mgmt/mcumgr/Kconfig#L550)
-     * in Zephyr KConfig, which is by default set to 4.
+     * This value should match MCUMGR_BUF_COUNT - 1
+     * (https://github.com/zephyrproject-rtos/zephyr/blob/bd4ddec0c8c822bbdd420bd558b62c1d1a532c16/subsys/mgmt/mcumgr/Kconfig#L550)
+     * in Zephyr KConfig, which is by default set to 4. One buffer is used for sending responses.
      * <p>
      * Mind, that the speed increases only if the returned offsets match the required offset
      * (initial offset + sent packet size). In other case the packets with unexpected offsets

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Confirm.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Confirm.java
@@ -42,7 +42,7 @@ class Confirm extends FirmwareUpgradeTask {
 		manager.confirm(hash, new McuMgrCallback<McuMgrImageStateResponse>() {
 			@Override
 			public void onResponse(@NotNull final McuMgrImageStateResponse response) {
-				LOG.trace("Confirm response: {}", response.toString());
+				LOG.trace("Confirm response: {}", response);
 				// Check for an error return code.
 				if (!response.isSuccess()) {
 					performer.onTaskFailed(Confirm.this, new McuMgrErrorException(response.getReturnCode()));
@@ -72,78 +72,4 @@ class Confirm extends FirmwareUpgradeTask {
 			}
 		});
 	}
-
-//	/**
-//	 * State: CONFIRM.
-//	 * Callback for the confirm command.
-//	 */
-//	private final McuMgrCallback<McuMgrImageStateResponse> mConfirmCallback = new McuMgrCallback<McuMgrImageStateResponse>() {
-//		private final static int MAX_ATTEMPTS = 2;
-//		private int mAttempts = 0;
-//
-//		@Override
-//		public void onResponse(@NotNull McuMgrImageStateResponse response) {
-//			// Reset retry counter
-//			mAttempts = 0;
-//
-//			LOG.trace("Confirm response: {}", response.toString());
-//			// Check for an error return code
-//			if (!response.isSuccess()) {
-//				fail(new McuMgrErrorException(response.getReturnCode()));
-//				return;
-//			}
-//			if (response.images.length == 0) {
-//				fail(new McuMgrException("Confirm response does not contain enough info"));
-//				return;
-//			}
-//			// Handle the response based on mode.
-//			switch (mMode) {
-//				case CONFIRM_ONLY:
-//					// Check that an image exists in slot 1
-//					if (response.images.length != 2) {
-//						fail(new McuMgrException("Confirm response does not contain enough info"));
-//						return;
-//					}
-//					// Check that the upgrade image has been confirmed
-//					if (!response.images[1].pending) {
-//						fail(new McuMgrException("Image is not in a confirmed state."));
-//						return;
-//					}
-//					// Reset the device, we don't want to do anything more.
-//					reset();
-//					break;
-//				case TEST_AND_CONFIRM:
-//					// Check that the upgrade image has successfully booted
-//					if (!Arrays.equals(mHash, response.images[0].hash)) {
-//						fail(new McuMgrException("Device failed to boot into new image"));
-//						return;
-//					}
-//					// Check that the upgrade image has been confirmed
-//					if (!response.images[0].confirmed) {
-//						fail(new McuMgrException("Image is not in a confirmed state."));
-//						return;
-//					}
-//					// The device has been tested and confirmed.
-//					success();
-//					break;
-//			}
-//		}
-//
-//		@Override
-//		public void onError(@NotNull McuMgrException e) {
-//			// The confirm request might have been sent after the device was rebooted
-//			// and the images were swapped. Swapping images, depending on the hardware,
-//			// make take a long time, during which the phone may throw 133 error as a
-//			// timeout. In such case we should try again.
-//			if (e instanceof McuMgrTimeoutException) {
-//				if (mAttempts++ < MAX_ATTEMPTS) {
-//					// Try again
-//					LOG.warn("Connection timeout. Retrying...");
-//					verify();
-//					return;
-//				}
-//			}
-//			fail(e);
-//		}
-//	};
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Test.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Test.java
@@ -42,7 +42,7 @@ class Test extends FirmwareUpgradeTask {
 		manager.test(hash, new McuMgrCallback<McuMgrImageStateResponse>() {
 			@Override
 			public void onResponse(@NotNull final McuMgrImageStateResponse response) {
-				LOG.trace("Test response: {}", response.toString());
+				LOG.trace("Test response: {}", response);
 				// Check for an error return code.
 				if (!response.isSuccess()) {
 					performer.onTaskFailed(Test.this, new McuMgrErrorException(response.getReturnCode()));

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Validate.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Validate.java
@@ -11,8 +11,8 @@ import java.util.List;
 
 import io.runtime.mcumgr.McuMgrCallback;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Mode;
-import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
 import io.runtime.mcumgr.exception.McuMgrErrorException;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.image.McuMgrImage;
@@ -23,7 +23,7 @@ import io.runtime.mcumgr.task.TaskManager;
 class Validate extends FirmwareUpgradeTask {
 	private final static Logger LOG = LoggerFactory.getLogger(Validate.class);
 
-	private static final int SLOT_PRIMARY = 0;
+	// private static final int SLOT_PRIMARY = 0;
 	private static final int SLOT_SECONDARY = 1;
 
 	@NotNull
@@ -59,7 +59,7 @@ class Validate extends FirmwareUpgradeTask {
 		manager.list(new McuMgrCallback<McuMgrImageStateResponse>() {
 			@Override
 			public void onResponse(@NotNull final McuMgrImageStateResponse response) {
-				LOG.trace("Validation response: {}", response.toString());
+				LOG.trace("Validation response: {}", response);
 
 				// Check for an error return code.
 				if (!response.isSuccess()) {
@@ -70,7 +70,7 @@ class Validate extends FirmwareUpgradeTask {
 				// Initial validation.
 				McuMgrImageStateResponse.ImageSlot[] slots = response.images;
 				if (slots == null) {
-					LOG.error("Missing images information: {}", response.toString());
+					LOG.error("Missing images information: {}", response);
 					performer.onTaskFailed(Validate.this, new McuMgrException("Missing images information"));
 					return;
 				}
@@ -149,7 +149,7 @@ class Validate extends FirmwareUpgradeTask {
 					switch (mode) {
 						case TEST_AND_CONFIRM:
 							// If the image is not pending (test command has not been sent) and not
-							// confirmed (another image is under test), and isnt the currently
+							// confirmed (another image is under test), and isn't the currently
 							// running image, send test command and update the flag.
 							if (!pending && !confirmed && !active) {
 								performer.enqueue(new Test(mcuMgrImage.getHash()));
@@ -165,7 +165,7 @@ class Validate extends FirmwareUpgradeTask {
 							break;
 						case TEST_ONLY:
 							// If the image is not pending (test command has not been sent) and not
-							// confirmed (another image is under test), and isnt the currently
+							// confirmed (another image is under test), and isn't the currently
 							// running image, send test command and update the flag.
 							if (!pending && !confirmed && !active) {
 								performer.enqueue(new Test(mcuMgrImage.getHash()));

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
@@ -85,7 +85,7 @@ public class ImageManager extends TransferManager {
      * @param callback the asynchronous callback.
      */
     public void list(@NotNull McuMgrCallback<McuMgrImageStateResponse> callback) {
-        send(OP_READ, ID_STATE, null, SHORT_TIMEOUT, McuMgrImageStateResponse.class, callback);
+        send(OP_READ, ID_STATE, null, MEDIUM_TIMEOUT, McuMgrImageStateResponse.class, callback);
     }
 
     /**
@@ -98,7 +98,7 @@ public class ImageManager extends TransferManager {
      */
     @NotNull
     public McuMgrImageStateResponse list() throws McuMgrException {
-        return send(OP_READ, ID_STATE, null, SHORT_TIMEOUT, McuMgrImageStateResponse.class);
+        return send(OP_READ, ID_STATE, null, MEDIUM_TIMEOUT, McuMgrImageStateResponse.class);
     }
 
     /**

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
@@ -145,7 +145,9 @@ public class ImageManager extends TransferManager {
     public void upload(byte @NotNull [] data, int offset, int image,
                        @NotNull McuMgrCallback<McuMgrImageUploadResponse> callback) {
         HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, image);
-        send(OP_WRITE, ID_UPLOAD, payloadMap, SHORT_TIMEOUT, McuMgrImageUploadResponse.class, callback);
+        // Timeout for the initial chunk is long, as the device may need to erase the flash.
+        final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
+        send(OP_WRITE, ID_UPLOAD, payloadMap, timeout, McuMgrImageUploadResponse.class, callback);
     }
 
     /**
@@ -191,7 +193,9 @@ public class ImageManager extends TransferManager {
     public McuMgrImageUploadResponse upload(byte @NotNull [] data, int offset, int image)
             throws McuMgrException {
         HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, image);
-        return send(OP_WRITE, ID_UPLOAD, payloadMap, SHORT_TIMEOUT, McuMgrImageUploadResponse.class);
+        // Timeout for the initial chunk is long, as the device may need to erase the flash.
+        final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
+        return send(OP_WRITE, ID_UPLOAD, payloadMap, timeout, McuMgrImageUploadResponse.class);
     }
 
     /*

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ImageUploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ImageUploader.kt
@@ -96,8 +96,8 @@ internal class ImageUploader(
     imageManager.mtu,
     imageManager.scheme
 ) {
-    override fun write(requestMap: Map<String, Any>, callback: (UploadResult) -> Unit) {
-        imageManager.uploadAsync(requestMap, callback)
+    override fun write(requestMap: Map<String, Any>, timeout: Long, callback: (UploadResult) -> Unit) {
+        imageManager.uploadAsync(requestMap, timeout, callback)
     }
 
     override fun getAdditionalData(
@@ -145,8 +145,9 @@ internal class ImageUploader(
 
 private fun ImageManager.uploadAsync(
     requestMap: Map<String, Any>,
+    timeout: Long,
     callback: (UploadResult) -> Unit
-) = send(OP_WRITE, ID_UPLOAD, requestMap, 1000, UploadResponse::class.java,
+) = send(OP_WRITE, ID_UPLOAD, requestMap, timeout, UploadResponse::class.java,
     object : McuMgrCallback<UploadResponse> {
         override fun onResponse(response: UploadResponse) {
             callback(UploadResult.Response(response, response.returnCode))

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
@@ -57,6 +57,7 @@ abstract class Uploader(
     @Throws
     internal abstract fun write(
         requestMap: Map<String, Any>,
+        timeout: Long,
         callback: (UploadResult) -> Unit
     )
 
@@ -184,7 +185,9 @@ abstract class Uploader(
         callback: suspend (UploadResult) -> Unit
     ): Chunk {
         val resultChannel: Channel<UploadResult> = Channel(1)
-        write(prepareWrite(chunk.data, chunk.offset)) { result ->
+        // Timeout for the initial chunk is long, as the device may need to erase the flash.
+        val timeout = if (chunk.offset == 0) 30_000L else 1_000L
+        write(prepareWrite(chunk.data, chunk.offset), timeout) { result ->
             resultChannel.trySend(result)
         }
 


### PR DESCRIPTION
This PR fixes #68. When the secondary slot of some image is not-empty, but hasn't been confirmed or tested, and user tries to upload a different image, the slot will be automatically erased.
However, when progressive flash or stream flash are not turned on, this may take some time, depending on the flash hardware. This PR sets the timeout for the first upload chunk (where offset = 0) to 30 seconds (was 1 second before).

This approach is better then adding an `Erase` command before upload, like proposed in #68, as `Erase` always takes a long time (erases whole slot), while if progressive erase is enabled, automatic erase can be much faster. Progressive erase erases only as much space as it needs.

This PR also increases timeout for `List` command from 1 sec to 2.5 seconds.