### PR TITLE
Bug fix: merging SMP response for Mcu parameters

### DIFF
--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -668,6 +668,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                 )
                 // The response should be received immediately.
                 .timeout(1000 /* ms */)
+                .merge(new SmpMerger())
                 .with((device, data) -> {
                     final byte[] bytes = data.getValue();
                     // If the response is 14 bytes or shorter, that means the McuMgr Params


### PR DESCRIPTION
This PR fixes an issue happening with MTU was too low to fit Mcu Parameters response in a single GATT notification.
Without the `SmpMerger` the first received notification was ignored and the MTU used for connection was too low to support most of the functionality.
With this fix, the low MTU is overwritten by `buf_size` param, as the fw side can reassemble long SMP packets sent split into multiple GATT writes.