### PR TITLE
Adding Bootloader info and app info to Device Status section

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/DeviceStatusFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/DeviceStatusFragment.java
@@ -99,6 +99,32 @@ public class DeviceStatusFragment extends Fragment implements Injectable {
                 binding.mcumgrBufferSize.setText(R.string.status_unknown);
             }
         });
+        viewModel.getBootloaderName().observe(getViewLifecycleOwner(), name -> {
+            if (name != null) {
+                binding.bootloaderName.setText(name);
+            } else {
+                binding.bootloaderName.setText(R.string.status_unknown);
+            }
+        });
+        viewModel.getBootloaderMode().observe(getViewLifecycleOwner(), mode -> {
+            if (mode != null) {
+                final CharSequence[] modes = getResources().getTextArray(R.array.bootloader_modes);
+                if (mode >= 0 && mode < modes.length) {
+                    binding.bootloaderMode.setText(modes[mode]);
+                } else {
+                    binding.bootloaderMode.setText(getString(R.string.status_unknown_value, mode));
+                }
+            } else {
+                binding.bootloaderMode.setText(R.string.status_unknown);
+            }
+        });
+        viewModel.getAppInfo().observe(getViewLifecycleOwner(), kernel -> {
+            if (kernel != null) {
+                binding.kernel.setText(kernel);
+            } else {
+                binding.kernel.setText(R.string.status_unknown);
+            }
+        });
         viewModel.getBusyState().observe(getViewLifecycleOwner(), busy ->
                 binding.workIndicator.setVisibility(busy ? View.VISIBLE : View.GONE));
     }

--- a/sample/src/main/res/layout/fragment_card_device_status.xml
+++ b/sample/src/main/res/layout/fragment_card_device_status.xml
@@ -85,7 +85,6 @@
             android:layout_marginBottom="16dp"
             android:layout_marginStart="16dp"
             android:text="@string/status_mcumgr_buffer_size_label"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/bonding_status_label"/>
 
@@ -98,6 +97,67 @@
             android:textStyle="bold"
             app:layout_constraintStart_toEndOf="@+id/connection_status_label"
             app:layout_constraintTop_toBottomOf="@+id/bonding_status_label"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/bootloader_name_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:layout_marginStart="16dp"
+            android:text="@string/status_bootloader_name_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/mcumgr_buffer_size_label"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/bootloader_name"
+            android:layout_width="wrap_content"
+            android:layout_height="21dp"
+            android:layout_marginStart="8dp"
+            android:text="@string/status_unknown"
+            android:textStyle="bold"
+            app:layout_constraintStart_toEndOf="@+id/connection_status_label"
+            app:layout_constraintTop_toBottomOf="@+id/mcumgr_buffer_size_label"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/bootloader_mode_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:layout_marginStart="16dp"
+            android:text="@string/status_bootloader_mode_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/bootloader_name_label"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/bootloader_mode"
+            android:layout_width="wrap_content"
+            android:layout_height="21dp"
+            android:layout_marginStart="8dp"
+            android:text="@string/status_unknown"
+            android:textStyle="bold"
+            app:layout_constraintStart_toEndOf="@+id/connection_status_label"
+            app:layout_constraintTop_toBottomOf="@+id/bootloader_name_label"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/kernel_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:layout_marginStart="16dp"
+            android:text="@string/status_kernel"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/bootloader_mode_label"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/kernel"
+            android:layout_width="wrap_content"
+            android:layout_height="21dp"
+            android:layout_marginStart="8dp"
+            android:text="@string/status_unknown"
+            android:textStyle="bold"
+            app:layout_constraintStart_toEndOf="@+id/connection_status_label"
+            app:layout_constraintTop_toBottomOf="@+id/bootloader_mode_label"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/sample/src/main/res/values/strings_device_status.xml
+++ b/sample/src/main/res/values/strings_device_status.xml
@@ -10,6 +10,9 @@
     <string name="status_status_label">Connection status:</string>
     <string name="status_bond_label">Bonding status:</string>
     <string name="status_mcumgr_buffer_size_label">Buffer details:</string>
+    <string name="status_bootloader_name_label">Bootloader name:</string>
+    <string name="status_bootloader_mode_label">Bootloader mode:</string>
+    <string name="status_kernel">Kernel:</string>
 
     <string name="status_not_connected">Not connected</string>
     <string name="status_connecting">Connecting…</string>
@@ -26,5 +29,16 @@
     <string name="status_bonded">Bonded</string>
 
     <string name="status_unknown">UNKNOWN</string>
+    <string name="status_unknown_value">UNKNOWN: %d</string>
     <string name="status_mcumgr_buffer_size">%d x %d bytes</string>
+
+    <string-array name="bootloader_modes">
+        <item>Single App</item>
+        <item>Swap Scratch</item>
+        <item>Overwrite-only</item>
+        <item>Swap Without Scratch</item>
+        <item>Direct XIP Without Revert</item>
+        <item>Direct XIP With Revert</item>
+        <item>RAM Loader</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
This PR adds:
* Bootloader name
* Bootloader mode
* Kernel

to Device Status section in nRF Connect Device Manager.

The values are available when [Bootloader Information](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/services/device_mgmt/smp_groups/smp_group_0.html#bootloader-information) command is enabled on the device and can be read, otherwise UNKNOWN is shown.

The parameters are read sequentially not to rely on mcu manager buffers.