### PR TITLE
SUIT support

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Upload.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Upload.java
@@ -5,7 +5,6 @@ import org.jetbrains.annotations.NotNull;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.Settings;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager.State;
 import io.runtime.mcumgr.exception.McuMgrException;
-import io.runtime.mcumgr.image.McuMgrImage;
 import io.runtime.mcumgr.managers.ImageManager;
 import io.runtime.mcumgr.task.TaskManager;
 import io.runtime.mcumgr.transfer.ImageUploader;
@@ -13,7 +12,7 @@ import io.runtime.mcumgr.transfer.TransferController;
 import io.runtime.mcumgr.transfer.UploadCallback;
 
 class Upload extends FirmwareUpgradeTask {
-	private final McuMgrImage mcuMgrImage;
+	private final byte[] data;
 	private final int image;
 
 	/**
@@ -21,8 +20,8 @@ class Upload extends FirmwareUpgradeTask {
 	 */
 	private TransferController mUploadController;
 
-	Upload(@NotNull final McuMgrImage mcuMgrImage, final int image) {
-		this.mcuMgrImage = mcuMgrImage;
+	Upload(final byte @NotNull [] data, final int image) {
+		this.data = data;
 		this.image = image;
 	}
 
@@ -72,12 +71,12 @@ class Upload extends FirmwareUpgradeTask {
 		if (settings.windowCapacity > 1) {
 			mUploadController =	new ImageUploader(
 					manager,
-					mcuMgrImage.getData(), image,
+					data, image,
 					settings.windowCapacity,
 					settings.memoryAlignment
 			).uploadAsync(callback);
 		} else {
-			mUploadController = manager.imageUpload(mcuMgrImage.getData(), image, callback);
+			mUploadController = manager.imageUpload(data, image, callback);
 		}
 	}
 

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/image/ImageWithHash.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/image/ImageWithHash.java
@@ -1,0 +1,12 @@
+package io.runtime.mcumgr.image;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface ImageWithHash {
+    /** Returns the image data. */
+    byte @NotNull [] getData();
+    /** Returns the hash of the image. */
+    byte @NotNull [] getHash();
+    /** Returns true if the image needs confirmation to be applied. */
+    boolean needsConfirmation();
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/image/McuMgrImage.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/image/McuMgrImage.java
@@ -22,7 +22,7 @@ import io.runtime.mcumgr.image.tlv.McuMgrImageTlv;
  * <a href="https://juullabs-oss.github.io/mcuboot/design.html">https://juullabs-oss.github.io/mcuboot/design.html</a>
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
-public class McuMgrImage {
+public class McuMgrImage implements ImageWithHash {
     public final static int IMG_HASH_LEN = 32;
 
     @NotNull
@@ -57,6 +57,7 @@ public class McuMgrImage {
         mData = image.mData;
     }
 
+    @Override
     public byte @NotNull [] getData() {
         return mData;
     }
@@ -76,8 +77,17 @@ public class McuMgrImage {
         return mTlv;
     }
 
+    @Override
     public byte @NotNull [] getHash() {
         return mHash;
+    }
+
+    @Override
+    public boolean needsConfirmation() {
+        // Actually, not all images require confirmation, but all require a reset.
+        // If an  image is sent to a MCUboot in "DirectXIP without revert" mode if doesn't get
+        // confirmed, but the Reset command is sent after uploading the image.
+        return true;
     }
 
     public static byte @NotNull [] getHash(byte @NotNull [] data) throws McuMgrException {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/image/SUITImage.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/image/SUITImage.java
@@ -1,0 +1,85 @@
+package io.runtime.mcumgr.image;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.runtime.mcumgr.exception.McuMgrException;
+
+public class SUITImage implements ImageWithHash {
+    private final byte @NotNull [] mHash;
+    private final byte @NotNull [] mData;
+
+    private SUITImage(byte @NotNull [] hash, byte @NotNull [] data) {
+        mHash = hash;
+        mData = data;
+    }
+
+    @Override
+    public byte @NotNull [] getData() {
+        return mData;
+    }
+
+    /**
+     * Returns the SHA256 hash of the Root Manifest from the Envelope.
+     */
+    @Override
+    public byte @NotNull [] getHash() {
+        return mHash;
+    }
+
+    @Override
+    public boolean needsConfirmation() {
+        // The implementation will find out what to do from SUIT file.
+        // No need to confirm, no need to send Reset.
+        // Just upload the file and that's all.
+        return false;
+    }
+
+    public static byte @NotNull [] getHash(byte @NotNull [] data) throws McuMgrException {
+        return fromBytes(data).getHash();
+    }
+
+    public static SUITImage fromBytes(byte @NotNull [] data) throws McuMgrException {
+        if (data.length < 2 || data[0] != (byte) 0xD8 || data[1] != (byte) 0x6B) {
+            throw new McuMgrException("Invalid SUIT image");
+        }
+        // We could parse the SUIT Envelope here, but that would require migrating to Kotlin CBOR
+        // (jackson-dataformat-cbor doesn't support non-String keys).
+        // One day, perhaps. For now, let's do a trick.
+
+        // The Root Manifest SHA256 is embedded in the Authentication Block in SUIT Envelope,
+        // so we can just extract it.
+        // The SHA is prefixed with:
+        // 82         # array(2)
+        //   2F       # negative(15) - this is actually -16, CBOR uses weird encoding.
+        //     58 20  # bytes(32)
+        //
+        // This -16 above is the key for SHA256 algorithm-id in COSE registry:
+        // REQUIRED to implement in SUIT:
+        // cose-alg-sha-256 = -16
+        //
+        // OPTIONAL to implement in SUIT and ignored currently:
+        // cose-alg-shake128 = -18
+        // cose-alg-sha-384 = -43
+        // cose-alg-sha-512 = -44
+        // cose-alg-shake256 = -45
+        //
+        // Link to the registry: https://www.iana.org/assignments/cose/cose.xhtml#algorithms
+
+        // Let's take the 32 bytes after the prefix. Btw, this may fail if the Envelope contains some
+        // other data with the same set of bytes before the Authentication Block. But that's unlikely,
+        // and even if, not a biggie.
+        int pos = -1;
+        for (int i = 0; i < data.length - 4 + 32; i++) {
+            if (data[i] == (byte) 0x82 && data[i + 1] == (byte) 0x2F && data[i + 2] == (byte) 0x58 && data[i + 3] == (byte) 0x20) {
+                pos = i + 4;
+                break;
+            }
+        }
+        if (pos == -1) {
+            throw new McuMgrException("Invalid SUIT image");
+        }
+        byte[] hash = new byte[32];
+        System.arraycopy(data, pos, hash, 0, 32);
+        return new SUITImage(hash, data);
+    }
+}

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
@@ -35,6 +35,7 @@ import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
 import io.runtime.mcumgr.dfu.model.McuMgrTargetImage;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.image.McuMgrImage;
+import io.runtime.mcumgr.image.SUITImage;
 import io.runtime.mcumgr.sample.R;
 import io.runtime.mcumgr.sample.databinding.FragmentCardImageUpgradeBinding;
 import io.runtime.mcumgr.sample.di.Injectable;
@@ -375,8 +376,18 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
                 binding.actionStart.setEnabled(true);
                 binding.status.setText(R.string.image_upgrade_status_ready);
             } catch (final Exception e1) {
-                clearFileContent();
-                onFileLoadingFailed(R.string.image_error_file_not_valid);
+                // Support for SUIT (Software Update for Internet of Things) format.
+                try {
+                    // Try parsing SUIT file.
+                    final byte[] hash = SUITImage.getHash(data);
+                    binding.fileHash.setText(StringUtils.toHex(hash));
+                    binding.actionStart.setEnabled(true);
+                    binding.status.setText(R.string.image_upgrade_status_ready);
+                } catch (final Exception e2) {
+                    binding.fileHash.setText(null);
+                    clearFileContent();
+                    onFileLoadingFailed(R.string.image_error_file_not_valid);
+                }
             }
         }
     }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
@@ -61,6 +61,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
 
     private ImageUpgradeViewModel viewModel;
     private int memoryAlignment;
+    private boolean requiresModeSelection;
 
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
@@ -260,9 +261,14 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
         // Restore START action state after rotation
         binding.actionStart.setEnabled(isFileLoaded());
         binding.actionStart.setOnClickListener(v -> {
-            // Show a mode picker. When mode is selected, the upgrade(Mode) method will be called.
-            final DialogFragment dialog = FirmwareUpgradeModeDialogFragment.getInstance();
-            dialog.show(getChildFragmentManager(), null);
+            if (requiresModeSelection) {
+                // Show a mode picker. When mode is selected, the upgrade(Mode) method will be called.
+                final DialogFragment dialog = FirmwareUpgradeModeDialogFragment.getInstance();
+                dialog.show(getChildFragmentManager(), null);
+            } else {
+                // The mode doesn't matter for SUIT files as it's ignored.
+                start(FirmwareUpgradeManager.Mode.NONE);
+            }
         });
 
         // Cancel and Pause/Resume buttons
@@ -349,6 +355,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
             binding.fileHash.setText(StringUtils.toHex(hash));
             binding.actionStart.setEnabled(true);
             binding.status.setText(R.string.image_upgrade_status_ready);
+            requiresModeSelection = true;
         } catch (final McuMgrException e) {
             // For multi-core devices images are bundled in a ZIP file.
             try {
@@ -375,6 +382,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
                 binding.fileSize.setText(sizeBuilder.toString());
                 binding.actionStart.setEnabled(true);
                 binding.status.setText(R.string.image_upgrade_status_ready);
+                requiresModeSelection = true;
             } catch (final Exception e1) {
                 // Support for SUIT (Software Update for Internet of Things) format.
                 try {
@@ -383,6 +391,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
                     binding.fileHash.setText(StringUtils.toHex(hash));
                     binding.actionStart.setEnabled(true);
                     binding.status.setText(R.string.image_upgrade_status_ready);
+                    requiresModeSelection = false;
                 } catch (final Exception e2) {
                     binding.fileHash.setText(null);
                     clearFileContent();

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUploadFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUploadFragment.java
@@ -16,15 +16,17 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import javax.inject.Inject;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProvider;
+
+import javax.inject.Inject;
+
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.image.McuMgrImage;
+import io.runtime.mcumgr.image.SUITImage;
 import io.runtime.mcumgr.sample.R;
 import io.runtime.mcumgr.sample.databinding.FragmentCardImageUploadBinding;
 import io.runtime.mcumgr.sample.di.Injectable;
@@ -175,8 +177,18 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
             binding.actionUpload.setEnabled(true);
             binding.status.setText(R.string.image_upgrade_status_ready);
         } catch (final McuMgrException e) {
-            clearFileContent();
-            onFileLoadingFailed(R.string.image_error_file_not_valid);
+            // Support for SUIT (Software Update for Internet of Things) format.
+            try {
+                // Try parsing SUIT file.
+                final byte[] hash = SUITImage.getHash(data);
+                binding.fileHash.setText(StringUtils.toHex(hash));
+                binding.actionUpload.setEnabled(true);
+                binding.status.setText(R.string.image_upgrade_status_ready);
+            } catch (final Exception e2) {
+                binding.fileHash.setText(null);
+                clearFileContent();
+                onFileLoadingFailed(R.string.image_error_file_not_valid);
+            }
         }
     }
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -152,8 +152,6 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
                         final int memoryAlignment) {
         McuMgrImageSet images;
         try {
-            // Check if the BIN file is valid.
-            McuMgrImage.getHash(data);
             images = new McuMgrImageSet().add(data);
         } catch (final Exception e) {
             try {

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -26,7 +26,6 @@ import io.runtime.mcumgr.dfu.FirmwareUpgradeController;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
 import io.runtime.mcumgr.dfu.model.McuMgrImageSet;
 import io.runtime.mcumgr.exception.McuMgrException;
-import io.runtime.mcumgr.image.McuMgrImage;
 import io.runtime.mcumgr.sample.observable.ConnectionParameters;
 import io.runtime.mcumgr.sample.observable.ObservableMcuMgrBleTransport;
 import io.runtime.mcumgr.sample.utils.ZipPackage;

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUploadViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUploadViewModel.java
@@ -19,6 +19,7 @@ import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.ble.McuMgrBleTransport;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.image.McuMgrImage;
+import io.runtime.mcumgr.image.SUITImage;
 import io.runtime.mcumgr.managers.ImageManager;
 import io.runtime.mcumgr.response.img.McuMgrImageStateResponse;
 import io.runtime.mcumgr.sample.viewmodel.SingleLiveEvent;
@@ -103,13 +104,18 @@ public class ImageUploadViewModel extends McuMgrViewModel implements UploadCallb
         setBusy();
         stateLiveData.setValue(State.VALIDATING);
 
-        byte[] hash;
+        byte[] tmpHash;
         try {
-            hash = McuMgrImage.getHash(data);
+            tmpHash = McuMgrImage.getHash(data);
         } catch (final McuMgrException e) {
-            errorLiveData.setValue(e);
-            return;
+            try {
+                tmpHash = SUITImage.getHash(data);
+            } catch (final McuMgrException e2) {
+                errorLiveData.setValue(e);
+                return;
+            }
         }
+        final byte[] hash = tmpHash;
 
         requestHighConnectionPriority();
         manager.list(new McuMgrCallback<>() {


### PR DESCRIPTION
This PR adds support for [SUIT](https://datatracker.ietf.org/wg/suit/about/).

SUIT files are encoded with CBOR. The file contains an Envelope with an Authorization Block and one or more binaries, or instructions how to get such. The SUIT binary is transfered as-is to the target, which applies the update instructions to itself.
There's no Confirm, Test or Reset command used, as the update procedure is defined in the binary itself.

This PR does not parse the CBOR with the Envelop, as the format uses non-String map keys, which are not supported by the currently used CBOR library (jackson). Migration to [Kotlin CBOR](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-cbor/kotlinx.serialization.cbor/-cbor/) would be required and may be added in another PR.