### PR TITLE
Bug fix: `setInstanceId` didn't exist on older Android versions

### DIFF
--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -792,13 +792,16 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                     characteristic.getPermissions());
             clone.addDescriptor(getNotifyCccd(characteristic));
             try {
-                Method setInstanceId = characteristic.getClass()
-                        .getDeclaredMethod("setInstanceId", int.class);
-                Method setService = characteristic.getClass()
-                        .getDeclaredMethod("setService", BluetoothGattService.class);
-                setService.setAccessible(true);
-                setInstanceId.invoke(clone, characteristic.getInstanceId());
-                setService.invoke(clone, characteristic.getService());
+                Method initCharacteristic = characteristic.getClass()
+                        .getDeclaredMethod("initCharacteristic", BluetoothGattService.class, UUID.class, int.class, int.class, int.class);
+                initCharacteristic.setAccessible(true);
+                initCharacteristic.invoke(clone,
+                        characteristic.getService(),
+                        characteristic.getUuid(),
+                        characteristic.getInstanceId(),
+                        characteristic.getProperties(),
+                        characteristic.getPermissions()
+                );
             } catch (Exception e) {
                 LOG.error("SMP characteristic clone failed", e);
                 clone = characteristic;


### PR DESCRIPTION
This PR fixes the workaround for having one characteristic with both WRITE and NOTIFY properties.

Before, trying to obtain `setInstanceId` was throwing `NoSuchMethodException` on Android 6 and older.