### PR TITLE
Fixed choosing active slot

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageControlViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageControlViewModel.java
@@ -170,7 +170,7 @@ public class ImageControlViewModel extends McuMgrViewModel {
         if (response != null && response.images != null) {
             for (McuMgrImageStateResponse.ImageSlot image: response.images) {
                 // Skip slots with active fw.
-                if (image.slot == 0)
+                if (image.active)
                     continue;
                 // Test should be enabled if at least one image has PENDING = false.
                 if (!image.pending)


### PR DESCRIPTION
When in *Image* tab user clicks *READ* for the *Images* section, enabling *TEST*, *CONFIRM* or *ERASE* buttons is dependent on non-active slots. Before it was hardcoded, that active slot is always in the primary slot, but with Direct XIP it may also be secondary. This PR changes comparing slot number to the actual `active` flag.