### PR TITLE
Do not truncate hash.

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
@@ -57,7 +57,6 @@ public class ImageManager extends TransferManager {
     private final static Logger LOG = LoggerFactory.getLogger(ImageManager.class);
 
     private final static int IMG_HASH_LEN = 32;
-    private final static int TRUNCATED_HASH_LEN = 3;
 
     // Image manager command IDs
     private final static int ID_STATE = 0;
@@ -224,14 +223,12 @@ public class ImageManager extends TransferManager {
              * Feature in Apache Mynewt: Device keeps track of unfinished uploads based on the
              * SHA256 hash over the image data. When an upload request is received which contains
              * the same hash of a partially finished upload, the device will send the offset to
-             * continue from. The hash is truncated to save packet
+             * continue from.
              */
             try {
                 MessageDigest digest = MessageDigest.getInstance("SHA-256");
                 byte[] hash = digest.digest(data);
-                // Truncate the hash to save space.
-                byte[] truncatedHash = Arrays.copyOf(hash, TRUNCATED_HASH_LEN);
-                payloadMap.put("sha", truncatedHash);
+                payloadMap.put("sha", hash);
             } catch (NoSuchAlgorithmException e) {
                 e.printStackTrace();
             }
@@ -812,7 +809,7 @@ public class ImageManager extends TransferManager {
                         overheadTestMap.put("image", image);
                     }
                     overheadTestMap.put("len", data.length);
-                    overheadTestMap.put("sha", new byte[TRUNCATED_HASH_LEN]);
+                    overheadTestMap.put("sha", new byte[IMG_HASH_LEN]);
                 }
                 byte[] header = {0, 0, 0, 0, 0, 0, 0, 0};
                 overheadTestMap.put("_h", header);


### PR DESCRIPTION
A full hash is needed to properly verify received images.