### PR TITLE
Updatying dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@
 
 buildscript {
     // https://kotlinlang.org/docs/releases.html#release-details
-    ext.kotlin_version = '1.8.10'
+    ext.kotlin_version = '1.8.21'
     // https://plugins.gradle.org/plugin/io.github.gradle-nexus.publish-plugin
     ext.gradle_nexus_publish_plugin = '1.1.0'
 
@@ -19,7 +19,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:8.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.github.gradle-nexus:publish-plugin:$gradle_nexus_publish_plugin"
     }

--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -10,11 +10,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
+    namespace "io.runtime.mcumgr.ble"
 
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 33
+        targetSdkVersion 34
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -26,8 +27,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 
@@ -39,10 +40,10 @@ dependencies {
     api 'no.nordicsemi.android:ble:2.6.0'
 
     // Logging
-    implementation 'org.slf4j:slf4j-api:1.7.25'
+    implementation 'org.slf4j:slf4j-api:1.7.30'
 
     // Kotlin
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"

--- a/mcumgr-ble/src/main/AndroidManifest.xml
+++ b/mcumgr-ble/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest
-    package="io.runtime.mcumgr.ble"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!--

--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -250,13 +250,13 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
 
     /**
      * Sets the initial MTU size to be requested upon connection.
-     *
+     * <p>
      * In general, it is the device side that should decide the MTU size. However, if the device
      * claims support for higher MTU than in fact it does, this method can be used to lower the MTU.
-     *
+     * <p>
      * By default, this is set to 498. This MTU will be requested when connecting to the device.
      * If the device supports lower MTU, it will be used instead.
-     *
+     * <p>
      * This method should be called before connecting to the device and has no affect after.
      * @param mtu The initial MTU size to be requested upon connection.
      */
@@ -266,7 +266,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
 
     /**
      * Sets the maximum packet length for the transport.
-     *
+     * <p>
      * Starting from version 1.3 the library can automatically obtain the value from a device build
      * on nRF Connect SDK 2.0+ using the new {@link DefaultManager#params()} command. If the feature
      * is not supported on the device the maximum length defaults to MTU-3 bytes.
@@ -300,23 +300,11 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
     @Override
     public void log(int priority, @NonNull String message) {
         switch (priority) {
-            case Log.DEBUG:
-                LOG.debug(message);
-                break;
-            case Log.INFO:
-                LOG.info(message);
-                break;
-            case Log.WARN:
-                LOG.warn(message);
-                break;
-            case Log.ERROR:
-            case Log.ASSERT:
-                LOG.error(message);
-                break;
-            case Log.VERBOSE:
-            default:
-                LOG.trace(message);
-                break;
+            case Log.DEBUG -> LOG.debug(message);
+            case Log.INFO -> LOG.info(message);
+            case Log.WARN -> LOG.warn(message);
+            case Log.ERROR, Log.ASSERT -> LOG.error(message);
+            case Log.VERBOSE -> LOG.trace(message);
         }
     }
 
@@ -430,30 +418,25 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                     });
                 }).fail((device, status) -> {
                     switch (status) {
-                        case FailCallback.REASON_REQUEST_FAILED:
-                            // This could be thrown only if the manager was requested to connect for
-                            // a second time and to a different device than the one that's already
-                            // connected. This may not happen here, as the device is given in the
-                            // constructor.
-                            // This may also happen if service discovery ends with an error, which
-                            // will trigger disconnection.
-                        case FailCallback.REASON_DEVICE_DISCONNECTED:
-                        case FailCallback.REASON_CANCELLED:
-                            callback.onError(new McuMgrDisconnectedException());
-                            break;
-                        case FailCallback.REASON_DEVICE_NOT_SUPPORTED:
-                            callback.onError(new McuMgrNotSupportedException());
-                            break;
-                        case FailCallback.REASON_TIMEOUT:
+                        // This could be thrown only if the manager was requested to connect for
+                        // a second time and to a different device than the one that's already
+                        // connected. This may not happen here, as the device is given in the
+                        // constructor.
+                        // This may also happen if service discovery ends with an error, which
+                        // will trigger disconnection.
+                        case FailCallback.REASON_REQUEST_FAILED,
+                             FailCallback.REASON_DEVICE_DISCONNECTED,
+                             FailCallback.REASON_CANCELLED ->
+                                callback.onError(new McuMgrDisconnectedException());
+                        case FailCallback.REASON_DEVICE_NOT_SUPPORTED ->
+                                callback.onError(new McuMgrNotSupportedException());
+                        case FailCallback.REASON_TIMEOUT ->
                             // Called after receiving error 133 after 30 seconds.
-                            callback.onError(new McuMgrTimeoutException());
-                            break;
-                        case FailCallback.REASON_BLUETOOTH_DISABLED:
-                            callback.onError(new McuMgrBluetoothDisabledException());
-                            break;
-                        default:
-                            callback.onError(new McuMgrException(GattError.parseConnectionError(status)));
-                            break;
+                                callback.onError(new McuMgrTimeoutException());
+                        case FailCallback.REASON_BLUETOOTH_DISABLED ->
+                                callback.onError(new McuMgrBluetoothDisabledException());
+                        default ->
+                                callback.onError(new McuMgrException(GattError.parseConnectionError(status)));
                     }
                 })
         .retry(3, 500)
@@ -482,30 +465,25 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                         return;
                     }
                     switch (status) {
-                        case FailCallback.REASON_REQUEST_FAILED:
-                            // This could be thrown only if the manager was requested to connect for
-                            // a second time and to a different device than the one that's already
-                            // connected. This may not happen here, as the device is given in the
-                            // constructor.
-                            // This may also happen if service discovery ends with an error, which
-                            // will trigger disconnection.
-                        case FailCallback.REASON_DEVICE_DISCONNECTED:
-                        case FailCallback.REASON_CANCELLED:
-                            callback.onError(new McuMgrDisconnectedException());
-                            break;
-                        case FailCallback.REASON_DEVICE_NOT_SUPPORTED:
-                            callback.onError(new McuMgrNotSupportedException());
-                            break;
-                        case FailCallback.REASON_TIMEOUT:
+                        // This could be thrown only if the manager was requested to connect for
+                        // a second time and to a different device than the one that's already
+                        // connected. This may not happen here, as the device is given in the
+                        // constructor.
+                        // This may also happen if service discovery ends with an error, which
+                        // will trigger disconnection.
+                        case FailCallback.REASON_REQUEST_FAILED,
+                             FailCallback.REASON_DEVICE_DISCONNECTED,
+                             FailCallback.REASON_CANCELLED ->
+                                callback.onError(new McuMgrDisconnectedException());
+                        case FailCallback.REASON_DEVICE_NOT_SUPPORTED ->
+                                callback.onError(new McuMgrNotSupportedException());
+                        case FailCallback.REASON_TIMEOUT ->
                             // Called after receiving error 133 after 30 seconds.
-                            callback.onError(new McuMgrTimeoutException());
-                            break;
-                        case FailCallback.REASON_BLUETOOTH_DISABLED:
-                            callback.onError(new McuMgrBluetoothDisabledException());
-                            break;
-                        default:
-                            callback.onError(new McuMgrException(GattError.parseConnectionError(status)));
-                            break;
+                                callback.onError(new McuMgrTimeoutException());
+                        case FailCallback.REASON_BLUETOOTH_DISABLED ->
+                                callback.onError(new McuMgrBluetoothDisabledException());
+                        default ->
+                                callback.onError(new McuMgrException(GattError.parseConnectionError(status)));
                     }
                 })
                 .enqueue();
@@ -588,7 +566,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
      * device has disconnected, Service Changed indication was received, or
      * {@link BleManager#refreshDeviceCache()} request was executed, which has invalidated cached
      * services.
-     *
+     * <p>
      * In version 1.6.0 this method was renamed from {@link #onServicesInvalidated()}, which is now
      * final. This is due to migration to Android BLE Library 2.6.0.
      * @since 1.6.0

--- a/mcumgr-core/build.gradle
+++ b/mcumgr-core/build.gradle
@@ -10,11 +10,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
+    namespace "io.runtime.mcumgr"
 
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 33
+        targetSdkVersion 34
     }
 
     buildTypes {
@@ -25,8 +26,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 
@@ -35,10 +36,10 @@ dependencies {
     implementation 'org.jetbrains:annotations:24.0.0'
 
     // Logging
-    implementation 'org.slf4j:slf4j-api:1.7.25'
+    implementation 'org.slf4j:slf4j-api:1.7.30'
 
     // Kotlin
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1'
 
     // Import CBOR parser
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.14.2'

--- a/mcumgr-core/src/main/AndroidManifest.xml
+++ b/mcumgr-core/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.runtime.mcumgr" />
+<manifest />

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -8,12 +8,13 @@ apply plugin: 'com.android.application'
 apply from: rootProject.file("gradle/git-tag-version.gradle")
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
+    namespace "io.runtime.mcumgr.sample"
 
     defaultConfig {
         applicationId "no.nordicsemi.android.nrfconnectdevicemanager"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode getVersionCodeFromTags()
         versionName getVersionNameFromTags()
         resConfigs 'en'
@@ -31,8 +32,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildFeatures {
@@ -53,25 +54,25 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.activity:activity:1.6.1'
-    implementation 'androidx.fragment:fragment:1.5.5'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation 'androidx.activity:activity:1.7.2'
+    implementation 'androidx.fragment:fragment:1.6.0'
+    implementation 'androidx.recyclerview:recyclerview:1.3.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.preference:preference:1.2.0'
-    implementation 'androidx.core:core-splashscreen:1.0.0'
-    implementation 'com.google.android.material:material:1.9.0-alpha02'
+    implementation 'androidx.core:core-splashscreen:1.0.1'
+    implementation 'com.google.android.material:material:1.10.0-alpha05'
     // This is added to fix dependency issue with androidx.preference:preference:1.2.0,
     // which for some reason depends on androidx.fragment:fragment-ktx:1.3.6.
-    implementation 'androidx.fragment:fragment-ktx:1.5.5'
+    implementation 'androidx.fragment:fragment-ktx:1.6.0'
 
     // Dagger 2
-    implementation 'com.google.dagger:dagger:2.45'
-    implementation 'com.google.dagger:dagger-android:2.45'
-    implementation 'com.google.dagger:dagger-android-support:2.45'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.44.2'
-    annotationProcessor 'com.google.dagger:dagger-android-processor:2.44.2'
+    implementation 'com.google.dagger:dagger:2.46.1'
+    implementation 'com.google.dagger:dagger-android:2.46.1'
+    implementation 'com.google.dagger:dagger-android-support:2.46.1'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.46.1'
+    annotationProcessor 'com.google.dagger:dagger-android-processor:2.46.1'
 
     // Brings the new BluetoothLeScanner API to older platforms
     implementation 'no.nordicsemi.android.support.v18:scanner:1.6.0'

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:tools="http://schemas.android.com/tools"
-	package="io.runtime.mcumgr.sample">
+	xmlns:tools="http://schemas.android.com/tools">
 
 	<!-- Bluetooth permission is required in order to communicate with Bluetooth LE devices. -->
 	<uses-permission

--- a/sample/src/main/java/io/runtime/mcumgr/sample/MainActivity.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/MainActivity.java
@@ -81,6 +81,7 @@ public class MainActivity extends AppCompatActivity
             if (id == R.id.nav_fs) t.show(filesFragment); else t.hide(filesFragment);
             if (id == R.id.nav_stats) t.show(logsStatsFragment); else t.hide(logsStatsFragment);
             if (id == R.id.nav_shell) t.show(shellFragment); else t.hide(shellFragment);
+            t.runOnCommit(this::invalidateMenu);
             t.commit();
             return true;
         });

--- a/sample/src/main/java/io/runtime/mcumgr/sample/ScannerActivity.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/ScannerActivity.java
@@ -7,7 +7,6 @@
 package io.runtime.mcumgr.sample;
 
 import android.Manifest;
-import android.annotation.SuppressLint;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.content.Intent;
@@ -202,22 +201,23 @@ public class ScannerActivity extends AppCompatActivity
         return true;
     }
 
-    @SuppressLint("NonConstantResourceId")
     @Override
     public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.filter_uuid:
-                item.setChecked(!item.isChecked());
-                scannerViewModel.filterByUuid(item.isChecked());
-                return true;
-            case R.id.filter_nearby:
-                item.setChecked(!item.isChecked());
-                scannerViewModel.filterByDistance(item.isChecked());
-                return true;
-            case R.id.menu_about:
-                final Intent launchIntro = new Intent(this, IntroActivity.class);
-                startActivity(launchIntro);
-                return true;
+        final int itemId = item.getItemId();
+        if (itemId == R.id.filter_uuid) {
+            item.setChecked(!item.isChecked());
+            scannerViewModel.filterByUuid(item.isChecked());
+            return true;
+        }
+        if (itemId == R.id.filter_nearby) {
+            item.setChecked(!item.isChecked());
+            scannerViewModel.filterByDistance(item.isChecked());
+            return true;
+        }
+        if (itemId == R.id.menu_about) {
+            final Intent launchIntro = new Intent(this, IntroActivity.class);
+            startActivity(launchIntro);
+            return true;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/FilesFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/FilesFragment.java
@@ -16,8 +16,10 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
 import io.runtime.mcumgr.sample.R;
 import io.runtime.mcumgr.sample.dialog.PartitionDialogFragment;
 
@@ -26,23 +28,6 @@ public class FilesFragment extends Fragment {
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setHasOptionsMenu(true);
-    }
-
-    @Override
-    public void onCreateOptionsMenu(@NonNull final Menu menu, @NonNull final MenuInflater inflater) {
-        inflater.inflate(R.menu.settings, menu);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_settings:
-                final DialogFragment dialog = PartitionDialogFragment.getInstance();
-                dialog.show(getChildFragmentManager(), null);
-                return true;
-        }
-        return false;
     }
 
     @Nullable
@@ -51,5 +36,33 @@ public class FilesFragment extends Fragment {
                              @Nullable final ViewGroup container,
                              @Nullable final Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_fs, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        requireActivity().addMenuProvider(new MenuProvider() {
+            @Override
+            public void onCreateMenu(@NonNull final Menu menu, @NonNull final MenuInflater menuInflater) {
+                menuInflater.inflate(R.menu.settings, menu);
+            }
+
+            @Override
+            public void onPrepareMenu(@NonNull final Menu menu) {
+                menu.findItem(R.id.action_settings)
+                        .setVisible(isVisible());
+            }
+
+            @Override
+            public boolean onMenuItemSelected(@NonNull final MenuItem menuItem) {
+                if (menuItem.getItemId() == R.id.action_settings) {
+                    final DialogFragment dialog = PartitionDialogFragment.getInstance();
+                    dialog.show(getChildFragmentManager(), null);
+                    return true;
+                }
+                return false;
+            }
+        }, getViewLifecycleOwner(), Lifecycle.State.RESUMED);
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageControlFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageControlFragment.java
@@ -16,20 +16,17 @@ import android.text.Spanned;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
 import android.view.LayoutInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
+import javax.inject.Inject;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
-
-import javax.inject.Inject;
-
 import io.runtime.mcumgr.McuMgrErrorCode;
 import io.runtime.mcumgr.exception.McuMgrErrorException;
 import io.runtime.mcumgr.exception.McuMgrException;
@@ -43,8 +40,7 @@ import io.runtime.mcumgr.sample.utils.StringUtils;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.ImageControlViewModel;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.McuMgrViewModelFactory;
 
-public class ImageControlFragment extends Fragment implements Injectable,
-        Toolbar.OnMenuItemClickListener, SelectImageDialogFragment.OnImageSelectedListener {
+public class ImageControlFragment extends Fragment implements Injectable, SelectImageDialogFragment.OnImageSelectedListener {
     private static final int REQUEST_TEST    = 1;
     private static final int REQUEST_CONFIRM = 2;
     private static final int REQUEST_ERASE   = 3;
@@ -70,7 +66,16 @@ public class ImageControlFragment extends Fragment implements Injectable,
                              @Nullable final Bundle savedInstanceState) {
         binding = FragmentCardImageControlBinding.inflate(inflater, container, false);
         binding.toolbar.inflateMenu(R.menu.help);
-        binding.toolbar.setOnMenuItemClickListener(this);
+        binding.toolbar.setOnMenuItemClickListener(item -> {
+            if (item.getItemId() == R.id.action_help) {
+                final DialogFragment dialog = HelpDialogFragment.getInstance(
+                        R.string.image_control_dialog_help_title,
+                        R.string.image_control_dialog_help_message);
+                dialog.show(getChildFragmentManager(), null);
+                return true;
+            }
+            return false;
+        });
         return  binding.getRoot();
     }
 
@@ -115,30 +120,11 @@ public class ImageControlFragment extends Fragment implements Injectable,
     }
 
     @Override
-    public boolean onMenuItemClick(final MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_help:
-                final DialogFragment dialog = HelpDialogFragment.getInstance(
-                        R.string.image_control_dialog_help_title,
-                        R.string.image_control_dialog_help_message);
-                dialog.show(getChildFragmentManager(), null);
-                return true;
-        }
-        return false;
-    }
-
-    @Override
     public void onImageSelected(final int requestId, final int image) {
         switch (requestId) {
-            case REQUEST_TEST:
-                viewModel.test(image);
-                break;
-            case REQUEST_CONFIRM:
-                viewModel.confirm(image);
-                break;
-            case REQUEST_ERASE:
-                viewModel.erase(image);
-                break;
+            case REQUEST_TEST -> viewModel.test(image);
+            case REQUEST_CONFIRM -> viewModel.confirm(image);
+            case REQUEST_ERASE -> viewModel.erase(image);
         }
     }
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageSettingsFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageSettingsFragment.java
@@ -14,7 +14,6 @@ import android.text.Spanned;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
 import android.view.LayoutInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -22,7 +21,6 @@ import javax.inject.Inject;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
@@ -38,7 +36,7 @@ import io.runtime.mcumgr.sample.utils.StringUtils;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.ImageSettingsViewModel;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.McuMgrViewModelFactory;
 
-public class ImageSettingsFragment extends Fragment implements Injectable, Toolbar.OnMenuItemClickListener {
+public class ImageSettingsFragment extends Fragment implements Injectable {
 
     @Inject
     McuMgrViewModelFactory viewModelFactory;
@@ -61,7 +59,16 @@ public class ImageSettingsFragment extends Fragment implements Injectable, Toolb
                              @Nullable final Bundle savedInstanceState) {
         binding = FragmentCardImageEraseSettingsBinding.inflate(inflater, container, false);
         binding.toolbar.inflateMenu(R.menu.help);
-        binding.toolbar.setOnMenuItemClickListener(this);
+        binding.toolbar.setOnMenuItemClickListener(item -> {
+            if (item.getItemId() == R.id.action_help) {
+                final DialogFragment dialog = HelpDialogFragment.getInstance(
+                        R.string.image_settings_dialog_help_title,
+                        R.string.image_settings_dialog_help_message);
+                dialog.show(getChildFragmentManager(), null);
+                return true;
+            }
+            return false;
+        });
         return  binding.getRoot();
     }
 
@@ -86,19 +93,6 @@ public class ImageSettingsFragment extends Fragment implements Injectable, Toolb
     public void onDestroyView() {
         super.onDestroyView();
         binding = null;
-    }
-
-    @Override
-    public boolean onMenuItemClick(final MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_help:
-                final DialogFragment dialog = HelpDialogFragment.getInstance(
-                        R.string.image_settings_dialog_help_title,
-                        R.string.image_settings_dialog_help_message);
-                dialog.show(getChildFragmentManager(), null);
-                return true;
-        }
-        return false;
     }
 
     private void printError(@Nullable final McuMgrException error) {

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUploadFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUploadFragment.java
@@ -13,19 +13,16 @@ import android.text.Spanned;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
 import android.view.LayoutInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
+import javax.inject.Inject;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProvider;
-
-import javax.inject.Inject;
-
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.image.McuMgrImage;
 import io.runtime.mcumgr.sample.R;
@@ -37,8 +34,7 @@ import io.runtime.mcumgr.sample.utils.StringUtils;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.ImageUploadViewModel;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.McuMgrViewModelFactory;
 
-public class ImageUploadFragment extends FileBrowserFragment implements Injectable,
-        Toolbar.OnMenuItemClickListener, SelectImageDialogFragment.OnImageSelectedListener {
+public class ImageUploadFragment extends FileBrowserFragment implements Injectable, SelectImageDialogFragment.OnImageSelectedListener {
     private static final int REQUEST_UPLOAD = 0;
 
     @Inject
@@ -62,7 +58,16 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
                              @Nullable final Bundle savedInstanceState) {
         binding = FragmentCardImageUploadBinding.inflate(inflater, container, false);
         binding.toolbar.inflateMenu(R.menu.help);
-        binding.toolbar.setOnMenuItemClickListener(this);
+        binding.toolbar.setOnMenuItemClickListener(item -> {
+            if (item.getItemId() == R.id.action_help) {
+                final DialogFragment dialog = HelpDialogFragment.getInstance(
+                        R.string.image_upload_dialog_help_title,
+                        R.string.image_upload_dialog_help_message);
+                dialog.show(getChildFragmentManager(), null);
+                return true;
+            }
+            return false;
+        });
         return binding.getRoot();
     }
 
@@ -83,20 +88,14 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
             binding.actionPauseResume.setVisibility(state.inProgress() ? View.VISIBLE : View.GONE);
             // Update status
             switch (state) {
-                case VALIDATING:
-                    binding.status.setText(R.string.image_upload_status_validating);
-                    break;
-                case UPLOADING:
-                    binding.status.setText(R.string.image_upload_status_uploading);
-                    break;
-                case PAUSED:
-                    binding.status.setText(R.string.image_upload_status_paused);
-                    break;
-                case COMPLETE:
+                case VALIDATING -> binding.status.setText(R.string.image_upload_status_validating);
+                case UPLOADING -> binding.status.setText(R.string.image_upload_status_uploading);
+                case PAUSED -> binding.status.setText(R.string.image_upload_status_paused);
+                case COMPLETE -> {
                     clearFileContent();
                     binding.status.setText(R.string.image_upload_status_completed);
                     binding.speed.setText(null);
-                    break;
+                }
             }
         });
         viewModel.getTransferSpeed().observe(getViewLifecycleOwner(), speed ->
@@ -155,19 +154,6 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
     public void onDestroyView() {
         super.onDestroyView();
         binding = null;
-    }
-
-    @Override
-    public boolean onMenuItemClick(final MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_help:
-                final DialogFragment dialog = HelpDialogFragment.getInstance(
-                        R.string.image_upload_dialog_help_title,
-                        R.string.image_upload_dialog_help_message);
-                dialog.show(getChildFragmentManager(), null);
-                return true;
-        }
-        return false;
     }
 
     @Override


### PR DESCRIPTION
This PR updates all dependencies to latest versions, including:
- Kotlin 1.8.21
- Required Java 17
- Gradle build tools 8.0.2

and fixes related issues:
- migration to extended `switch` wherever possible,
- migration to `MenuProvider` instead of `onOptionsMenuSelected` in `Fragment`s.
- Moving Toolbar menu handlers to toolbars initialization,