### PR TITLE
Fix R8 SLF4J error on minified builds

### DIFF
--- a/mcumgr-core/mcumgr-core-proguard-rules.pro
+++ b/mcumgr-core/mcumgr-core-proguard-rules.pro
@@ -35,3 +35,6 @@
      @com.fasterxml.jackson.annotation.JsonCreator *;
      @com.fasterxml.jackson.annotation.JsonProperty *;
 }
+
+# SLF4J
+-dontwarn org.slf4j.impl.StaticLoggerBinder


### PR DESCRIPTION
Fixes the following error on minified builds:
```
ERROR: R8: Missing class org.slf4j.impl.StaticLoggerBinder (referenced from: void org.slf4j.LoggerFactory.bind() and 3 other contexts)
```