### PR TITLE
Minor UI improvements

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
@@ -357,25 +357,16 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
                 for (final McuMgrTargetImage binary: zip.getBinaries().getImages()) {
                     final byte[] hash = binary.image.getHash();
                     hashBuilder
-                            .append(StringUtils.toHex(hash));
+                            .append(StringUtils.toHex(hash))
+                            .append("\n");
                     sizeBuilder
                             .append(getString(R.string.image_upgrade_size_value, binary.image.getData().length));
                     switch (binary.imageIndex) {
-                        case 0 -> {
-                            hashBuilder.append(" (app core)");
-                            sizeBuilder.append(" (app core)");
-                        }
-                        case 1 -> {
-                            hashBuilder.append(" (net core)");
-                            sizeBuilder.append(" (net core)");
-                        }
-                        default -> {
-                            hashBuilder.append(" (unknown core (").append(binary.imageIndex).append(")");
-                            sizeBuilder.append(" (unknown core (").append(binary.imageIndex).append(")");
-                        }
+                        case 0 -> sizeBuilder.append(" (app core");
+                        case 1 -> sizeBuilder.append(" (net core");
+                        default -> sizeBuilder.append(" (unknown core (").append(binary.imageIndex);
                     }
-                    hashBuilder.append("\n");
-                    sizeBuilder.append("\n");
+                    sizeBuilder.append(", slot: ").append(binary.slot).append(")\n");
                 }
                 hashBuilder.setLength(hashBuilder.length() - 1);
                 sizeBuilder.setLength(sizeBuilder.length() - 1);


### PR DESCRIPTION
This PR improves how core name and slot index are presented on *Image* tab after selecting a ZIP file.

Before:

```
Size: 12345 bytes (app core)
      23456 bytes (app core)
Hash: <HASH VALUE> (app core) 
      <HASH VALUE> (app core) 
```
After:

```
Size: 12345 bytes (app core, slot 0)
      23456 bytes (app core, slot 1)
Hash: <HASH VALUE>
      <HASH VALUE>
```