### PR TITLE
Bug fix: Keep Constructor for GroupReturnCode class when using Proguard

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/HasReturnCode.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/HasReturnCode.java
@@ -1,5 +1,6 @@
 package io.runtime.mcumgr.response;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.jetbrains.annotations.NotNull;
@@ -17,6 +18,9 @@ public interface HasReturnCode {
         /** The return code from the group. */
         @JsonProperty("rc")
         public int rc;
+
+        @JsonCreator
+        public GroupReturnCode() {}
 
         @Override
         @NotNull


### PR DESCRIPTION
This PR fixes an issue with the released version of nRF Connect Device Manager app, where the default constructor of `GroupReturnCode` class was subject for removal by Proguard. This issue was reported on DevZone.