### PR TITLE
DFU Validation step fixed

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/model/McuMgrImageSet.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/model/McuMgrImageSet.java
@@ -57,4 +57,14 @@ public class McuMgrImageSet {
             this.images.add(new McuMgrTargetImage(image.first, image.second));
         return this;
     }
+
+    public McuMgrImageSet removeImagesWithImageIndex(int imageIndex) {
+        for (int i = 0; i < images.size(); i++) {
+            if (images.get(i).imageIndex == imageIndex) {
+                images.remove(i);
+                i--;
+            }
+        }
+        return this;
+    }
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Validate.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Validate.java
@@ -93,6 +93,13 @@ class Validate extends FirmwareUpgradeTask {
 		});
 	}
 
+	/**
+	 * Validates the current firmware on the device and adds the required tasks to the queue.
+	 *
+	 * @param performer The task performer.
+	 * @param noSwap Whether the bootloader is in Direct XIP mode and there will be no swapping.
+	 * @param allowRevert Whether the bootloader requires confirming images.
+	 */
 	private void validate(@NotNull final TaskManager<Settings, State> performer,
 						  final boolean noSwap,
 						  final boolean allowRevert) {


### PR DESCRIPTION
There was an issue with DFU validation step when Direct XIP mode was user and user tried to upload again the image which was already running. Hash of one of the binaries matched the hash of the active slot, but library tried to send the other image instead of simply finishind, as device was up-to-date.

This PR fixes the issue.