### PR TITLE
Encoding maps in CBOR in canonical form (finite length)

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
@@ -961,7 +961,7 @@ public class ImageManager extends TransferManager {
             } else {
                 // The code below removes the need of calling an expensive method CBOR.toBytes(..)
                 // by calculating the overhead manually. Mind, that the data itself are not added.
-                int size = 2;  // map: 0xBF at the beginning and 0xFF at the end
+                int size = 1;  // map: 0xAn (or 0xBn) - Map in a canonical form (max 23 pairs)
                 size += 5 + CBOR.uintLength(data.length); // "data": 0x6464617461 + 3 for encoding length (as 16-bin positive int, worse case scenario) + NO DATA
                 size += 4 + CBOR.uintLength(offset); // "off": 0x636F6666 + 3 bytes for the offset (as 16-bin positive int, worse case scenario)
                 if (offset == 0) {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Uploader.kt
@@ -382,8 +382,8 @@ abstract class Uploader(
             else -> 8 + 4
         }
 
-        // Size of the indefinite length map tokens (bf, ff)
-        val mapSize = 2
+        // A map token with 5-bit length (A0-AF or B0-B7) - map size of max 23 pairs
+        val mapSize = 1
 
         // Size of the field name "data" utf8 string
         val dataStringSize = CBOR.stringLength("data")

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/util/CBOR.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/util/CBOR.java
@@ -8,6 +8,7 @@ package io.runtime.mcumgr.util;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 
 import org.jetbrains.annotations.NotNull;
@@ -23,6 +24,14 @@ public class CBOR {
 
     public static byte[] toBytes(Object obj) throws IOException {
         ObjectMapper mapper = new ObjectMapper(sFactory);
+
+        // Add canonical serializer for maps. This one will be used instead
+        // of the default one.
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(new CanonicalMapSerializer());
+        mapper.registerModule(module);
+        // TODO: Similar could be added for arrays, but they aren't used.
+
         return mapper.writeValueAsBytes(obj);
     }
 

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/util/CanonicalMapSerializer.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/util/CanonicalMapSerializer.java
@@ -1,0 +1,73 @@
+package io.runtime.mcumgr.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.MapSerializer;
+import com.fasterxml.jackson.databind.type.SimpleType;
+import com.fasterxml.jackson.databind.util.ClassUtil;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This serializer does exactly the same as {@link MapSerializer},
+ * but is using canonical form of encoding maps, instead of
+ * indefinite length.
+ * That is, a map is encoded using it's length instead of a STOP sign.
+ * <ul>
+ *     <li>A0 - map of size 0</li>
+ *     <li>A3 - map of size 3</li>
+ *     <li>An - where n is in { 0 - F }</li>
+ *     <li>B0 - map of size 16</li>
+ *     <li>B7 - max map size encoded in a single byte (23 pairs)</li>
+ *     <li>B8 18 - map of size 24 pairs</li>
+ * </ul>
+ * Before, maps were using BF - map of indefinite length, ending with FF (stop sign).
+ */
+public class CanonicalMapSerializer extends MapSerializer {
+
+    public CanonicalMapSerializer() {
+        super(Collections.emptySet(), null, SimpleType.constructUnsafe(Object.class), SimpleType.constructUnsafe(Object.class), false, null, null, null);
+    }
+
+    @Override
+    public void serialize(
+            Map<?, ?> value, JsonGenerator gen, SerializerProvider provider)
+      throws IOException, JsonProcessingException {
+        // This is the only line that had to be modified:
+        gen.writeStartObject(value, value.size());
+
+        // Rest is as in super class:
+        this.serializeWithoutTypeInfo(value, gen, provider);
+        gen.writeEndObject();
+    }
+
+    // These methods are required to make the overriding class to work:
+
+    public CanonicalMapSerializer(CanonicalMapSerializer canonicalMapSerializer, BeanProperty property, JsonSerializer<?> keySerializer, JsonSerializer<?> valueSerializer, Set<String> ignored, Set<String> included) {
+        super(canonicalMapSerializer, property, keySerializer, valueSerializer, ignored, included);
+    }
+
+    public CanonicalMapSerializer(CanonicalMapSerializer ser, Object filterId, boolean sortKeys) {
+        super(ser, filterId, sortKeys);
+    }
+
+    protected void _ensureOverride(String method) {
+        ClassUtil.verifyMustOverride(CanonicalMapSerializer.class, this, method);
+    }
+
+    public CanonicalMapSerializer withResolved(BeanProperty property, JsonSerializer<?> keySerializer, JsonSerializer<?> valueSerializer, Set<String> ignored, Set<String> included, boolean sortKeys) {
+        this._ensureOverride("withResolved");
+        CanonicalMapSerializer ser = new CanonicalMapSerializer(this, property, keySerializer, valueSerializer, ignored, included);
+        if (sortKeys != ser._sortKeys) {
+            ser = new CanonicalMapSerializer(ser, this._filterId, sortKeys);
+        }
+
+        return ser;
+    }
+}


### PR DESCRIPTION
This PR changes the way how maps are encoded to CBOR by using a finite length.

### Before

Maps were encoded with `BF` token (indefinite length map), followed by key-value pairs and `FF` stop sign.

#### Example

`BF...FF` - a map oa any size

### After

The new `CanonicalMapSerializer` uses `writeStartObject(Object, Int)` to encode the map using its length instead.

#### Example

`A0` - empty map
`A3...` - map with 3 key-value pairs
`AF...` - map with 15 pairs
`B0...` - map with 16 pairs
`B7...` - map with 23 pairs
`B8-18...` map with 24 pairs

> [!Note]
> Canonical form of encoding maps is currently not supported in Jackson library nor in Kotlin CBOR. The proper implementation should rather add a Feature to the `CBORFactory` or somewhere. This one is using a bit of a hack.

This PR is related to https://github.com/FasterXML/jackson-dataformats-binary/issues/3