### PR TITLE
Making the state public as getState() was such

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/TransferCallable.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/TransferCallable.java
@@ -11,7 +11,7 @@ import io.runtime.mcumgr.exception.McuMgrException;
 
 public class TransferCallable implements Callable<Transfer>, TransferController {
 
-    private enum State {
+    public enum State {
         NONE, TRANSFER, PAUSED, CLOSED
     }
 


### PR DESCRIPTION
This PR makes the `State` of `TransferCallable` class public.
I'm not sure why anyone would want to use it, but the `getState()` method was public before despite its return type being private, which was generating a warning. All good now.