### PR TITLE
Fixed CBOR overhead calculation

### DIFF
--- a/mcumgr-core/build.gradle
+++ b/mcumgr-core/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
 
     // Test
-    testImplementation 'junit:junit:4.13.2'
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
 }
 
 // === Maven Central configuration ===

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/meta/StatisticsCollector.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/meta/StatisticsCollector.kt
@@ -135,6 +135,7 @@ private class StatCollection(
             }
 
             override fun onError(error: McuMgrException) {
+                error.printStackTrace()
                 callback(StatCollectionResult.Failure(error))
             }
         })

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
@@ -353,7 +353,7 @@ abstract class Uploader(
      * out of bounds on the last chunk, if the calculated chunk size is greater than data.size -
      * offset, then the latter value is returned.
      */
-    private fun getMaxChunkSize(data: ByteArray, offset: Int): Int {
+    internal fun getMaxChunkSize(data: ByteArray, offset: Int): Int {
         // The size of the header is based on the scheme. CoAP scheme is larger because there are
         // 4 additional bytes of CBOR.
         val headerSize = when (protocol) {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
@@ -320,7 +320,7 @@ abstract class Uploader(
         // SMP pipelining may require data to be aligned to some number of bytes.
         // In Zephyr, since https://github.com/zephyrproject-rtos/zephyr/pull/41959 has been merged
         // this is not required, but memory aligning here makes even older devices to work.
-        val maxChunkSize = getMaxChunkSize(data, offset)
+        val maxChunkSize = getMaxChunkSize(offset)
         val alignedSize =
             if (offset + maxChunkSize < data.size) maxChunkSize / memoryAlignment * memoryAlignment else maxChunkSize
         val chunkData = data.copyOfRange(offset, offset + alignedSize)
@@ -353,7 +353,7 @@ abstract class Uploader(
      * out of bounds on the last chunk, if the calculated chunk size is greater than data.size -
      * offset, then the latter value is returned.
      */
-    internal fun getMaxChunkSize(data: ByteArray, offset: Int): Int {
+    private fun getMaxChunkSize(offset: Int): Int {
         // The size of the header is based on the scheme. CoAP scheme is larger because there are
         // 4 additional bytes of CBOR.
         val headerSize = when (protocol) {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/util/CBOR.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/util/CBOR.java
@@ -81,7 +81,7 @@ public class CBOR {
         if (n < 0) throw new IllegalArgumentException("n must be >= 0");
         if (n < 24) return 1;
         if (n < 256) return 2; // 2^8
-        if (n < 65636) return 3; // 2^16
+        if (n < 65535) return 3; // 2^16
         return 5; // 2^32
         // For long values it could return 9, but this won't happen here.
     }

--- a/mcumgr-core/src/test/java/io/runtime/mcumgr/McuMgrImageTest.kt
+++ b/mcumgr-core/src/test/java/io/runtime/mcumgr/McuMgrImageTest.kt
@@ -9,7 +9,7 @@ class McuMgrImageTest {
 
     @Test
     fun `parse image without protected tlvs success`() {
-        val inputStream = this::class.java.classLoader?.getResourceAsStream("slinky-no-prot-tlv.img")!!
+        val inputStream = this::class.java.classLoader?.getResourceAsStream("slinky-no-prot-tlv.img")
             ?: throw IllegalStateException("input stream is null")
         val imageData = toByteArray(inputStream)
         McuMgrImage.fromBytes(imageData)

--- a/mcumgr-core/src/test/java/io/runtime/mcumgr/mock/McuMgrHandler.kt
+++ b/mcumgr-core/src/test/java/io/runtime/mcumgr/mock/McuMgrHandler.kt
@@ -4,7 +4,7 @@ import io.runtime.mcumgr.McuMgrHeader
 import io.runtime.mcumgr.response.McuMgrResponse
 
 interface McuMgrHandler {
-    fun <T: McuMgrResponse?> handle(
+    fun <T: McuMgrResponse> handle(
         header: McuMgrHeader,
         payload: ByteArray,
         responseType: Class<T>

--- a/mcumgr-core/src/test/java/io/runtime/mcumgr/mock/MockBleMcuMgrTransport.kt
+++ b/mcumgr-core/src/test/java/io/runtime/mcumgr/mock/MockBleMcuMgrTransport.kt
@@ -1,0 +1,77 @@
+package io.runtime.mcumgr.mock
+
+import io.runtime.mcumgr.McuMgrCallback
+import io.runtime.mcumgr.McuMgrErrorCode
+import io.runtime.mcumgr.McuMgrHeader
+import io.runtime.mcumgr.McuMgrScheme
+import io.runtime.mcumgr.McuMgrTransport
+import io.runtime.mcumgr.exception.McuMgrException
+import io.runtime.mcumgr.response.McuMgrResponse
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+
+class MockBleMcuMgrTransport(
+    private val handler: McuMgrHandler? = null,
+    private val handlerOverrides: List<OverrideHandler> = listOf()
+): McuMgrTransport {
+
+    private val executor: Executor = Executors.newSingleThreadExecutor()
+
+    override fun getScheme(): McuMgrScheme {
+        return McuMgrScheme.BLE
+    }
+
+    override fun <T : McuMgrResponse> send(
+        data: ByteArray,
+        timeout: Long,
+        responseType: Class<T>
+    ): T {
+        val header = McuMgrHeader.fromBytes(data)
+        val payload = data.drop(McuMgrHeader.HEADER_LENGTH).toByteArray()
+
+        // Check for handler overrides
+        handlerOverrides.firstOrNull { handler ->
+                handler.groupId == header.groupId && handler.commandId == header.commandId
+        }?.let {
+            return it.handle(header, payload, responseType)
+        }
+
+        // Call defaults
+        return handler?.handle(header, payload, responseType) ?:
+            buildMockErrorResponse(scheme, McuMgrErrorCode.NOT_SUPPORTED, header.toResponse(), responseType)
+    }
+
+    override fun <T : McuMgrResponse> send(
+        payload: ByteArray,
+        timeout: Long,
+        responseType: Class<T>,
+        callback: McuMgrCallback<T>
+    ) {
+        executor.execute {
+            try {
+                callback.onResponse(send(payload, timeout, responseType))
+            } catch (mme: McuMgrException) {
+                callback.onError(mme)
+            } catch (e: Exception) {
+                callback.onError(McuMgrException(e))
+            }
+        }
+    }
+
+    /*
+     * Unimplemented.
+     */
+    override fun addObserver(observer: McuMgrTransport.ConnectionObserver) =
+        throw IllegalStateException("Not implemented.")
+
+    override fun removeObserver(observer: McuMgrTransport.ConnectionObserver) =
+        throw IllegalStateException("Not implemented.")
+
+    override fun release() =
+        throw IllegalStateException("Not implemented.")
+
+    override fun connect(callback: McuMgrTransport.ConnectionCallback?) =
+        throw IllegalStateException("Not implemented.")
+}
+
+

--- a/mcumgr-core/src/test/java/io/runtime/mcumgr/mock/MockMcuMgrResponse.kt
+++ b/mcumgr-core/src/test/java/io/runtime/mcumgr/mock/MockMcuMgrResponse.kt
@@ -10,6 +10,7 @@ import io.runtime.mcumgr.util.CBOR
  * Build a mock error response.
  */
 fun <T: McuMgrResponse?> buildMockErrorResponse(
+    scheme: McuMgrScheme,
     errorCode: McuMgrErrorCode,
     responseHeader: McuMgrHeader,
     responseType: Class<T>,
@@ -17,35 +18,60 @@ fun <T: McuMgrResponse?> buildMockErrorResponse(
     codeDetail: Int = 5
 ): T {
     val responsePayload = CBOR.toBytes(McuMgrErrorResponse(errorCode))
-    return McuMgrResponse.buildCoapResponse(
-        McuMgrScheme.COAP_BLE,
-        responsePayload,
-        responseHeader.toBytes(),
-        responsePayload,
-        codeClass,
-        codeDetail,
-        responseType
-    )
+    when (scheme) {
+        McuMgrScheme.BLE ->
+            return McuMgrResponse.buildResponse(
+                McuMgrScheme.BLE,
+                responsePayload,
+                responseType
+            )
+        McuMgrScheme.COAP_BLE ->
+            return McuMgrResponse.buildCoapResponse(
+                McuMgrScheme.COAP_BLE,
+                responsePayload,
+                responseHeader.toBytes(),
+                responsePayload,
+                codeClass,
+                codeDetail,
+                responseType
+            )
+        else -> {
+            throw IllegalArgumentException("Unsupported scheme: $scheme")
+        }
+    }
 }
 
 /**
  * Build a mock response.
  */
-fun <T: McuMgrResponse?> buildMockResponse(
+fun <T: McuMgrResponse> buildMockResponse(
+    scheme: McuMgrScheme,
     responseHeader: McuMgrHeader,
     responsePayload: ByteArray,
     responseType: Class<T>,
     codeClass: Int = 2,
     codeDetail: Int = 5
-): T = McuMgrResponse.buildCoapResponse(
-    McuMgrScheme.COAP_BLE,
-    responsePayload,
-    responseHeader.toBytes(),
-    responsePayload,
-    codeClass,
-    codeDetail,
-    responseType
-)
+): T = when (scheme) {
+    McuMgrScheme.BLE ->
+        McuMgrResponse.buildResponse(
+            McuMgrScheme.BLE,
+            responseHeader.toBytes() + responsePayload,
+            responseType
+        )
+    McuMgrScheme.COAP_BLE ->
+        McuMgrResponse.buildCoapResponse(
+            McuMgrScheme.COAP_BLE,
+            responsePayload,
+            responseHeader.toBytes(),
+            responsePayload,
+            codeClass,
+            codeDetail,
+            responseType
+        )
+    else -> {
+        throw IllegalArgumentException("Unsupported scheme: $scheme")
+    }
+}
 
 /**
  * Helper class for building an mcumgr error response.

--- a/mcumgr-core/src/test/java/io/runtime/mcumgr/mock/handlers/MockStatsHandler.kt
+++ b/mcumgr-core/src/test/java/io/runtime/mcumgr/mock/handlers/MockStatsHandler.kt
@@ -2,6 +2,7 @@ package io.runtime.mcumgr.mock.handlers
 
 import io.runtime.mcumgr.McuMgrErrorCode
 import io.runtime.mcumgr.McuMgrHeader
+import io.runtime.mcumgr.McuMgrScheme
 import io.runtime.mcumgr.mock.McuMgrErrorResponse
 import io.runtime.mcumgr.mock.McuMgrHandler
 import io.runtime.mcumgr.mock.buildMockResponse
@@ -17,6 +18,7 @@ enum class McuMgrStatsCommand(val value: Int) {
 }
 
 class MockStatsHandler(
+    private val scheme: McuMgrScheme,
     private val stats: Map<String, Map<String, Long>> = allStats
 ): McuMgrHandler {
 
@@ -77,7 +79,7 @@ class MockStatsHandler(
     /**
      * Handle a request for the stats group
      */
-    override fun <T : McuMgrResponse?> handle(
+    override fun <T : McuMgrResponse> handle(
         header: McuMgrHeader,
         payload: ByteArray,
         responseType: Class<T>
@@ -92,7 +94,7 @@ class MockStatsHandler(
     /**
      * Handle a stats list request.
      */
-    private fun <T : McuMgrResponse?> handleStatsListRequest(
+    private fun <T : McuMgrResponse> handleStatsListRequest(
         header: McuMgrHeader,
         responseType: Class<T>
     ): T {
@@ -100,13 +102,13 @@ class MockStatsHandler(
             stat_list = stats.keys.toTypedArray()
         }
         val responsePayload = CBOR.toBytes(response)
-        return buildMockResponse(header.toResponse(), responsePayload, responseType)
+        return buildMockResponse(scheme, header.toResponse(), responsePayload, responseType)
     }
 
     /**
      * Handle a stats read request.
      */
-    private fun <T : McuMgrResponse?> handleStatsReadRequest(
+    private fun <T : McuMgrResponse> handleStatsReadRequest(
         header: McuMgrHeader,
         payload: ByteArray,
         responseType: Class<T>
@@ -123,6 +125,6 @@ class MockStatsHandler(
             McuMgrErrorResponse(McuMgrErrorCode.IN_VALUE)
         }
         val responsePayload = CBOR.toBytes(response)
-        return buildMockResponse(header.toResponse(), responsePayload, responseType)
+        return buildMockResponse(scheme, header.toResponse(), responsePayload, responseType)
     }
 }

--- a/mcumgr-core/src/test/java/io/runtime/mcumgr/transfer/UploaderTest.kt
+++ b/mcumgr-core/src/test/java/io/runtime/mcumgr/transfer/UploaderTest.kt
@@ -19,7 +19,7 @@ internal class UploaderTest {
     fun `test image Uploader`() {
         // Parameters
         val data = ByteArray(100000) { 0 } // keep it > 64k
-        val mtu = 249
+        val mtu = 245
         val image = 1
 
         // Test values
@@ -33,7 +33,7 @@ internal class UploaderTest {
                 responseType: Class<T>
             ): T {
                 assert(payload.size + McuMgrHeader.HEADER_LENGTH <= mtu) {
-                    "Payload size is too big (${payload.size + McuMgrHeader.HEADER_LENGTH} / $mtu) at $received"
+                    "Payload size is too big (${payload.size + McuMgrHeader.HEADER_LENGTH} bytes, mtu = $mtu) at $received"
                 }
 
                 val map = CBOR.toObjectMap(payload)

--- a/mcumgr-core/src/test/java/io/runtime/mcumgr/transfer/UploaderTest.kt
+++ b/mcumgr-core/src/test/java/io/runtime/mcumgr/transfer/UploaderTest.kt
@@ -1,0 +1,84 @@
+package io.runtime.mcumgr.transfer
+
+import io.runtime.mcumgr.McuMgrHeader
+import io.runtime.mcumgr.managers.ImageManager
+import io.runtime.mcumgr.mock.McuMgrHandler
+import io.runtime.mcumgr.mock.MockBleMcuMgrTransport
+import io.runtime.mcumgr.response.McuMgrResponse
+import io.runtime.mcumgr.response.img.McuMgrImageUploadResponse
+import io.runtime.mcumgr.util.CBOR
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class UploaderTest {
+
+    @Test
+    fun `test image Uploader`() {
+        // Parameters
+        val data = ByteArray(100000) { 0 } // keep it > 64k
+        val mtu = 249
+        val image = 1
+
+        // Test values
+        var received = 0
+
+        // Upload handler
+        val handler = object : McuMgrHandler {
+            override fun <T : McuMgrResponse> handle(
+                header: McuMgrHeader,
+                payload: ByteArray,
+                responseType: Class<T>
+            ): T {
+                assert(payload.size + McuMgrHeader.HEADER_LENGTH <= mtu) {
+                    "Payload size is too big (${payload.size + McuMgrHeader.HEADER_LENGTH} / $mtu) at $received"
+                }
+
+                val map = CBOR.toObjectMap(payload)
+                assertTrue { map.containsKey("off") }
+                assertTrue { map.containsKey("data") }
+
+                val off = map["off"] as Int
+                if (off == 0) {
+                    assertTrue { map.containsKey("len") }
+                    assertTrue { map.containsKey("sha") }
+                    val len = map["len"] as Int
+                    assertEquals(data.size, len)
+
+                    if (image != 0) {
+                        assertTrue { map.containsKey("image") }
+                        val img = map["image"] as Int
+                        assertEquals(image, img)
+                    } else {
+                        assertFalse { map.containsKey("image") }
+                    }
+                } else {
+                    assertFalse { map.containsKey("len") }
+                    assertFalse { map.containsKey("sha") }
+                    assertFalse { map.containsKey("image") }
+                }
+                val chunk = map["data"] as ByteArray
+                received += chunk.size
+
+                return McuMgrImageUploadResponse()
+                    .apply {
+                        this.off = received
+                        this.rc = 0 // Success
+                    } as T
+            }
+        }
+
+        // Test
+        val im = ImageManager(MockBleMcuMgrTransport(handler))
+        im.setUploadMtu(mtu)
+        val uploader = ImageUploader(im, data, image, 4, 1)
+        runBlocking { uploader.upload() }
+
+        // Ensure that the
+        assertEquals(data.size, received)
+    }
+
+}
+

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -49,7 +49,7 @@ android {
 
 dependencies {
     implementation 'androidx.activity:activity:1.6.1'
-    implementation 'androidx.fragment:fragment:1.5.4'
+    implementation 'androidx.fragment:fragment:1.5.5'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
@@ -59,14 +59,14 @@ dependencies {
     implementation 'com.google.android.material:material:1.8.0-alpha03'
     // This is added to fix dependency issue with androidx.preference:preference:1.2.0,
     // which for some reason depends on androidx.fragment:fragment-ktx:1.3.6.
-    implementation 'androidx.fragment:fragment-ktx:1.5.4'
+    implementation 'androidx.fragment:fragment-ktx:1.5.5'
 
     // Dagger 2
-    implementation 'com.google.dagger:dagger:2.44'
-    implementation 'com.google.dagger:dagger-android:2.44'
-    implementation 'com.google.dagger:dagger-android-support:2.44'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.44'
-    annotationProcessor 'com.google.dagger:dagger-android-processor:2.44'
+    implementation 'com.google.dagger:dagger:2.44.2'
+    implementation 'com.google.dagger:dagger-android:2.44.2'
+    implementation 'com.google.dagger:dagger-android-support:2.44.2'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.44.2'
+    annotationProcessor 'com.google.dagger:dagger-android-processor:2.44.2'
 
     // Brings the new BluetoothLeScanner API to older platforms
     implementation 'no.nordicsemi.android.support.v18:scanner:1.6.0'


### PR DESCRIPTION
This PR fixes #88.

The main issue fixed in this PR is 5259f9d0d93e666a12af1fe3ae3a2ef3807ff159.
This commit fixes CBOR overhead calculation for cases where the offset was greater than 65535 and less than 65636. In that case the method was incorrectly returning 3 bytes, not 5.

The PR also fixes and adds a new test for this specific case.