### PR TITLE
New OS Manager command: Bootloader info

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/DefaultManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/DefaultManager.java
@@ -23,6 +23,7 @@ import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.response.HasReturnCode;
 import io.runtime.mcumgr.response.McuMgrResponse;
 import io.runtime.mcumgr.response.dflt.McuMgrAppInfoResponse;
+import io.runtime.mcumgr.response.dflt.McuMgrBootloaderInfoResponse;
 import io.runtime.mcumgr.response.dflt.McuMgrEchoResponse;
 import io.runtime.mcumgr.response.dflt.McuMgrMpStatResponse;
 import io.runtime.mcumgr.response.dflt.McuMgrOsResponse;
@@ -43,7 +44,10 @@ public class DefaultManager extends McuManager {
        UNKNOWN(1),
 
         /** The provided format value is not valid. */
-       INVALID_FORMAT(2);
+       INVALID_FORMAT(2),
+
+        /** Query was not recognized. */
+       QUERY_YIELDS_NO_ANSWER(3);
 
         private final int mCode;
 
@@ -92,6 +96,7 @@ public class DefaultManager extends McuManager {
     private final static int ID_RESET = 5;
     private final static int ID_MCUMGR_PARAMS = 6;
     private final static int ID_APP_INFO = 7;
+    private final static int ID_BOOTLOADER_INFO = 8;
 
     /**
      * Construct an default manager.
@@ -352,5 +357,57 @@ public class DefaultManager extends McuManager {
             payloadMap.put("format", format);
         }
         return send(OP_READ, ID_APP_INFO, payloadMap, SHORT_TIMEOUT, McuMgrParamsResponse.class);
+    }
+
+    /**
+     * When used as query in {@link #bootloaderInfo(String)} command, returns string representing
+     * bootloader name.
+     */
+    public static String BOOTLOADER_INFO_QUERY_BOOTLOADER = null;
+    /**
+     * For bootloader with name "MCUboot" returns the bootloader mode.
+     */
+    public static String BOOTLOADER_INFO_MCUBOOT_QUERY_MODE = "mode";
+
+    /**
+     * Reads the Bootloader info (asynchronous).
+     *
+     * @param query Allows to query MCUmgr about bootloader used by device and various bootloader
+     * 	            parameters. Use {@link #BOOTLOADER_INFO_QUERY_BOOTLOADER} to get string
+     * 	            representing bootloader name.
+     * 	            For bootloader named "MCUboot" use {@link #BOOTLOADER_INFO_MCUBOOT_QUERY_MODE} to get
+     * 	            the bootloader mode. If query yields no answer, the response will contain
+     * 	            an {@link ReturnCode#QUERY_YIELDS_NO_ANSWER} error.
+     * @param callback the asynchronous callback.
+     */
+    public void bootloaderInfo(@Nullable String query, @NotNull McuMgrCallback<McuMgrBootloaderInfoResponse> callback) {
+        HashMap<String, Object> payloadMap = null;
+        if (query != null) {
+            payloadMap = new HashMap<>();
+            payloadMap.put("query", query);
+        }
+        send(OP_READ, ID_BOOTLOADER_INFO, payloadMap, SHORT_TIMEOUT, McuMgrBootloaderInfoResponse.class, callback);
+    }
+
+    /**
+     * Reads the Bootloader info (synchronous).
+     *
+     * @param query Allows to query MCUmgr about bootloader used by device and various bootloader
+     * 	            parameters. Use {@link #BOOTLOADER_INFO_QUERY_BOOTLOADER} to get string
+     * 	            representing bootloader name.
+     * 	            For bootloader named "MCUboot" use {@link #BOOTLOADER_INFO_MCUBOOT_QUERY_MODE} to get
+     * 	            the bootloader mode. If query yields no answer, the response will contain
+     * 	            an {@link ReturnCode#QUERY_YIELDS_NO_ANSWER} error.
+     * @return The response.
+     * @throws McuMgrException Transport error. See cause.
+     */
+    @NotNull
+    public McuMgrBootloaderInfoResponse bootloaderInfo(@Nullable String query) throws McuMgrException {
+        HashMap<String, Object> payloadMap = null;
+        if (query != null) {
+            payloadMap = new HashMap<>();
+            payloadMap.put("query", query);
+        }
+        return send(OP_READ, ID_BOOTLOADER_INFO, payloadMap, SHORT_TIMEOUT, McuMgrBootloaderInfoResponse.class);
     }
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrBootloaderInfoResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrBootloaderInfoResponse.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Intellinium SAS, 2014-present
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.runtime.mcumgr.response.dflt;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** @noinspection unused*/
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class McuMgrBootloaderInfoResponse extends McuMgrOsResponse {
+    /** Unknown mode of MCUboot. */
+    public static final int MODE_UNKNOWN = -1;
+    /** MCUboot is in single application mode. */
+    public static final int MODE_SINGLE_APP = 0;
+    /** MCUboot is in swap using scratch partition mode. */
+    public static final int MODE_SWAP_SCRATCH = 1;
+    /** MCUboot is in overwrite (upgrade-only) mode. */
+    public static final int MODE_SWAP_OVERWRITE_ONLY = 2;
+    /** MCUboot is in swap without scratch mode. */
+    public static final int MODE_SWAP_WITHOUT_SCRATCH = 3;
+    /** MCUboot is in DirectXIP without revert mode. */
+    public static final int MODE_DIRECT_XIP	= 4;
+    /** MCUboot is in DirectXIP with revert mode. */
+    public static final int MODE_DIRECT_XIP_WITH_REVERT	= 5;
+    /** MCUboot is in RAM loader mode. */
+    public static final int MODE_RAM_LOADER = 6;
+
+    // Note: other modes may be added in the future.
+
+    /** Text response including requested parameters. */
+    @JsonProperty("mode")
+    public int mode = MODE_UNKNOWN;
+
+    @JsonProperty("bootloader")
+    public String bootloader;
+
+    @JsonCreator
+    public McuMgrBootloaderInfoResponse() {}
+}


### PR DESCRIPTION
This PR adds support for querying bootloader information: https://github.com/zephyrproject-rtos/zephyr/pull/57797

Currently only the "mode" parameter is supported, but can be extended for other parameters.
When no query is given the bootlaoder should reply with it's name. For Mcuboot the returned name will be "MCUboot", from which it can be deducted what other query parameters should be supported.