### PR TITLE
Image validation

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
 import java.util.HashMap;
 
 import io.runtime.mcumgr.McuMgrCallback;
@@ -57,7 +56,6 @@ public class ImageManager extends TransferManager {
     private final static Logger LOG = LoggerFactory.getLogger(ImageManager.class);
 
     private final static int IMG_HASH_LEN = 32;
-    private final static int TRUNCATED_HASH_LEN = 3;
 
     // Image manager command IDs
     private final static int ID_STATE = 0;
@@ -224,14 +222,12 @@ public class ImageManager extends TransferManager {
              * Feature in Apache Mynewt: Device keeps track of unfinished uploads based on the
              * SHA256 hash over the image data. When an upload request is received which contains
              * the same hash of a partially finished upload, the device will send the offset to
-             * continue from. The hash is truncated to save packet
+             * continue from.
              */
             try {
                 MessageDigest digest = MessageDigest.getInstance("SHA-256");
                 byte[] hash = digest.digest(data);
-                // Truncate the hash to save space.
-                byte[] truncatedHash = Arrays.copyOf(hash, TRUNCATED_HASH_LEN);
-                payloadMap.put("sha", truncatedHash);
+                payloadMap.put("sha", hash);
             } catch (NoSuchAlgorithmException e) {
                 e.printStackTrace();
             }
@@ -812,7 +808,7 @@ public class ImageManager extends TransferManager {
                         overheadTestMap.put("image", image);
                     }
                     overheadTestMap.put("len", data.length);
-                    overheadTestMap.put("sha", new byte[TRUNCATED_HASH_LEN]);
+                    overheadTestMap.put("sha", new byte[IMG_HASH_LEN]);
                 }
                 byte[] header = {0, 0, 0, 0, 0, 0, 0, 0};
                 overheadTestMap.put("_h", header);

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageUploadResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageUploadResponse.java
@@ -7,10 +7,26 @@
 package io.runtime.mcumgr.response.img;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.jetbrains.annotations.Nullable;
 
 import io.runtime.mcumgr.response.UploadResponse;
 
 public class McuMgrImageUploadResponse extends UploadResponse {
+
+    /**
+     * Since NCS 2.4 the SMP server expects 32-byte 'sha' of the image sent with the
+     * first data packet. After the upload is complete this variable will contain information
+     * whether the SHA=256 matched the received image.
+     * <p>
+     * Client may abort when match is false instead of trying to confirm. This is only to ensure the
+     * full file was sent correctly, not to validate the file or its signature.
+     */
+    @JsonProperty("match")
+    @Nullable
+    public Boolean match;
+
     @JsonCreator
     public McuMgrImageUploadResponse() {}
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ImageUploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ImageUploader.kt
@@ -95,10 +95,10 @@ private fun ImageManager.uploadAsync(
 ) = send(OP_WRITE, ID_UPLOAD, requestMap, timeout, McuMgrImageUploadResponse::class.java,
     object : McuMgrCallback<McuMgrImageUploadResponse> {
         override fun onResponse(response: McuMgrImageUploadResponse) {
-            // Since NCS 2.4 if the first packet of a image upload contains a 32-byte SHA-256
-            // parameter, the last packet (where reported offset is equal to the image size)
-            // will contain a "match" parameter with a flag whether the received file matches
-            // previously sent digest. This parameter is only sent in the last packet and
+            // Since nRF Connect SDK (NCS) 2.3 if the first packet of a image upload contains a
+            // 32-byte SHA-256 parameter, the last packet (where reported offset is equal to the
+            // image size) will contain a "match" parameter with a flag whether the received file
+            // matches previously sent digest. This parameter is only sent in the last packet and
             // omitted otherwise.
             if (response.match == false) {
                 callback(UploadResult.Failure(DigestException("Image digest does not match, try again.")))

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ImageUploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ImageUploader.kt
@@ -7,11 +7,11 @@ import io.runtime.mcumgr.response.UploadResponse
 import io.runtime.mcumgr.util.CBOR
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
-import java.util.*
 
 private const val OP_WRITE = 2
 private const val ID_UPLOAD = 1
-private const val TRUNCATED_HASH_LEN = 3
+
+private const val IMG_HASH_LEN = 32
 
 @Deprecated(
     message = "Use TransferManager.windowUpload instead",
@@ -61,7 +61,7 @@ open class ImageUploader(
         // "sha" and "image" params are only sent in the first packet.
         0 -> {
             val shaSize =
-                CBOR.stringLength("sha") + CBOR.uintLength(TRUNCATED_HASH_LEN) + TRUNCATED_HASH_LEN
+                CBOR.stringLength("sha") + CBOR.uintLength(IMG_HASH_LEN) + IMG_HASH_LEN
             val imageSize = if (image > 0) {
                 CBOR.stringLength("image") + CBOR.uintLength(image)
             } else 0
@@ -80,9 +80,7 @@ open class ImageUploader(
     private fun sha(data: ByteArray): ByteArray? {
         return try {
             val digest = MessageDigest.getInstance("SHA-256")
-            val hash = digest.digest(data)
-            // Truncate the hash to save space.
-            Arrays.copyOf(hash, TRUNCATED_HASH_LEN)
+            digest.digest(data)
         } catch (e: NoSuchAlgorithmException) {
             null
         }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
@@ -341,7 +341,7 @@ abstract class Uploader(
         if (offset == 0) {
             it["len"] = this.data.size // NOT data.size, as data is just a chunk of this.data
         }
-        getAdditionalData(data, offset, it)
+        getAdditionalData(this.data, offset, it)
     }
 
     /**

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
@@ -2,6 +2,7 @@ package io.runtime.mcumgr.transfer
 
 import io.runtime.mcumgr.McuMgrScheme
 import io.runtime.mcumgr.exception.InsufficientMtuException
+import io.runtime.mcumgr.exception.McuMgrErrorException
 import io.runtime.mcumgr.exception.McuMgrException
 import io.runtime.mcumgr.exception.McuMgrTimeoutException
 import io.runtime.mcumgr.util.CBOR
@@ -18,6 +19,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
 import org.slf4j.LoggerFactory
+import java.security.DigestException
 import kotlin.math.min
 
 const val MAX_CHUNK_FAILURES = 5
@@ -141,6 +143,12 @@ abstract class Uploader(
                     // On insufficient MTU, the uploader will be restarted with proper MTU set.
                     // The proper MTU value is embedded in the exception.
                     if (failure is InsufficientMtuException) {
+                        throw failure
+                    }
+
+                    // This error may be thrown after sending all data when reported digest does
+                    // not match the data sent.
+                    if (failure is DigestException) {
                         throw failure
                     }
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/utils/StringUtils.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/utils/StringUtils.java
@@ -52,6 +52,10 @@ public class StringUtils {
         } else if (error instanceof McuMgrTimeoutException) {
             return context.getString(R.string.status_connection_timeout);
         }
-        return error != null ? error.getMessage() : null;
+        return error != null ?
+                error.getCause() != null ?
+                        error.getCause().getMessage() :
+                        error.getMessage() :
+                null;
     }
 }


### PR DESCRIPTION
This PR replaces #81.

In NCS 2.3 a new feature was added to ensure image transfer integrity. The `sha` parameter, which before was truncated to 3 bytes, is now sent in its full size. Receiver will store it and compare to the SHA-256 of the received image and will report match or no match with a new parameter `match`, sent to the central after upload is complete.

In case of no match update is aborted with error message:
![Screenshot_20230725_155852](https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/assets/6576580/0efcd397-af30-46fe-9d60-90b9f8625f27)
