### PR TITLE
SMP protocol version 2: Adding "err" field for group responses

### DIFF
--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 34
+    compileSdk 34
     namespace "io.runtime.mcumgr.ble"
 
     defaultConfig {

--- a/mcumgr-core/build.gradle
+++ b/mcumgr-core/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 34
+    compileSdk 34
     namespace "io.runtime.mcumgr"
 
     defaultConfig {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
@@ -55,6 +55,8 @@ public abstract class McuManager {
     protected final static int OP_WRITE = 2;
     protected final static int OP_WRITE_RSP = 3;
 
+    private final static int SMP_VERSION = 0b01;
+
     // Mcu Manager groups
     protected final static int GROUP_DEFAULT = 0;
     protected final static int GROUP_IMAGE = 1;
@@ -470,7 +472,7 @@ public abstract class McuManager {
             int len = cborPayload.length;
 
             // Build header
-            byte[] header = McuMgrHeader.build(op, flags, len, groupId, sequenceNum, commandId);
+            byte[] header = McuMgrHeader.build(SMP_VERSION, op, flags, len, groupId, sequenceNum, commandId);
 
             // Build the packet based on scheme
             if (scheme.isCoap()) {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/McuMgrGroupReturnCode.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/McuMgrGroupReturnCode.java
@@ -1,0 +1,4 @@
+package io.runtime.mcumgr;
+
+public interface McuMgrGroupReturnCode {
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/EraseStorage.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/EraseStorage.java
@@ -11,7 +11,7 @@ import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
 import io.runtime.mcumgr.exception.McuMgrErrorException;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.managers.BasicManager;
-import io.runtime.mcumgr.response.McuMgrResponse;
+import io.runtime.mcumgr.response.zephyr.basic.McuMgrZephyrBasicResponse;
 import io.runtime.mcumgr.task.TaskManager;
 
 class EraseStorage extends FirmwareUpgradeTask {
@@ -37,7 +37,7 @@ class EraseStorage extends FirmwareUpgradeTask {
 		final BasicManager manager = new BasicManager(settings.transport);
 		manager.eraseStorage(new McuMgrCallback<>() {
 			@Override
-			public void onResponse(@NotNull final McuMgrResponse response) {
+			public void onResponse(@NotNull final McuMgrZephyrBasicResponse response) {
 				LOG.trace("Erase storage response: {}", response);
 
 				// Fix: If this feature is not supported on the device, this should not cause fail
@@ -55,9 +55,8 @@ class EraseStorage extends FirmwareUpgradeTask {
 			public void onError(@NotNull McuMgrException e) {
 				// If Erase is not supported, proceed with the update.
 				// Erase Storage has been added in NCS 1.8.
-				if (e instanceof McuMgrErrorException) {
-					final McuMgrErrorException error = (McuMgrErrorException) e;
-					if (error.getCode() == McuMgrErrorCode.NOT_SUPPORTED) {
+				if (e instanceof McuMgrErrorException error) {
+					if (error.getCode() == McuMgrErrorCode.NOT_SUPPORTED || error.getGroupCode() != null) {
 						performer.onTaskCompleted(EraseStorage.this);
 						return;
 					}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Reset.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Reset.java
@@ -14,7 +14,7 @@ import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
 import io.runtime.mcumgr.exception.McuMgrErrorException;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.managers.DefaultManager;
-import io.runtime.mcumgr.response.McuMgrResponse;
+import io.runtime.mcumgr.response.dflt.McuMgrOsResponse;
 import io.runtime.mcumgr.task.TaskManager;
 
 class Reset extends FirmwareUpgradeTask {
@@ -77,7 +77,7 @@ class Reset extends FirmwareUpgradeTask {
 		final DefaultManager manager = new DefaultManager(transport);
 		manager.reset(new McuMgrCallback<>() {
 			@Override
-			public void onResponse(@NotNull final McuMgrResponse response) {
+			public void onResponse(@NotNull final McuMgrOsResponse response) {
 				// Check for an error return code.
 				if (!response.isSuccess()) {
 					performer.onTaskFailed(Reset.this, new McuMgrErrorException(response.getReturnCode()));

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/McuMgrErrorException.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/McuMgrErrorException.java
@@ -7,9 +7,11 @@
 package io.runtime.mcumgr.exception;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import io.runtime.mcumgr.McuMgrErrorCode;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
+import io.runtime.mcumgr.response.HasReturnCode;
 import io.runtime.mcumgr.response.McuMgrResponse;
 
 /**
@@ -22,13 +24,25 @@ public class McuMgrErrorException extends McuMgrException {
     @NotNull
     private final McuMgrErrorCode mCode;
 
+    @Nullable
+    private final HasReturnCode.GroupReturnCode mGroupCode;
+
     public McuMgrErrorException(@NotNull McuMgrErrorCode code) {
         super("Mcu Mgr Error: " + code);
         mCode = code;
+        mGroupCode = null;
+    }
+
+    public McuMgrErrorException(@NotNull HasReturnCode.GroupReturnCode code) {
+        super("Mcu Mgr Error: " + code);
+        mCode = McuMgrErrorCode.OK;
+        mGroupCode = code;
     }
 
     public McuMgrErrorException(@NotNull McuMgrResponse response) {
-        this(McuMgrErrorCode.valueOf(response.rc));
+        super("Mcu Mgr Error: " + (response.getGroupReturnCode() != null ? response.getGroupReturnCode() : response.rc));
+        mCode = response.getReturnCode();
+        mGroupCode = response.getGroupReturnCode();
     }
 
     /**
@@ -39,5 +53,9 @@ public class McuMgrErrorException extends McuMgrException {
     @NotNull
     public McuMgrErrorCode getCode() {
         return mCode;
+    }
+
+    public HasReturnCode.GroupReturnCode getGroupCode() {
+        return mGroupCode;
     }
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/StatsManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/StatsManager.java
@@ -13,8 +13,12 @@ import java.util.HashMap;
 
 import io.runtime.mcumgr.McuManager;
 import io.runtime.mcumgr.McuMgrCallback;
+import io.runtime.mcumgr.McuMgrErrorCode;
+import io.runtime.mcumgr.McuMgrGroupReturnCode;
 import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.exception.McuMgrException;
+import io.runtime.mcumgr.response.HasReturnCode;
+import io.runtime.mcumgr.response.McuMgrResponse;
 import io.runtime.mcumgr.response.stat.McuMgrStatListResponse;
 import io.runtime.mcumgr.response.stat.McuMgrStatResponse;
 
@@ -23,6 +27,63 @@ import io.runtime.mcumgr.response.stat.McuMgrStatResponse;
  */
 @SuppressWarnings("unused")
 public class StatsManager extends McuManager {
+    public enum ReturnCode implements McuMgrGroupReturnCode {
+        /** No error, this is implied if there is no ret value in the response */
+        OK(0),
+
+        /** Unknown error occurred. */
+        UNKNOWN(1),
+
+        /** The provided statistic group name was not found. */
+        INVALID_GROUP(2),
+
+        /** The provided statistic name was not found. */
+        INVALID_STAT_NAME(3),
+
+        /** The size of the statistic cannot be handled. */
+        INVALID_STAT_SIZE(4),
+
+        /** Walk through of statistics was aborted. */
+        WALK_ABORTED(5);
+
+        private final int mCode;
+
+        ReturnCode(int code) {
+            mCode = code;
+        }
+
+        public int value() {
+            return mCode;
+        }
+
+        public static @Nullable StatsManager.ReturnCode valueOf(@Nullable McuMgrResponse.GroupReturnCode returnCode) {
+            if (returnCode == null || returnCode.group != GROUP_STATS) {
+                return null;
+            }
+            for (StatsManager.ReturnCode code : values()) {
+                if (code.value() == returnCode.rc) {
+                    return code;
+                }
+            }
+            return UNKNOWN;
+        }
+    }
+
+    public interface Response extends HasReturnCode {
+
+        @Nullable
+        default BasicManager.ReturnCode getOsReturnCode() {
+            McuMgrResponse.GroupReturnCode groupReturnCode = getGroupReturnCode();
+            if (groupReturnCode == null) {
+                if (getReturnCodeValue() == McuMgrErrorCode.OK.value()) {
+                    return BasicManager.ReturnCode.OK;
+                }
+                return BasicManager.ReturnCode.UNKNOWN;
+            }
+            return BasicManager.ReturnCode.valueOf(groupReturnCode);
+        }
+    }
+
 
     // Command IDs
     private final static int ID_READ = 0;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/HasReturnCode.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/HasReturnCode.java
@@ -1,0 +1,53 @@
+package io.runtime.mcumgr.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.runtime.mcumgr.McuMgrErrorCode;
+
+public interface HasReturnCode {
+
+    class GroupReturnCode {
+
+        /** The group ID from which the response was received. */
+        @JsonProperty("group")
+        public int group = 0;
+
+        /** The return code from the group. */
+        @JsonProperty("rc")
+        public int rc;
+
+        @Override
+        @NotNull
+        public String toString() {
+            return rc + " (group: " + group + ")";
+        }
+    }
+
+    /**
+     * Return the Mcu Manager return code as an int.
+     *
+     * @return Mcu Manager return code.
+     */
+    int getReturnCodeValue();
+
+    /**
+     * Get the return code as an enum.
+     *
+     * @return The return code enum.
+     */
+    McuMgrErrorCode getReturnCode();
+
+    /**
+     * Since nRF Connect SDK version 2.4 the groups return more granular return codes than before.
+     * This change was added in SMP protocol version 2.
+     * <p>
+     * The standard return code is reserved for the Mcu Manager errors, e.g. parsing error, unsupported
+     * group, etc, while the group return code is used for the group specific errors.
+     * <p>
+     * Instead of using this method, consider designated methods in specific response classes.
+     * @return The group specific return code.
+     */
+    GroupReturnCode getGroupReturnCode();
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/McuMgrResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/McuMgrResponse.java
@@ -314,18 +314,18 @@ public class McuMgrResponse implements HasReturnCode {
     }
 
     /**
-     * Searches for 'what' in `where` and returns the index of the first occurrence,
+     * Searches for a 'needle' in a `haystack` and returns the index of the first occurrence,
      * or -1 if not found.
      *
-     * @param where The array in which to search.
-     * @param what The array to search for.
-     * @return The index of the first occurrence of 'what' in 'where', or -1 if not found.
+     * @param haystack The array in which to search.
+     * @param needle The array to search for.
+     * @return The index of the first occurrence of 'needle' in 'haystack', or -1 if not found.
      */
-    private static int indexOf(byte @NotNull [] where, byte @NotNull [] what) {
-        for (int i = 0; i < where.length - what.length + 1; i++) {
+    private static int indexOf(byte @NotNull [] haystack, byte @NotNull [] needle) {
+        for (int i = 0; i < haystack.length - needle.length + 1; i++) {
             boolean found = true;
-            for (int j = 0; j < what.length; j++) {
-                if (where[i + j] != what[j]) {
+            for (int j = 0; j < needle.length; j++) {
+                if (haystack[i + j] != needle[j]) {
                     found = false;
                     break;
                 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrEchoResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrEchoResponse.java
@@ -9,9 +9,9 @@ package io.runtime.mcumgr.response.dflt;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import io.runtime.mcumgr.response.McuMgrResponse;
+import io.runtime.mcumgr.managers.DefaultManager;
 
-public class McuMgrEchoResponse extends McuMgrResponse {
+public class McuMgrEchoResponse extends McuMgrOsResponse implements DefaultManager.Response {
     /** The echo response. */
     @JsonProperty("r")
     public String r;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrMpStatResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrMpStatResponse.java
@@ -12,10 +12,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
 
-import io.runtime.mcumgr.response.McuMgrResponse;
-
 @SuppressWarnings("unused")
-public class McuMgrMpStatResponse extends McuMgrResponse {
+public class McuMgrMpStatResponse extends McuMgrOsResponse {
     // For Mynewt see:
     // https://github.com/apache/mynewt-core/blob/master/kernel/os/include/os/os_mempool.h
 

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrOsResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrOsResponse.java
@@ -1,0 +1,12 @@
+package io.runtime.mcumgr.response.dflt;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import io.runtime.mcumgr.managers.DefaultManager;
+import io.runtime.mcumgr.response.McuMgrResponse;
+
+public class McuMgrOsResponse extends McuMgrResponse implements DefaultManager.Response {
+
+    @JsonCreator
+    public McuMgrOsResponse() {}
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrParamsResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrParamsResponse.java
@@ -9,9 +9,7 @@ package io.runtime.mcumgr.response.dflt;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import io.runtime.mcumgr.response.McuMgrResponse;
-
-public class McuMgrParamsResponse extends McuMgrResponse {
+public class McuMgrParamsResponse extends McuMgrOsResponse {
     /** The McuMgr buffer size. */
     @JsonProperty("buf_size")
     public int bufSize;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrReadDateTimeResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrReadDateTimeResponse.java
@@ -9,9 +9,7 @@ package io.runtime.mcumgr.response.dflt;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import io.runtime.mcumgr.response.McuMgrResponse;
-
-public class McuMgrReadDateTimeResponse extends McuMgrResponse {
+public class McuMgrReadDateTimeResponse extends McuMgrOsResponse {
     /**
      * Date & time in <code>yyyy-MM-dd'T'HH:mm:ss.SSSSSS</code> format.
      */

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrTaskStatResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrTaskStatResponse.java
@@ -11,10 +11,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
 
-import io.runtime.mcumgr.response.McuMgrResponse;
-
 @SuppressWarnings({"PointlessBitwiseExpression", "unused"})
-public class McuMgrTaskStatResponse extends McuMgrResponse {
+public class McuMgrTaskStatResponse extends McuMgrOsResponse {
     // For Zephyr see:
     // https://github.com/zephyrproject-rtos/zephyr/blob/master/kernel/include/kernel_structs.h
     /** Not a real thread */

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/fs/McuMgrFsDownloadResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/fs/McuMgrFsDownloadResponse.java
@@ -9,9 +9,10 @@ package io.runtime.mcumgr.response.fs;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import io.runtime.mcumgr.managers.FsManager;
 import io.runtime.mcumgr.response.DownloadResponse;
 
-public class McuMgrFsDownloadResponse extends DownloadResponse {
+public class McuMgrFsDownloadResponse extends DownloadResponse implements FsManager.Response {
     @JsonCreator
     public McuMgrFsDownloadResponse() {}
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/fs/McuMgrFsUploadResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/fs/McuMgrFsUploadResponse.java
@@ -9,9 +9,10 @@ package io.runtime.mcumgr.response.fs;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import io.runtime.mcumgr.managers.FsManager;
 import io.runtime.mcumgr.response.UploadResponse;
 
-public class McuMgrFsUploadResponse extends UploadResponse {
+public class McuMgrFsUploadResponse extends UploadResponse implements FsManager.Response {
     @JsonCreator
     public McuMgrFsUploadResponse() {}
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrCoreLoadResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrCoreLoadResponse.java
@@ -24,9 +24,10 @@ package io.runtime.mcumgr.response.img;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import io.runtime.mcumgr.managers.ImageManager;
 import io.runtime.mcumgr.response.DownloadResponse;
 
-public class McuMgrCoreLoadResponse extends DownloadResponse {
+public class McuMgrCoreLoadResponse extends DownloadResponse implements ImageManager.Response {
     @JsonCreator
     public McuMgrCoreLoadResponse() {}
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageResponse.java
@@ -1,0 +1,12 @@
+package io.runtime.mcumgr.response.img;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import io.runtime.mcumgr.managers.DefaultManager;
+import io.runtime.mcumgr.response.McuMgrResponse;
+
+public class McuMgrImageResponse extends McuMgrResponse implements DefaultManager.Response {
+
+    @JsonCreator
+    public McuMgrImageResponse() {}
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageStateResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageStateResponse.java
@@ -8,10 +8,11 @@ package io.runtime.mcumgr.response.img;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.runtime.mcumgr.managers.ImageManager;
 import io.runtime.mcumgr.response.McuMgrResponse;
 
 @SuppressWarnings("unused")
-public class McuMgrImageStateResponse extends McuMgrResponse {
+public class McuMgrImageStateResponse extends McuMgrResponse implements ImageManager.Response {
     // For Mynewt see:
     // https://github.com/apache/mynewt-core/blob/master/boot/split/include/split/split.h
     public static final int SPLIT_STATUS_INVALID = 0;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageUploadResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageUploadResponse.java
@@ -11,9 +11,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.jetbrains.annotations.Nullable;
 
+import io.runtime.mcumgr.managers.ImageManager;
 import io.runtime.mcumgr.response.UploadResponse;
 
-public class McuMgrImageUploadResponse extends UploadResponse {
+public class McuMgrImageUploadResponse extends UploadResponse implements ImageManager.Response {
 
     /**
      * Since NCS 2.4 the SMP server expects 32-byte 'sha' of the image sent with the

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/shell/McuMgrExecResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/shell/McuMgrExecResponse.java
@@ -13,9 +13,13 @@ import io.runtime.mcumgr.managers.ShellManager;
 import io.runtime.mcumgr.response.McuMgrResponse;
 
 public class McuMgrExecResponse extends McuMgrResponse implements ShellManager.Response {
-    /** The command response. */
+    /** The command output. */
     @JsonProperty("o")
     public String o;
+
+    /** Return code from shell command execution. */
+    @JsonProperty("ret")
+    public int ret;
 
     @JsonCreator
     public McuMgrExecResponse() {}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/shell/McuMgrExecResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/shell/McuMgrExecResponse.java
@@ -4,14 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.runtime.mcumgr.response.dflt;
+package io.runtime.mcumgr.response.shell;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.runtime.mcumgr.managers.ShellManager;
 import io.runtime.mcumgr.response.McuMgrResponse;
 
-public class McuMgrExecResponse extends McuMgrResponse {
+public class McuMgrExecResponse extends McuMgrResponse implements ShellManager.Response {
     /** The command response. */
     @JsonProperty("o")
     public String o;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/stat/McuMgrStatListResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/stat/McuMgrStatListResponse.java
@@ -9,9 +9,10 @@ package io.runtime.mcumgr.response.stat;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.runtime.mcumgr.managers.StatsManager;
 import io.runtime.mcumgr.response.McuMgrResponse;
 
-public class McuMgrStatListResponse extends McuMgrResponse {
+public class McuMgrStatListResponse extends McuMgrResponse implements StatsManager.Response {
     /** A list of modules. */
     @JsonProperty("stat_list")
     public String[] stat_list;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/stat/McuMgrStatResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/stat/McuMgrStatResponse.java
@@ -11,9 +11,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
 
+import io.runtime.mcumgr.managers.StatsManager;
 import io.runtime.mcumgr.response.McuMgrResponse;
 
-public class McuMgrStatResponse extends McuMgrResponse {
+public class McuMgrStatResponse extends McuMgrResponse implements StatsManager.Response {
     /** Module name. */
     @JsonProperty("name")
     public String name;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/zephyr/basic/McuMgrZephyrBasicResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/zephyr/basic/McuMgrZephyrBasicResponse.java
@@ -1,0 +1,12 @@
+package io.runtime.mcumgr.response.zephyr.basic;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import io.runtime.mcumgr.managers.BasicManager;
+import io.runtime.mcumgr.response.McuMgrResponse;
+
+public class McuMgrZephyrBasicResponse extends McuMgrResponse implements BasicManager.Response {
+
+    @JsonCreator
+    public McuMgrZephyrBasicResponse() {}
+}

--- a/mcumgr-core/src/test/java/io/runtime/mcumgr/mock/MockMcuMgrResponse.kt
+++ b/mcumgr-core/src/test/java/io/runtime/mcumgr/mock/MockMcuMgrResponse.kt
@@ -91,5 +91,5 @@ fun McuMgrHeader.toResponse(): McuMgrHeader {
         McuMgrOperation.WRITE.value -> McuMgrOperation.WRITE_RESPONSE.value
         else -> op
     }
-    return McuMgrHeader(newOp, flags, len, groupId, sequenceNum, commandId)
+    return McuMgrHeader(version, newOp, flags, len, groupId, sequenceNum, commandId)
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'com.android.application'
 apply from: rootProject.file("gradle/git-tag-version.gradle")
 
 android {
-    compileSdkVersion 34
+    compileSdk 34
     namespace "io.runtime.mcumgr.sample"
 
     defaultConfig {

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ExecFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ExecFragment.java
@@ -7,13 +7,8 @@
 package io.runtime.mcumgr.sample.fragment.mcumgr;
 
 import android.content.Context;
-import android.graphics.Typeface;
 import android.os.Bundle;
-import android.text.SpannableString;
-import android.text.Spanned;
 import android.text.TextUtils;
-import android.text.style.ForegroundColorSpan;
-import android.text.style.StyleSpan;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.View;
@@ -21,19 +16,17 @@ import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.PopupMenu;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+
 import java.util.Arrays;
 import java.util.Set;
 
 import javax.inject.Inject;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.widget.PopupMenu;
-import androidx.core.content.ContextCompat;
-import androidx.fragment.app.Fragment;
-import androidx.lifecycle.ViewModelProvider;
-import io.runtime.mcumgr.McuMgrErrorCode;
-import io.runtime.mcumgr.exception.McuMgrErrorException;
 import io.runtime.mcumgr.sample.R;
 import io.runtime.mcumgr.sample.databinding.FragmentCardExecBinding;
 import io.runtime.mcumgr.sample.di.Injectable;
@@ -85,16 +78,7 @@ public class ExecFragment extends Fragment implements Injectable {
         );
         viewModel.getError().observe(
                 getViewLifecycleOwner(),
-                error -> {
-                    if (error instanceof McuMgrErrorException) {
-                        final McuMgrErrorCode code = ((McuMgrErrorException) error).getCode();
-                        if (code == McuMgrErrorCode.UNKNOWN) {
-                            printOutput(getString(R.string.exec_unknown));
-                            return;
-                        }
-                    }
-                    printOutput(StringUtils.toString(requireContext(), error));
-                }
+                error -> printOutput(StringUtils.toString(requireContext(), error))
         );
         binding.actionHistory.setOnClickListener(v -> {
             final PopupMenu popupMenu = new PopupMenu(requireContext(), v);

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FilesDownloadFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FilesDownloadFragment.java
@@ -177,8 +177,8 @@ public class FilesDownloadFragment extends Fragment implements Injectable {
         binding.fileResult.setVisibility(View.VISIBLE);
 
         String message = StringUtils.toString(requireContext(), error);
-        if (error instanceof McuMgrErrorException) {
-            final McuMgrErrorCode code = ((McuMgrErrorException) error).getCode();
+        if (error instanceof McuMgrErrorException e) {
+            final McuMgrErrorCode code = e.getCode();
             if (code == McuMgrErrorCode.UNKNOWN) {
                 message = getString(R.string.files_download_error_file_not_found);
             }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageControlFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageControlFragment.java
@@ -174,8 +174,8 @@ public class ImageControlFragment extends Fragment implements Injectable, Select
 
     private void printError(@Nullable final McuMgrException error) {
         String message = StringUtils.toString(requireContext(), error);
-        if (error instanceof McuMgrErrorException) {
-            final McuMgrErrorCode code = ((McuMgrErrorException) error).getCode();
+        if (error instanceof McuMgrErrorException e) {
+            final McuMgrErrorCode code = e.getCode();
             if (code == McuMgrErrorCode.UNKNOWN) {
                 // User tried to test a firmware with hash equal to the hash of the
                 // active firmware. This would result in changing the permanent flag

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageSettingsFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageSettingsFragment.java
@@ -97,8 +97,8 @@ public class ImageSettingsFragment extends Fragment implements Injectable {
 
     private void printError(@Nullable final McuMgrException error) {
         String message = StringUtils.toString(requireContext(), error);
-        if (error instanceof McuMgrErrorException) {
-            final McuMgrErrorCode code = ((McuMgrErrorException) error).getCode();
+        if (error instanceof McuMgrErrorException e) {
+            final McuMgrErrorCode code = e.getCode();
             if (code == McuMgrErrorCode.UNKNOWN) {
                 // User tried to test a firmware with hash equal to the hash of the
                 // active firmware. This would result in changing the permanent flag

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ExecViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ExecViewModel.java
@@ -16,7 +16,7 @@ import androidx.lifecycle.MutableLiveData;
 import io.runtime.mcumgr.McuMgrCallback;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.managers.ShellManager;
-import io.runtime.mcumgr.response.dflt.McuMgrExecResponse;
+import io.runtime.mcumgr.response.shell.McuMgrExecResponse;
 import io.runtime.mcumgr.sample.viewmodel.SingleLiveEvent;
 
 public class ExecViewModel extends McuMgrViewModel {

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/FilesUploadViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/FilesUploadViewModel.java
@@ -182,16 +182,14 @@ public class FilesUploadViewModel extends McuMgrViewModel implements UploadCallb
 
     private void requestHighConnectionPriority() {
         final McuMgrTransport transporter = manager.getTransporter();
-        if (transporter instanceof McuMgrBleTransport) {
-            final McuMgrBleTransport bleTransporter = (McuMgrBleTransport) transporter;
+        if (transporter instanceof McuMgrBleTransport bleTransporter) {
             bleTransporter.requestConnPriority(ConnectionPriorityRequest.CONNECTION_PRIORITY_HIGH);
         }
     }
 
     private void setLoggingEnabled(final boolean enabled) {
         final McuMgrTransport transporter = manager.getTransporter();
-        if (transporter instanceof McuMgrBleTransport) {
-            final McuMgrBleTransport bleTransporter = (McuMgrBleTransport) transporter;
+        if (transporter instanceof final McuMgrBleTransport bleTransporter) {
             bleTransporter.setLoggingEnabled(enabled);
         }
     }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageControlViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageControlViewModel.java
@@ -6,17 +6,18 @@
 
 package io.runtime.mcumgr.sample.viewmodel.mcumgr;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import io.runtime.mcumgr.McuMgrCallback;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.managers.ImageManager;
-import io.runtime.mcumgr.response.McuMgrResponse;
+import io.runtime.mcumgr.response.img.McuMgrImageResponse;
 import io.runtime.mcumgr.response.img.McuMgrImageStateResponse;
 
 public class ImageControlViewModel extends McuMgrViewModel {
@@ -149,7 +150,7 @@ public class ImageControlViewModel extends McuMgrViewModel {
         errorLiveData.setValue(null);
         manager.erase(image, new McuMgrCallback<>() {
             @Override
-            public void onResponse(@NonNull final McuMgrResponse response) {
+            public void onResponse(@NonNull final McuMgrImageResponse response) {
                 read();
             }
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageSettingsViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageSettingsViewModel.java
@@ -6,16 +6,17 @@
 
 package io.runtime.mcumgr.sample.viewmodel.mcumgr;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
 import androidx.annotation.NonNull;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import io.runtime.mcumgr.McuMgrCallback;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.managers.BasicManager;
-import io.runtime.mcumgr.response.McuMgrResponse;
+import io.runtime.mcumgr.response.zephyr.basic.McuMgrZephyrBasicResponse;
 
 public class ImageSettingsViewModel extends McuMgrViewModel {
     private final BasicManager manager;
@@ -39,7 +40,7 @@ public class ImageSettingsViewModel extends McuMgrViewModel {
         errorLiveData.setValue(null);
         manager.eraseStorage(new McuMgrCallback<>() {
             @Override
-            public void onResponse(@NonNull final McuMgrResponse response) {
+            public void onResponse(@NonNull final McuMgrZephyrBasicResponse response) {
                 errorLiveData.postValue(null);
                 postReady();
             }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ResetViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ResetViewModel.java
@@ -6,17 +6,18 @@
 
 package io.runtime.mcumgr.sample.viewmodel.mcumgr;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
 import androidx.annotation.NonNull;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import io.runtime.mcumgr.McuMgrCallback;
 import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.managers.DefaultManager;
-import io.runtime.mcumgr.response.McuMgrResponse;
+import io.runtime.mcumgr.response.dflt.McuMgrOsResponse;
 
 public class ResetViewModel extends McuMgrViewModel {
     private final DefaultManager manager;
@@ -39,7 +40,7 @@ public class ResetViewModel extends McuMgrViewModel {
         setBusy();
         manager.reset(new McuMgrCallback<>() {
             @Override
-            public void onResponse(@NonNull final McuMgrResponse response) {
+            public void onResponse(@NonNull final McuMgrOsResponse response) {
                 manager.getTransporter().addObserver(new McuMgrTransport.ConnectionObserver() {
                     @Override
                     public void onConnected() {

--- a/sample/src/main/res/values/strings_errors.xml
+++ b/sample/src/main/res/values/strings_errors.xml
@@ -20,5 +20,87 @@
 		<item>Busy (10)</item>
 		<item>Access Denied (11)</item>
 	</string-array>
+
+	<string-array name="mcu_mgr_os_error">
+		<item>Success</item>
+		<item>Unknown error (1)</item>
+		<item>Invalid format (2)</item>
+	</string-array>
+
+	<string-array name="mcu_mgr_img_error">
+		<item>Success</item>
+		<item>Unknown error (1)</item>
+		<item>Flash config query fail (2)</item>
+		<item>No image (3)</item>
+		<item>No TLVs (4)</item>
+		<item>Invalid TLV (5)</item>
+		<item>TLV: Multiple hashes found (6)</item>
+		<item>TLV: Invalid size (7)</item>
+		<item>Hash not found (8)</item>
+		<item>No free slot (9)</item>
+		<item>Flash open failed (10)</item>
+		<item>Flash read failed (11)</item>
+		<item>Flash write failed (12)</item>
+		<item>Flash erase failed (13)</item>
+		<item>Invalid slot (14)</item>
+		<item>No free memory (15)</item>
+		<item>Flash context already set (16)</item>
+		<item>Flash context not set (17)</item>
+		<item>The device for the flash area is NULL (18)</item>
+		<item>Invalid page offset (19)</item>
+		<item>Invalid offset (20)</item>
+		<item>Invalid length (21)</item>
+		<item>Invalid image header (22)</item>
+		<item>Invalid image header magic (23)</item>
+		<item>Invalid hash (24)</item>
+		<item>Invalid flash address (25)</item>
+		<item>Version get failed (26)</item>
+		<item>Current version is newer (27)</item>
+		<item>Image already pending (28)</item>
+		<item>Invalid image vector table (29)</item>
+	</string-array>
+
+	<string-array name="mcu_mgr_stats_error">
+		<item>Success</item>
+		<item>Unknown error (1)</item>
+		<item>Invalid group (2)</item>
+		<item>Invalid stat name (3)</item>
+		<item>Invalid stat size (4)</item>
+		<item>Walk aborted (5)</item>
+	</string-array>
+
+	<string-array name="mcu_mgr_fs_error">
+		<item>Success</item>
+		<item>Unknown error (1)</item>
+		<item>Invalid name (2)</item>
+		<item>File not found (3)</item>
+		<item>Specified file is a directory, not a file (4)</item>
+		<item>Open failed (5)</item>
+		<item>Seek failed (6)</item>
+		<item>Read failed (7)</item>
+		<item>Truncate failed (8)</item>
+		<item>Delete failed (9)</item>
+		<item>Write failed (10)</item>
+		<item>Offset not valid (11)</item>
+		<item>Offset larger than file (12)</item>
+		<item>Checksum or hash not found or not supported (13)</item>
+	</string-array>
+
+	<string-array name="mcu_mgr_shell_error">
+		<item>Success</item>
+		<item>Unknown error (1)</item>
+		<item>Command too long (2)</item>
+		<item>Command empty (3)</item>
+	</string-array>
+
+	<string-array name="mcu_mgr_zephyr_basic_error">
+		<item>Success</item>
+		<item>Unknown error (1)</item>
+		<item>Open flash area failed (2)</item>
+		<item>Querying flash area parameters failed (3)</item>
+		<item>Erasing flash failed (4)</item>
+	</string-array>
+
 	<string name="mcu_mgr_error_other">Unknown error (%d)</string>
+	<string name="mcu_mgr_group_error_other">Unknown error (%d, group %d)</string>
 </resources>


### PR DESCRIPTION
nRF Connect SDK 2.4 introduced breaking changes in Simple Management Protocol (SMP) (https://github.com/zephyrproject-rtos/zephyr/pull/54041).

1. `Ver` field added. In 2nd version the value of this 2-bit field is 0b01, before it was 0b00.
2. `rc` parameter is now reserved for McuMgr errors, e.g. Group not supported, or CBOR parsing errors. Instead, groups return `ret` field with `group` and `rc`, where each group may return own error codes.

In NCS 2.4 the new `err` parameter was named `ret`, which conflicted with other `ret` property in the Shell Manager. This PR: https://github.com/zephyrproject-rtos/zephyr/pull/60984 renamed `ret` to `err`. This PR handles both cases as it replaces `ret` to `err` before parsing CBOR response.

### Breaking changes

1. `McuMgrExecResponse` was moved to its correct package: `shell`, instead of `dflt`.
2. Some callbacks in various managers have changed types, as `McuMgrResponse` is no longer used in them. Instead, where this type was used a per-group type is used, which allows parsing returned error to specific type.