### PR TITLE
Handling image upload errors

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/McuMgrErrorCode.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/McuMgrErrorCode.java
@@ -17,6 +17,9 @@ import org.jetbrains.annotations.NotNull;
  * determined based on the request and error code. Since McuManager errors are vague and often the
  * same error code could be caused by different reasons, the best way to debug errors here is
  * step through the handler on the device to determine the cause.
+ * <p>
+ * List of possible error codes may be found
+ * <a href="https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/mgmt/mcumgr/mgmt/mgmt.h">here</a>.
  */
 public enum McuMgrErrorCode {
     /**
@@ -56,6 +59,21 @@ public enum McuMgrErrorCode {
      * Command is not supported.
      */
     NOT_SUPPORTED(8),
+    /**
+     * Corrupt.
+     */
+    CORRUPT(9),
+    /**
+     * Command blocked by processing of other command.
+     */
+    BUSY(10),
+    /**
+     * Access to specific function, command or resource denied.
+     */
+    ACCESS_DENIED(11),
+    /**
+     * User errors defined from 256 onwards.
+     */
     PER_USER(256);
 
     private final int mCode;
@@ -68,6 +86,7 @@ public enum McuMgrErrorCode {
         return mCode;
     }
 
+    @NotNull
     @Override
     public String toString() {
         return super.toString() + " (" + mCode + ")";
@@ -75,29 +94,21 @@ public enum McuMgrErrorCode {
 
     @NotNull
     public static McuMgrErrorCode valueOf(int error) {
-        switch (error) {
-            case 0:
-                return OK;
-            case 1:
-                return UNKNOWN;
-            case 2:
-                return NO_MEMORY;
-            case 3:
-                return IN_VALUE;
-            case 4:
-                return TIMEOUT;
-            case 5:
-                return NO_ENTRY;
-            case 6:
-                return BAD_STATE;
-            case 7:
-                return TOO_LARGE;
-            case 8:
-                return NOT_SUPPORTED;
-            case 256:
-                return PER_USER;
-            default:
-                return UNKNOWN;
-        }
+        return switch (error) {
+            case 0 -> OK;
+            // case 1 is equal to default case
+            case 2 -> NO_MEMORY;
+            case 3 -> IN_VALUE;
+            case 4 -> TIMEOUT;
+            case 5 -> NO_ENTRY;
+            case 6 -> BAD_STATE;
+            case 7 -> TOO_LARGE;
+            case 8 -> NOT_SUPPORTED;
+            case 9 -> CORRUPT;
+            case 10 -> BUSY;
+            case 11 -> ACCESS_DENIED;
+            case 256 -> PER_USER;
+            default -> UNKNOWN;
+        };
     }
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
@@ -140,6 +140,11 @@ abstract class Uploader(
                         }
                     }
                 }.onErrorOrFailure { failure ->
+                    // If a non-success response was returned abort sending the file.
+                    if (failure is McuMgrErrorException) {
+                        throw failure
+                    }
+
                     // On insufficient MTU, the uploader will be restarted with proper MTU set.
                     // The proper MTU value is embedded in the exception.
                     if (failure is InsufficientMtuException) {
@@ -192,6 +197,7 @@ abstract class Uploader(
                 next.send(nextChunk)
             }
         }
+        window.release()
     }
 
     /**

--- a/sample/src/main/res/values/strings_errors.xml
+++ b/sample/src/main/res/values/strings_errors.xml
@@ -16,6 +16,9 @@
 		<item>Bad state (6)</item>
 		<item>Too large (7)</item>
 		<item>Not supported (8)</item>
+		<item>Corrupt (9)</item>
+		<item>Busy (10)</item>
+		<item>Access Denied (11)</item>
 	</string-array>
 	<string name="mcu_mgr_error_other">Unknown error (%d)</string>
 </resources>


### PR DESCRIPTION
Sometimes a device that is being updated can't handle update or wants to reject the image (e.g. to prevent downgrade).
In that case it may send a message with `rc` instead of simply confirming received data with `off` (offset) parameter. In the normal case, where `off` is returned, the `rc` would be 0 (success) and is omitted.

Before this change, the error would trigger resending the same packet 3 times and eventually failing with some unrelated error. Now the error aborts the upload and it is shown to the user.

Also, this PR updated list of available error codes adding:
- CORRUPT
- BUST
- ACCESS DENIED

List of all errors is available here: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/mgmt/mcumgr/mgmt/mgmt.h