### PR TITLE
BLE operation timeouts increased

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
@@ -38,9 +38,9 @@ public abstract class McuManager {
     /** Maximum length of a single SMP packet. */
     private final static int DEFAULT_MTU = 0xFFFF + 8; // Header size + max packet size.
 
-    protected final static long DEFAULT_TIMEOUT = 30_000; // ms
-    protected final static long SHORT_TIMEOUT = 1_000; // ms
-    protected final static long MEDIUM_TIMEOUT = 2_500; // ms
+    protected final static long DEFAULT_TIMEOUT = 40_000; // ms
+    protected final static long SHORT_TIMEOUT = 2_500; // ms
+    protected final static long MEDIUM_TIMEOUT = 5_000; // ms
 
     // Date format
     private final static String MCUMGR_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ";

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
@@ -154,6 +154,8 @@ abstract class Uploader(
                         if (currentOffset > chunk.offset) {
                             log.warn("A notification for chunk with offset=${chunk.offset} was lost, but the chunk was ack-ed by later chunk (confirmed offset=$currentOffset)")
                             return@onErrorOrFailure
+                        } else {
+                            log.warn("A notification for chunk with offset=${chunk.offset} was lost, current offset: $currentOffset")
                         }
                     }
 
@@ -274,7 +276,7 @@ abstract class Uploader(
     ): Chunk {
         val resultChannel: Channel<UploadResult> = Channel(1)
         // Timeout for the initial chunk is long, as the device may need to erase the flash.
-        val timeout = if (chunk.offset == 0) 30_000L else 1_000L
+        val timeout = if (chunk.offset == 0) 40_000L else 2_500L
         write(prepareWrite(chunk.data, chunk.offset), timeout) { result ->
             resultChannel.trySend(result)
         }


### PR DESCRIPTION
This PR increases the timeouts for all BLE operations:
1. Short timeout, for quick operations was increased from 1 sec to 2.5 seconds.
2. Medium timeout changed from 2.5 sec to 5 seconds.
3. Long timeout, mainly used by "erase" operations was increased from 30 to 40 seconds. This change has less to do with BLE performance, but to prevent timeouts when erasing memory of larger devices.

The reason for the change is to support older devices after a packet size has been increased recently. Devices running NCS 2+ can send 2475 bytes per single SMP packet, which on older Android phones takes long time.

This PR fixes #72. Hopefully. Tested on Samsung Folder with Android 6.0.1 and it was enough to make both DFU and FS operations successful. 