### PR TITLE
SUIT validation condition fixed

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Validate.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/task/Validate.java
@@ -238,7 +238,7 @@ class Validate extends FirmwareUpgradeTask {
 					}
 					if (!found) {
 						performer.enqueue(new Upload(mcuMgrImage.getData(), imageIndex));
-						if (mcuMgrImage.needsConfirmation() && !allowRevert || mode == Mode.NONE) {
+						if (mcuMgrImage.needsConfirmation() && (!allowRevert || mode == Mode.NONE)) {
 							resetRequired = true;
 						}
 					}


### PR DESCRIPTION
This PR fixes an issue with DFU using SUIT protocol.
When a *.suit* file is used, there should be no TEST, CONFIRM or RESET commands sent, as the procedure is defined in the file itself. However, when `mode` was set to `NONE` (upload only), the RESET command was sent. This was not a big issue, as it isn't supported and the device replies with NOT SUPPORTED error.