### PR TITLE
BLE library dependency updated

### DIFF
--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     api project(':mcumgr-core')
 
     // Import the BLE Library
-    api 'no.nordicsemi.android:ble:2.6.0-alpha03'
+    api 'no.nordicsemi.android:ble:2.6.0-alpha04'
 
     // Logging
     implementation 'org.slf4j:slf4j-api:1.7.35'


### PR DESCRIPTION
This PR sets the BLE lib dependency to version 2.6.0-alpha04