### PR TITLE
Direct XIP support

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
@@ -17,8 +17,6 @@ import io.runtime.mcumgr.dfu.model.McuMgrImageSet;
 import io.runtime.mcumgr.dfu.model.McuMgrTargetImage;
 import io.runtime.mcumgr.exception.McuMgrException;
 
-// TODO Add retries for each step
-
 /**
  * Manages a McuManager firmware upgrade. Once initialized, <b>this object can only perform a single
  * firmware upgrade for a single device to completion</b>. In other words, the same
@@ -346,14 +344,14 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      * notifications and continue to send until the complete image is sent.
      * <p>
      * This value should match MCUMGR_BUF_COUNT - 1
-     * (https://github.com/zephyrproject-rtos/zephyr/blob/bd4ddec0c8c822bbdd420bd558b62c1d1a532c16/subsys/mgmt/mcumgr/Kconfig#L550)
+     * (<a href="https://github.com/zephyrproject-rtos/zephyr/blob/bd4ddec0c8c822bbdd420bd558b62c1d1a532c16/subsys/mgmt/mcumgr/Kconfig#L550">link</a>)
      * in Zephyr KConfig, which is by default set to 4. One buffer is used for sending responses.
      * <p>
      * Mind, that the speed increases only if the returned offsets match the required offset
      * (initial offset + sent packet size). In other case the packets with unexpected offsets
      * are dropped by the device causing teh packets to be resent, which actually makes the upload
      * slower.
-     *
+     * <p>
      * Pause and resume will throw an exception when window upload is used.
      * @param windowCapacity the maximum number of concurrent upload requests at any time.
      */
@@ -379,8 +377,8 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
      * first one would have to be sent again, not with slightly decremented offset.
      * By trimming to memory alignment, this library makes sure that all bytes sent are consumed.
      * <p>
-     * With https://github.com/zephyrproject-rtos/zephyr/pull/41959 PR merged, you can set the
-     * alignment to 1 (disabled), as the flash manager itself takes care of alignment.
+     * With <a href="https://github.com/zephyrproject-rtos/zephyr/pull/41959">PR merged</a>, you
+     * can set the alignment to 1 (disabled), as the flash manager itself takes care of alignment.
      */
     public void setMemoryAlignment(final int alignment) {
         if (alignment < 1) {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradePerformer.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradePerformer.java
@@ -1,21 +1,17 @@
 package io.runtime.mcumgr.dfu;
 
-import android.util.Pair;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Mode;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
+import io.runtime.mcumgr.dfu.model.McuMgrImageSet;
 import io.runtime.mcumgr.dfu.task.FirmwareUpgradeTask;
 import io.runtime.mcumgr.dfu.task.PerformDfu;
 import io.runtime.mcumgr.exception.McuMgrException;
-import io.runtime.mcumgr.image.McuMgrImage;
 import io.runtime.mcumgr.task.Task;
 import io.runtime.mcumgr.task.TaskPerformer;
 
@@ -41,7 +37,7 @@ public class FirmwareUpgradePerformer extends TaskPerformer<Settings, State> {
 
 	void start(@NotNull final Settings settings,
 			   @NotNull final Mode mode,
-			   @NotNull final List<Pair<Integer, McuMgrImage>> images,
+			   @NotNull final McuMgrImageSet images,
 			   final boolean eraseSettings) {
 		LOG.trace("Starting DFU, mode: {}", mode.name());
 		super.start(settings, new PerformDfu(mode, images, eraseSettings));

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/model/McuMgrImageSet.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/model/McuMgrImageSet.java
@@ -1,0 +1,60 @@
+package io.runtime.mcumgr.dfu.model;
+
+import android.util.Pair;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.runtime.mcumgr.exception.McuMgrException;
+
+/** @noinspection unused*/
+public class McuMgrImageSet {
+    @NotNull
+    private final List<McuMgrTargetImage> images;
+
+    /**
+     * Creates an empty image set. Use {@link #add(McuMgrTargetImage)} to add targets.
+     */
+    public McuMgrImageSet() {
+        this.images = new ArrayList<>(4);
+    }
+
+    /**
+     * Creates an image set with given targets.
+     * @param targets image targets.
+     */
+    public McuMgrImageSet(@NotNull final List<McuMgrTargetImage> targets) {
+        this.images = targets;
+    }
+
+    /**
+     * Returns list of targets.
+     */
+    @NotNull
+    public List<McuMgrTargetImage> getImages() {
+        return images;
+    }
+
+    public McuMgrImageSet add(McuMgrTargetImage binary) {
+        images.add(binary);
+        return this;
+    }
+
+    public McuMgrImageSet add(byte[] image) throws McuMgrException {
+        images.add(new McuMgrTargetImage(image));
+        return this;
+    }
+
+    public McuMgrImageSet add(Pair<Integer, byte[]> image) throws McuMgrException {
+        images.add(new McuMgrTargetImage(image.first, image.second));
+        return this;
+    }
+
+    public McuMgrImageSet add(List<android.util.Pair<Integer, byte[]>> images) throws McuMgrException {
+        for (Pair<Integer, byte[]> image : images)
+            this.images.add(new McuMgrTargetImage(image.first, image.second));
+        return this;
+    }
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/model/McuMgrTargetImage.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/model/McuMgrTargetImage.java
@@ -1,0 +1,83 @@
+package io.runtime.mcumgr.dfu.model;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.runtime.mcumgr.exception.McuMgrException;
+import io.runtime.mcumgr.image.McuMgrImage;
+
+/** @noinspection unused*/
+public class McuMgrTargetImage {
+    public final static int SLOT_PRIMARY = 0;
+    public final static int SLOT_SECONDARY = 1;
+
+    /** Target image index (core index) for the image. */
+    public final int imageIndex;
+    /**
+     *  Target slot for the image. By default images are run from the primary slot.
+     *  An update will be written to the secondary slot and will be swapped to the primary slot
+     *  after it is confirmed and reset.
+     *  <p>
+     *  If the device supports Direct XIP feature it is possible to run an app from a secondary
+     *  slot. The image has to be compiled for this slot. A ZIP package in that case may
+     *  contain both images. In that case only the one compiled for the available slot will be sent,
+     *  there is no swapping and the image is run directly from the slot that it was sent to.
+     */
+    public final int slot;
+    /**
+     * The image.
+     * <p>
+     * Currently only MCUboot images are supported. Valid images contain a header with a MAGIC
+     * number and a version number.
+     */
+    public final McuMgrImage image;
+
+    /**
+     * This constructor creates a basic image target. It will be sent to the secondary slot (slot = 1)
+     * of the default core (image index = 0).
+     * <p>
+     * This constructor can be used to send an update to a single core device that does not support
+     * Direct XIP (option to boot an image from a non-primary image).
+     * @param data the signed binary to be sent.
+     * @throws McuMgrException when the image does not have a valid mcu header
+     */
+    public McuMgrTargetImage(byte @NotNull [] data) throws McuMgrException {
+        // Default or single core.
+        this.imageIndex = 0;
+        // If not specified, the image will be sent to the secondary slot.
+        this.slot = SLOT_SECONDARY;
+        this.image = McuMgrImage.fromBytes(data);
+    }
+
+    /**
+     * This constructor creates a basic image targeting specified core (image index). The binary will
+     * be sent to the secondary slot (slot = 1) for that core.
+     * <p>
+     * This constructor can be used to send an update to a mutli-core device that does not support
+     * Direct XIP (option to boot an image from a non-primary image).
+     * @param imageIndex an index of the core (0 is the main (app) core, 1 is secondary (network) core, etc.
+     * @param data the signed binary to be sent.
+     * @throws McuMgrException when the image does not have a valid mcu header
+     */
+    public McuMgrTargetImage(int imageIndex, byte @NotNull [] data) throws McuMgrException {
+        this.imageIndex = imageIndex;
+        // If not specified, the image will be sent to the secondary slot.
+        this.slot = SLOT_SECONDARY;
+        this.image = McuMgrImage.fromBytes(data);
+    }
+
+    /**
+     * This constructor allows to define a target for a multi-core device with support for Direct XIP
+     * (option to run an image from a noo-primary slot. In that case it should contain binaries
+     * compiled for any slot and the DFU uploader will determine the correct slot when validating the
+     * device.
+     * @param imageIndex an index of the core (0 is the main (app) core, 1 is secondary (network) core, etc.
+     * @param slot 0 for a primary slot and 1 for a secondary slot.
+     * @param data the signed binary to be sent.
+     * @throws McuMgrException when the image does not have a valid mcu header
+     */
+    public McuMgrTargetImage(int imageIndex, int slot, byte @NotNull [] data) throws McuMgrException {
+        this.imageIndex = imageIndex;
+        this.slot = slot;
+        this.image = McuMgrImage.fromBytes(data);
+    }
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/PerformDfu.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/PerformDfu.java
@@ -1,15 +1,11 @@
 package io.runtime.mcumgr.dfu.task;
 
-import android.util.Pair;
-
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
-import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
-import io.runtime.mcumgr.image.McuMgrImage;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
+import io.runtime.mcumgr.dfu.model.McuMgrImageSet;
 import io.runtime.mcumgr.task.TaskManager;
 
 /**
@@ -19,14 +15,14 @@ import io.runtime.mcumgr.task.TaskManager;
 public class PerformDfu extends FirmwareUpgradeTask {
 
 	@NotNull
-	private final List<Pair<Integer, McuMgrImage>> images;
+	private final McuMgrImageSet images;
 	@NotNull
 	private final FirmwareUpgradeManager.Mode mode;
 
 	private final boolean eraseSettings;
 
 	public PerformDfu(final @NotNull FirmwareUpgradeManager.Mode mode,
-					  final @NotNull List<Pair<Integer, McuMgrImage>> images,
+					  final @NotNull McuMgrImageSet images,
 					  final boolean eraseSettings) {
 		this.mode = mode;
 		this.images = images;

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
@@ -13,14 +13,11 @@ import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
-import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
-
-import org.jetbrains.annotations.NotNull;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -28,11 +25,14 @@ import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.preference.PreferenceManager;
+
+import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Inject;
 
-import androidx.preference.PreferenceManager;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
+import io.runtime.mcumgr.dfu.model.McuMgrTargetImage;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.image.McuMgrImage;
 import io.runtime.mcumgr.sample.R;
@@ -367,24 +367,25 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
                 final ZipPackage zip = new ZipPackage(data);
                 final StringBuilder sizeBuilder = new StringBuilder();
                 final StringBuilder hashBuilder = new StringBuilder();
-                for (final Pair<Integer, byte[]> binary: zip.getBinaries()) {
-                    final byte[] hash = McuMgrImage.getHash(binary.second);
+                for (final McuMgrTargetImage binary: zip.getBinaries().getImages()) {
+                    final byte[] hash = binary.image.getHash();
                     hashBuilder
                             .append(StringUtils.toHex(hash));
                     sizeBuilder
-                            .append(getString(R.string.image_upgrade_size_value, binary.second.length));
-                    switch (binary.first) {
-                        case 0:
+                            .append(getString(R.string.image_upgrade_size_value, binary.image.getData().length));
+                    switch (binary.imageIndex) {
+                        case 0 -> {
                             hashBuilder.append(" (app core)");
                             sizeBuilder.append(" (app core)");
-                            break;
-                        case 1:
+                        }
+                        case 1 -> {
                             hashBuilder.append(" (net core)");
                             sizeBuilder.append(" (net core)");
-                            break;
-                        default:
-                            hashBuilder.append(" (unknown core (").append(binary.first).append(")");
-                            sizeBuilder.append(" (unknown core (").append(binary.first).append(")");
+                        }
+                        default -> {
+                            hashBuilder.append(" (unknown core (").append(binary.imageIndex).append(")");
+                            sizeBuilder.append(" (unknown core (").append(binary.imageIndex).append(")");
+                        }
                     }
                     hashBuilder.append("\n");
                     sizeBuilder.append("\n");

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -7,26 +7,24 @@
 package io.runtime.mcumgr.sample.viewmodel.mcumgr;
 
 import android.os.Build;
-import android.util.Pair;
-
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.SystemClock;
-import java.util.Collections;
-import java.util.List;
-
-import javax.inject.Inject;
-import javax.inject.Named;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.ble.McuMgrBleTransport;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeCallback;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeController;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
+import io.runtime.mcumgr.dfu.model.McuMgrImageSet;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.image.McuMgrImage;
 import io.runtime.mcumgr.sample.observable.ConnectionParameters;
@@ -152,11 +150,11 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
                         final int estimatedSwapTime,
                         final int windowCapacity,
                         final int memoryAlignment) {
-        List<Pair<Integer, byte[]>> images;
+        McuMgrImageSet images;
         try {
             // Check if the BIN file is valid.
             McuMgrImage.getHash(data);
-            images = Collections.singletonList(new Pair<>(0, data));
+            images = new McuMgrImageSet().add(data);
         } catch (final Exception e) {
             try {
                 final ZipPackage zip = new ZipPackage(data);


### PR DESCRIPTION
The new Direct XIP feature allows to boot a device with an image from a non-primary slot.

### Before

Each image had to be compiled to be run from a primary slot. An update was sent to the secondary slot for given code, confirmed and on next reset the MCUboot would swap the two slots, so what was initially on the primary slot would end up on the secondary, and what was on secondary out end on primary. The device could then be started with an updated image run from the primary slot.

### Issue

Depending on a device, the swap took ~20 seconds in addition to the upload time.

### Direct XIP

The new feature allows to build an image for both slots. When compiling, two binaries are generate, each for one slot (addresses in hex are different). The ZIP packet contains both images.
Such ZIP is given to the nRF Connect Device Manager app, which reads the current image state on the connected device, picks the image for the available slot and uploads it. No swap is used, as the image can be directly booted from where it was saved making the first slot available for future updates.