### PR TITLE
SUIT manager

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
@@ -70,6 +70,7 @@ public abstract class McuManager {
     protected final static int GROUP_SHELL = 9;
     // https://github.com/nrfconnect/sdk-zephyr/blob/master/include/mgmt/mcumgr/zephyr_groups.h
     protected final static int GROUP_BASIC = 63;
+    protected final static int GROUP_SUIT = 66; // TODO This should be changed to 62 at some point
 
     // User defined groups should start from GROUP_PERUSER.
     protected final static int GROUP_PERUSER = 64;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SUITManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SUITManager.java
@@ -12,6 +12,11 @@ import io.runtime.mcumgr.response.McuMgrResponse;
 import io.runtime.mcumgr.response.suit.McuMgrManifestListResponse;
 import io.runtime.mcumgr.response.suit.McuMgrManifestStateResponse;
 
+/**
+ * The SUIT Manager provides API to access SUIT manifests on supported devices, as well as
+ * perform firmware update. Comparing to {@link ImageManager} it provides more granular control
+ * over the running firmware split into several domains.
+ */
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class SUITManager extends McuManager {
 
@@ -37,7 +42,8 @@ public class SUITManager extends McuManager {
 
     /**
      * Command allows to get information about roles of manifests supported by the device.
-     * @return The response
+     * @return The response with the list of manifest roles. Use {@link #getManifestState(int)}
+     * to get more information about the manifest.
      * @throws McuMgrException on failure.
      */
     @NotNull
@@ -47,6 +53,9 @@ public class SUITManager extends McuManager {
 
     /**
      * Command allows to get information about roles of manifests supported by the device.
+     * <p>
+     * The response contains the list of manifest roles. Use {@link #getManifestState(int, McuMgrCallback)}
+     * to get more information about the manifest.
      * @param callback The response callback.
      */
     public void listManifests(@NotNull McuMgrCallback<McuMgrManifestListResponse> callback) {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SUITManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SUITManager.java
@@ -1,16 +1,23 @@
 package io.runtime.mcumgr.managers;
 
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.HashMap;
 
 import io.runtime.mcumgr.McuManager;
 import io.runtime.mcumgr.McuMgrCallback;
 import io.runtime.mcumgr.McuMgrTransport;
+import io.runtime.mcumgr.exception.InsufficientMtuException;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.response.McuMgrResponse;
+import io.runtime.mcumgr.response.img.McuMgrImageUploadResponse;
+import io.runtime.mcumgr.response.suit.McuMgrEnvelopeUploadResponse;
 import io.runtime.mcumgr.response.suit.McuMgrManifestListResponse;
 import io.runtime.mcumgr.response.suit.McuMgrManifestStateResponse;
+import io.runtime.mcumgr.util.CBOR;
 
 /**
  * The SUIT Manager provides API to access SUIT manifests on supported devices, as well as
@@ -19,6 +26,7 @@ import io.runtime.mcumgr.response.suit.McuMgrManifestStateResponse;
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class SUITManager extends McuManager {
+    private final static Logger LOG = LoggerFactory.getLogger(SUITManager.class);
 
     /**
      * Command allows to get information about roles of manifests supported by the device.
@@ -30,6 +38,11 @@ public class SUITManager extends McuManager {
      * and selected attributes of installed manifests of specified role.
      */
     private final static int ID_MANIFEST_STATE = 1;
+
+    /**
+     * Command delivers a packet of a SUIT envelope to the device.
+     */
+    private final static int ID_UPLOAD = 2;
 
     /**
      * Construct a McuManager instance.
@@ -89,4 +102,103 @@ public class SUITManager extends McuManager {
         payloadMap.put("role", role);
         return send(OP_READ, ID_MANIFEST_STATE, payloadMap, SHORT_TIMEOUT, McuMgrManifestStateResponse.class);
     }
+
+    /**
+     * Command delivers a part of SUIT envelope to the device (asynchronous).
+     * <p>
+     * Once upload is completed the device validates delivered envelope and starts SUIT processing.
+     * <p>
+     * The chunk size is limited by the current MTU. If the current MTU set by
+     * {@link #setUploadMtu(int)} is too large, the {@link McuMgrCallback#onError(McuMgrException)}
+     * with {@link InsufficientMtuException} error will be returned.
+     * Use {@link InsufficientMtuException#getMtu()} to get the current MTU and
+     * pass it to {@link #setUploadMtu(int)} and try again.
+     *
+     * @param data     image data.
+     * @param offset   the offset, from which the chunk will be sent.
+     * @param callback the asynchronous callback.
+     */
+    public void upload(byte @NotNull [] data, int offset,
+                       @NotNull McuMgrCallback<McuMgrEnvelopeUploadResponse> callback) {
+        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset);
+        // Timeout for the initial chunk is long, as the device may need to erase the flash.
+        final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
+        send(OP_WRITE, ID_UPLOAD, payloadMap, timeout, McuMgrEnvelopeUploadResponse.class, callback);
+    }
+
+    /**
+     * Command delivers a part of SUIT envelope to the device (synchronous).
+     * <p>
+     * Once upload is completed the device validates delivered envelope and starts SUIT processing.
+     * <p>
+     * The chunk size is limited by the current MTU. If the current MTU set by
+     * {@link #setUploadMtu(int)} is too large, the {@link InsufficientMtuException} error will be
+     * thrown. Use {@link InsufficientMtuException#getMtu()} to get the current MTU and
+     * pass it to {@link #setUploadMtu(int)} and try again.
+     *
+     * @param data   image data.
+     * @param offset the offset, from which the chunk will be sent.
+     * @return The upload response.
+     */
+    @NotNull
+    public McuMgrImageUploadResponse upload(byte @NotNull [] data, int offset)
+            throws McuMgrException {
+        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset);
+        // Timeout for the initial chunk is long, as the device may need to erase the flash.
+        final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
+        return send(OP_WRITE, ID_UPLOAD, payloadMap, timeout, McuMgrImageUploadResponse.class);
+    }
+
+    /*
+     * Build the upload payload.
+     */
+    @NotNull
+    private HashMap<String, Object> buildUploadPayload(byte @NotNull [] data, int offset) {
+        // Get chunk of image data to send
+        int dataLength = Math.min(mMtu - calculatePacketOverhead(data, offset), data.length - offset);
+        byte[] sendBuffer = new byte[dataLength];
+        System.arraycopy(data, offset, sendBuffer, 0, dataLength);
+
+        // Create the map of key-values for the McuManager payload
+        HashMap<String, Object> payloadMap = new HashMap<>();
+        payloadMap.put("data", sendBuffer);
+        payloadMap.put("off", offset);
+        if (offset == 0) {
+            payloadMap.put("len", data.length);
+        }
+        return payloadMap;
+    }
+
+    private int calculatePacketOverhead(byte @NotNull [] data, int offset) {
+        try {
+            if (getScheme().isCoap()) {
+                HashMap<String, Object> overheadTestMap = new HashMap<>();
+                overheadTestMap.put("data", new byte[0]);
+                overheadTestMap.put("off", offset);
+                if (offset == 0) {
+                    overheadTestMap.put("len", data.length);
+                }
+                byte[] header = {0, 0, 0, 0, 0, 0, 0, 0};
+                overheadTestMap.put("_h", header);
+                byte[] cborData = CBOR.toBytes(overheadTestMap);
+                // 20 byte estimate of CoAP Header; 5 bytes for good measure
+                return cborData.length + 20 + 5;
+            } else {
+                // The code below removes the need of calling an expensive method CBOR.toBytes(..)
+                // by calculating the overhead manually. Mind, that the data itself are not added.
+                int size = 1;  // map: 0xAn (or 0xBn) - Map in a canonical form (max 23 pairs)
+                size += 5 + CBOR.uintLength(data.length); // "data": 0x6464617461 + 3 for encoding length (as 16-bin positive int, worse case scenario) + NO DATA
+                size += 4 + CBOR.uintLength(offset); // "off": 0x636F6666 + 3 bytes for the offset (as 16-bin positive int, worse case scenario)
+                if (offset == 0) {
+                    size += 4 + 5; // "len": 0x636C656E + len as 32-bit positive integer
+                }
+                return size + 8; // 8 additional bytes for the SMP header
+            }
+        } catch (IOException e) {
+            LOG.error("Error while calculating packet overhead", e);
+        }
+        return -1;
+    }
+
+
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SUITManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SUITManager.java
@@ -1,0 +1,46 @@
+package io.runtime.mcumgr.managers;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.runtime.mcumgr.McuManager;
+import io.runtime.mcumgr.McuMgrCallback;
+import io.runtime.mcumgr.McuMgrTransport;
+import io.runtime.mcumgr.exception.McuMgrException;
+import io.runtime.mcumgr.response.McuMgrResponse;
+import io.runtime.mcumgr.response.suit.McuMgrManifestListResponse;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+public class SUITManager extends McuManager {
+
+    /**
+     * Command allows to get information about roles of manifests supported by the device.
+     */
+    private final static int ID_MANIFEST_LIST = 0;
+
+    /**
+     * Construct a McuManager instance.
+     *
+     * @param transporter the transporter to use to send commands.
+     */
+    public SUITManager(@NotNull McuMgrTransport transporter) {
+        super(McuManager.GROUP_SUIT, transporter);
+    }
+
+    /**
+     * Command allows to get information about roles of manifests supported by the device.
+     * @return The response
+     * @throws McuMgrException on failure.
+     */
+    @NotNull
+    public McuMgrResponse listManifests() throws McuMgrException {
+        return send(OP_READ, ID_MANIFEST_LIST, null, SHORT_TIMEOUT, McuMgrManifestListResponse.class);
+    }
+
+    /**
+     * Command allows to get information about roles of manifests supported by the device.
+     * @param callback The response callback.
+     */
+    public void listManifests(@NotNull McuMgrCallback<McuMgrManifestListResponse> callback) {
+        send(OP_READ, ID_MANIFEST_LIST, null, SHORT_TIMEOUT, McuMgrManifestListResponse.class, callback);
+    }
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SUITManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SUITManager.java
@@ -2,12 +2,15 @@ package io.runtime.mcumgr.managers;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
+
 import io.runtime.mcumgr.McuManager;
 import io.runtime.mcumgr.McuMgrCallback;
 import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.response.McuMgrResponse;
 import io.runtime.mcumgr.response.suit.McuMgrManifestListResponse;
+import io.runtime.mcumgr.response.suit.McuMgrManifestStateResponse;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class SUITManager extends McuManager {
@@ -16,6 +19,12 @@ public class SUITManager extends McuManager {
      * Command allows to get information about roles of manifests supported by the device.
      */
     private final static int ID_MANIFEST_LIST = 0;
+
+    /**
+     * Command allows to get information about the configuration of supported manifests
+     * and selected attributes of installed manifests of specified role.
+     */
+    private final static int ID_MANIFEST_STATE = 1;
 
     /**
      * Construct a McuManager instance.
@@ -42,5 +51,33 @@ public class SUITManager extends McuManager {
      */
     public void listManifests(@NotNull McuMgrCallback<McuMgrManifestListResponse> callback) {
         send(OP_READ, ID_MANIFEST_LIST, null, SHORT_TIMEOUT, McuMgrManifestListResponse.class, callback);
+    }
+
+    /**
+     * Command allows to get information about the configuration of supported manifests
+     * and selected attributes of installed manifests of specified role (asynchronous).
+     *
+     * @param role Manifest role, one of values returned by {@link #listManifests()} command.
+     * @param callback the asynchronous callback.
+     */
+    public void getManifestState(int role, @NotNull McuMgrCallback<McuMgrManifestStateResponse> callback) {
+        HashMap<String, Object> payloadMap = new HashMap<>();
+        payloadMap.put("role", role);
+        send(OP_READ, ID_MANIFEST_STATE, payloadMap, SHORT_TIMEOUT, McuMgrManifestStateResponse.class, callback);
+    }
+
+    /**
+     * Command allows to get information about the configuration of supported manifests
+     * and selected attributes of installed manifests of specified role (synchronous).
+     *
+     * @param role Manifest role, one of values returned by {@link #listManifests()} command.
+     * @return The response.
+     * @throws McuMgrException Transport error. See cause.
+     */
+    @NotNull
+    public McuMgrManifestStateResponse getManifestState(int role) throws McuMgrException {
+        HashMap<String, Object> payloadMap = new HashMap<>();
+        payloadMap.put("role", role);
+        return send(OP_READ, ID_MANIFEST_STATE, payloadMap, SHORT_TIMEOUT, McuMgrManifestStateResponse.class);
     }
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SUITManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SUITManager.java
@@ -17,7 +17,10 @@ import io.runtime.mcumgr.response.img.McuMgrImageUploadResponse;
 import io.runtime.mcumgr.response.suit.McuMgrEnvelopeUploadResponse;
 import io.runtime.mcumgr.response.suit.McuMgrManifestListResponse;
 import io.runtime.mcumgr.response.suit.McuMgrManifestStateResponse;
+import io.runtime.mcumgr.transfer.UploadCallback;
+import io.runtime.mcumgr.transfer.EnvelopeUploader;
 import io.runtime.mcumgr.util.CBOR;
+import kotlinx.coroutines.CoroutineScope;
 
 /**
  * The SUIT Manager provides API to access SUIT manifests on supported devices, as well as
@@ -113,6 +116,9 @@ public class SUITManager extends McuManager {
      * with {@link InsufficientMtuException} error will be returned.
      * Use {@link InsufficientMtuException#getMtu()} to get the current MTU and
      * pass it to {@link #setUploadMtu(int)} and try again.
+     * <p>
+     * Use {@link EnvelopeUploader#uploadAsync(UploadCallback)} to
+     * upload the whole envelope.
      *
      * @param data     image data.
      * @param offset   the offset, from which the chunk will be sent.
@@ -135,18 +141,21 @@ public class SUITManager extends McuManager {
      * {@link #setUploadMtu(int)} is too large, the {@link InsufficientMtuException} error will be
      * thrown. Use {@link InsufficientMtuException#getMtu()} to get the current MTU and
      * pass it to {@link #setUploadMtu(int)} and try again.
+     * <p>
+     * Use {@link EnvelopeUploader#uploadAsync(UploadCallback, CoroutineScope)}
+     * to upload the whole envelope.
      *
      * @param data   image data.
      * @param offset the offset, from which the chunk will be sent.
      * @return The upload response.
      */
     @NotNull
-    public McuMgrImageUploadResponse upload(byte @NotNull [] data, int offset)
+    public McuMgrEnvelopeUploadResponse upload(byte @NotNull [] data, int offset)
             throws McuMgrException {
         HashMap<String, Object> payloadMap = buildUploadPayload(data, offset);
         // Timeout for the initial chunk is long, as the device may need to erase the flash.
         final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
-        return send(OP_WRITE, ID_UPLOAD, payloadMap, timeout, McuMgrImageUploadResponse.class);
+        return send(OP_WRITE, ID_UPLOAD, payloadMap, timeout, McuMgrEnvelopeUploadResponse.class);
     }
 
     /*

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrEnvelopeUploadResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrEnvelopeUploadResponse.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Intellinium SAS, 2014-present
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.runtime.mcumgr.response.suit;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import io.runtime.mcumgr.response.UploadResponse;
+
+public class McuMgrEnvelopeUploadResponse extends UploadResponse {
+
+    @JsonCreator
+    public McuMgrEnvelopeUploadResponse() {}
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrManifestListResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrManifestListResponse.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Intellinium SAS, 2014-present
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.runtime.mcumgr.response.suit;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+import io.runtime.mcumgr.response.McuMgrResponse;
+
+public class McuMgrManifestListResponse extends McuMgrResponse {
+
+    public static class Manifest {
+        @JsonProperty("role")
+        public int role;
+    }
+
+    /**
+     * Manifest role encoded as two nibbles: &lt;domain ID&gt; &lt;index&gt;.
+     * Some role values are already know, i.e. 0x20 - Root Manifest.
+     */
+    @JsonProperty("manifests")
+    public List<Manifest> manifests;
+
+    @JsonCreator
+    public McuMgrManifestListResponse() {}
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrManifestListResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrManifestListResponse.java
@@ -9,20 +9,78 @@ package io.runtime.mcumgr.response.suit;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 
+import io.runtime.mcumgr.McuMgrCallback;
+import io.runtime.mcumgr.managers.SUITManager;
 import io.runtime.mcumgr.response.McuMgrResponse;
 
+/** @noinspection unused*/
 public class McuMgrManifestListResponse extends McuMgrResponse {
 
     public static class Manifest {
+
+        /**
+         * Known manifest roles.
+         * This enum is based on <a href="https://github.com/nrfconnect/sdk-nrf/blob/46f6922cce98c9b9ccb69c2458bf57f9bcfb85b9/subsys/suit/metadata/include/suit_metadata.h#L70-L98">suit_metadata.h</a>.
+         */
+        public enum KnownRole {
+            /** Manifest describes the entry-point for all Nordic-controlled manifests. */
+            SEC_TOP(0x10),
+            /** Manifest describes SDFW firmware and recovery updates. */
+            SEC_SDFW(0x11),
+            /** Manifest describes SYSCTRL firmware update and boot procedures. */
+            SEC_SYSCTRL(0x12),
+
+            /** Manifest describes the entry-point for all OEM-controlled manifests. */
+            APP_ROOT(0x20),
+            /** Manifest describes OEM-specific recovery procedure. */
+            APP_RECOVERY(0x21),
+            /** Manifest describes OEM-specific binaries, specific for application core. */
+            APP_LOCAL_1(0x22),
+            /** Manifest describes OEM-specific binaries, specific for application core. */
+            APP_LOCAL_2(0x23),
+            /** Manifest describes OEM-specific binaries, specific for application core. */
+            APP_LOCAL_3(0x24),
+
+            /** Manifest describes radio part of OEM-specific recovery procedure. */
+            RAD_RECOVERY(0x30),
+            /** Manifest describes OEM-specific binaries, specific for radio core. */
+            RAD_LOCAL_1(0x31),
+            /** Manifest describes OEM-specific binaries, specific for radio core. */
+            RAD_LOCAL_2(0x32);
+
+            /** The role value. */
+            public final int id;
+            
+            KnownRole(int id) {
+                this.id = id;
+            }
+        }
+
         @JsonProperty("role")
         public int role;
+
+        /**
+         * Returns the role as a {@link KnownRole} enum, or null if the role is unknown.
+         */
+        @Nullable
+        public KnownRole getRoleOrNull() {
+            for (KnownRole knownRole : KnownRole.values()) {
+                if (knownRole.id == role) {
+                    return knownRole;
+                }
+            }
+            return null;
+        }
     }
 
     /**
-     * Manifest role encoded as two nibbles: &lt;domain ID&gt; &lt;index&gt;.
-     * Some role values are already know, i.e. 0x20 - Root Manifest.
+     * List of manifests available on the device. Each manifest is identified by its role.
+     * Use {@link SUITManager#getManifestState(int, McuMgrCallback)} to
+     * get more manifest details.
      */
     @JsonProperty("manifests")
     public List<Manifest> manifests;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrManifestStateResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrManifestStateResponse.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) Intellinium SAS, 2014-present
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.runtime.mcumgr.response.suit;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.UUID;
+
+import io.runtime.mcumgr.response.McuMgrResponse;
+
+/** @noinspection unused*/
+public class McuMgrManifestStateResponse extends McuMgrResponse {
+
+    /**
+     * Use {@link #getClassId()} to get the class ID as UUID.
+     */
+    @JsonProperty("class_id")
+    public byte[] classId;
+    /**
+     * Use {@link #getVendorId()} to get the vendor ID as UUID.
+     */
+    @JsonProperty("vendor_id")
+    public byte[] vendorId;
+    @JsonProperty("downgrade_prevention_policy")
+    public DowngradePreventionPolicy downgradePreventionPolicy;
+    @JsonProperty("independent_updateability_policy")
+    public IndependentUpdateabilityPolicy independentUpdateabilityPolicy;
+    @JsonProperty("signature_verification_policy")
+    public SignatureVerificationPolicy signatureVerificationPolicy;
+    // In such case response will not contain ‘digest’ field, also remaining fields will not
+    // contain any meaningful information.
+    @JsonProperty("digest")
+    public byte[] digest;
+    @JsonProperty("digest_algorithm")
+    public DigestAlgorithm digest_algorithm;
+    @JsonProperty("signature_check")
+    public SignatureVerification signatureCheck;
+    @JsonProperty("sequence_number")
+    public int sequenceNumber;
+    /**
+     * Use {@link #getVersion()} to get the human-readable version.
+     */
+    @JsonProperty("semantic_version")
+    public int[] semanticVersion;
+
+    @JsonCreator
+    public McuMgrManifestStateResponse() {}
+
+    /** Returns the Manifest class ID. */
+    public UUID getClassId() {
+        return convertBytesToUUID(classId);
+    }
+
+    /** Returns the Manifest vendor ID. */
+    public UUID getVendorId() {
+        return convertBytesToUUID(vendorId);
+    }
+
+    /**
+     * Returns whether the manifest is owned by Nordic Semiconductor.
+     * <br/>
+     * The UUID is generated using the following code:
+     * <code>uuid5(uuid.NAMESPACE_DNS, ‘nordicsemi.com’)</code>
+     */
+    public boolean isVendorNordic() {
+        return getVendorId().equals(UUID.fromString("7617daa5-71fd-5a85-8f94-e28d735ce9f4"));
+    }
+
+    @Nullable
+    private static UUID convertBytesToUUID(final byte @Nullable [] bytes) {
+        if (bytes == null || bytes.length != 16)
+            return null;
+        ByteBuffer bb = ByteBuffer.wrap(bytes);
+        final long msb = bb.getLong();
+        final long lsb = bb.getLong();
+        return new UUID(msb, lsb);
+    }
+
+    public enum DigestAlgorithm {
+        SHA_256(-16),
+        SHA_512(-44);
+
+        @JsonValue
+        private final int code;
+
+        DigestAlgorithm(int code) {
+            this.code = code;
+        }
+    }
+
+    public enum SignatureVerification {
+        NOT_CHECKED(2),
+        FAILED(3),
+        PASSED(4);
+
+        @JsonValue
+        private final int code;
+
+        SignatureVerification(int code) {
+            this.code = code;
+        }
+    }
+
+    public enum DowngradePreventionPolicy {
+        /** No downgrade prevention. */
+        DISABLED(1),
+        /** Update forbidden if candidate version is lower than installed version */
+        ENABLED(2),
+        /** Unknown downgrade prevention policy */
+        UNKNOWN(3);
+
+        @JsonValue
+        private final int code;
+
+        DowngradePreventionPolicy(int code) {
+            this.code = code;
+        }
+    }
+
+    public enum IndependentUpdateabilityPolicy {
+        /** Independent update is forbidden. */
+        DENIED(1),
+        /** Independent update is allowed. */
+        ALLOWED(2),
+        /** Unknown independent updateability policy. */
+        UNKNOWN(3);
+
+        @JsonValue
+        private final int code;
+
+        IndependentUpdateabilityPolicy(int code) {
+            this.code = code;
+        }
+    }
+
+    public enum SignatureVerificationPolicy {
+        /** Do not verify the manifest signature */
+        DISABLED(1),
+        /** Verify the manifest signature only when performing update */
+        ENABLED_ON_UPDATE(2),
+        /** Verify the manifest signature only both when performing update and when booting */
+        ENABLED_ON_UPDATE_AND_BOOT(3),
+        /** Unknown signature verification policy */
+        UNKNOWN(4);
+
+        @JsonValue
+        private final int code;
+
+        SignatureVerificationPolicy(int code) {
+            this.code = code;
+        }
+    }
+
+    private enum ReleaseType {
+        NORMAL(0, ""),
+        RC(-1, "-rc"),
+        BETA(-2, "-beta"),
+        ALPHA(-3, "-alpha");
+
+        private final int code;
+        private final String text;
+
+        static ReleaseType fromCode(int code) {
+            for (ReleaseType type : values()) {
+                if (type.code == code) {
+                    return type;
+                }
+            }
+            throw new IllegalArgumentException("Invalid release type: " + code);
+        }
+
+        ReleaseType(int code, String text) {
+            this.code = code;
+            this.text = text;
+        }
+    }
+
+    /**
+     * Returns human-readable version of the semantic version in format:
+     * <code>&lt;major&gt;.&lt;minor&gt;.&lt;patch&gt;[-&lt;type&gt;][.&lt;release_number&gt;]</code>,
+     * e.g. 1.2.3-rc.4. or 1.0.0.
+     * The release number is optional and present only for non-normal releases.
+     * @return The version string or null if the semantic version is not set.
+     * @throws IllegalArgumentException if the semantic version is invalid.
+     * @see <a href="https://github.com/nrfconnect/sdk-nrf/blob/f441cf9c782099a82c4dc04fad5b110fe4d3072c/subsys/suit/metadata/src/suit_metadata.c#L23-L72">Source</a>
+     */
+    @Nullable
+    public String getVersion() {
+        if (semanticVersion == null) {
+            return null;
+        }
+
+        // There can be only one negative value in the semantic version.
+        // The negative value is the release type.
+        // The value after the release type, if greater than 0, is the release number.
+        // Normal releases have no release number.
+        ReleaseType type = ReleaseType.NORMAL;
+        int major = 0, minor = 0, patch = 0, releaseNumber = 0;
+
+        // Iterate over the semantic version array.
+        for (int i = 0; i < semanticVersion.length; i++) {
+            // If the value is non-negative, assign the correct number. They all default to 0.
+            if (semanticVersion[i] >= 0) {
+                switch (i) {
+                    case 0:
+                        major = semanticVersion[i];
+                        break;
+                    case 1:
+                        minor = semanticVersion[i];
+                        break;
+                    case 2:
+                        patch = semanticVersion[i];
+                        break;
+                    default:
+                        // Too many non-negative values.
+                        throw new IllegalArgumentException("Invalid semantic version: " + Arrays.toString(semanticVersion));
+                }
+            } else {
+                type = ReleaseType.fromCode(semanticVersion[i]);
+                if (semanticVersion.length == i + 2 && semanticVersion[i + 1] >= 0) {
+                    // The release type is followed by a version number.
+                    releaseNumber = semanticVersion[i + 1];
+                    break;
+                } else if (semanticVersion.length == i + 1) {
+                    break;
+                } else {
+                    // Duplicated release type or too many number.
+                    throw new IllegalArgumentException("Invalid semantic version: " + Arrays.toString(semanticVersion));
+                }
+            }
+        }
+        return major + "." + minor + "." + patch + type.text + (releaseNumber > 0 ? "." + releaseNumber : "");
+    }
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrPollResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrPollResponse.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Intellinium SAS, 2014-present
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.runtime.mcumgr.response.suit;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+import java.util.List;
+
+import io.runtime.mcumgr.response.McuMgrResponse;
+
+/** @noinspection unused*/
+public class McuMgrPollResponse extends McuMgrResponse {
+
+
+    /**
+     * Session identifier. Non-zero value, unique for image request.
+     * Not provided if there is no pending image request.
+     */
+    @JsonProperty("stream_session_id")
+    public int streamSessionId;
+
+    /**
+     * Resource identifier, typically in form of a URI.
+     * Not provided if there is no pending image request.
+     */
+    @JsonProperty("resource_id")
+    public byte[] resourceId;
+
+    /**
+     * Checks whether the device is awaiting a resource.
+     * @return true, if the client should deliver requested image to proceed with the update,
+     * false otherwise.
+     */
+    public boolean isRequestingResource() {
+        return streamSessionId != 0;
+    }
+
+    /**
+     * Returns the resource URI, or null if no resource is requested.
+     * @return the resource URI.
+     * @throws IllegalArgumentException if the resource ID is not a valid URI.
+     */
+    @Nullable
+    public URI getResourceUri() {
+        if (resourceId == null) {
+            return null;
+        }
+        return URI.create(new String(resourceId));
+    }
+
+    @JsonCreator
+    public McuMgrPollResponse() {}
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrPollResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrPollResponse.java
@@ -12,20 +12,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
-import java.util.List;
 
 import io.runtime.mcumgr.response.McuMgrResponse;
 
 /** @noinspection unused*/
 public class McuMgrPollResponse extends McuMgrResponse {
 
-
     /**
      * Session identifier. Non-zero value, unique for image request.
      * Not provided if there is no pending image request.
      */
     @JsonProperty("stream_session_id")
-    public int streamSessionId;
+    public int sessionId;
 
     /**
      * Resource identifier, typically in form of a URI.
@@ -40,7 +38,7 @@ public class McuMgrPollResponse extends McuMgrResponse {
      * false otherwise.
      */
     public boolean isRequestingResource() {
-        return streamSessionId != 0;
+        return sessionId != 0;
     }
 
     /**

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrUploadResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrUploadResponse.java
@@ -10,8 +10,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 
 import io.runtime.mcumgr.response.UploadResponse;
 
-public class McuMgrEnvelopeUploadResponse extends UploadResponse {
+public class McuMgrUploadResponse extends UploadResponse {
 
     @JsonCreator
-    public McuMgrEnvelopeUploadResponse() {}
+    public McuMgrUploadResponse() {}
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/EnvelopeUploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/EnvelopeUploader.kt
@@ -8,6 +8,25 @@ import io.runtime.mcumgr.response.suit.McuMgrUploadResponse
 private const val OP_WRITE = 2
 private const val ID_ENVELOPE_UPLOAD = 2
 
+/**
+ * This uploader is using a [SUITManager] to upload the SUIT Envelope.
+ *
+ * The SUIT Envelope is a CBOR-encoded data structure that contains the manifest and, optionally,
+ * the firmware. The SUIT Envelope is sent to the device to start the firmware update process.
+ * If the device decides, during the processing, that additional resources are required, it will
+ * notify the polling client using the [SUITManager.poll] method.
+ *
+ * The response the the poll operation contains a resource URI and session ID. The resource
+ * should be sent using [ResourceUploader].
+ *
+ * @property suitManager The SUIT Manager.
+ * @param envelope The candidate SUIT Envelope to be sent, as bytes.
+ * @param windowCapacity Number of buffers available for sending data, defaults to 1. The more buffers
+ * are available, the more packets can be sent without awaiting notification with response, thus
+ * accelerating upload process.
+ * @param memoryAlignment The memory alignment of the device, defaults to 1. Some memory
+ * implementations may require bytes to be aligned to a certain value before saving them.
+ */
 open class EnvelopeUploader(
     private val suitManager: SUITManager,
     envelope: ByteArray,

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/EnvelopeUploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/EnvelopeUploader.kt
@@ -1,0 +1,42 @@
+package io.runtime.mcumgr.transfer
+
+import io.runtime.mcumgr.McuMgrCallback
+import io.runtime.mcumgr.exception.McuMgrException
+import io.runtime.mcumgr.managers.SUITManager
+import io.runtime.mcumgr.response.suit.McuMgrEnvelopeUploadResponse
+
+private const val OP_WRITE = 2
+private const val ID_UPLOAD = 2
+
+open class EnvelopeUploader(
+    private val suitManager: SUITManager,
+    envelope: ByteArray,
+    windowCapacity: Int = 1,
+    memoryAlignment: Int = 1,
+) : Uploader(
+    envelope,
+    windowCapacity,
+    memoryAlignment,
+    suitManager.mtu,
+    suitManager.scheme
+) {
+    override fun write(requestMap: Map<String, Any>, timeout: Long, callback: (UploadResult) -> Unit) {
+        suitManager.uploadAsync(requestMap, timeout, callback)
+    }
+}
+
+private fun SUITManager.uploadAsync(
+    requestMap: Map<String, Any>,
+    timeout: Long,
+    callback: (UploadResult) -> Unit
+) = send(OP_WRITE, ID_UPLOAD, requestMap, timeout, McuMgrEnvelopeUploadResponse::class.java,
+    object : McuMgrCallback<McuMgrEnvelopeUploadResponse> {
+        override fun onResponse(response: McuMgrEnvelopeUploadResponse) {
+            callback(UploadResult.Response(response, response.returnCode))
+        }
+
+        override fun onError(error: McuMgrException) {
+            callback(UploadResult.Failure(error))
+        }
+    }
+)

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ImageUploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ImageUploader.kt
@@ -15,10 +15,10 @@ private const val ID_UPLOAD = 1
 private const val IMG_HASH_LEN = 32
 
 @Deprecated(
-    message = "Use TransferManager.windowUpload instead",
+    message = "Use ImageUploader.uploadAsync instead",
     replaceWith = ReplaceWith(
         "ImageUploader(this, data, image, windowCapacity, memoryAlignment).uploadAsync(callback)",
-        "io.runtime.mcumgr.transfer.TransferManager.windowUpload"
+        "io.runtime.mcumgr.transfer.ImageUploader"
     )
 )
 fun ImageManager.windowUpload(

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ResourceUploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ResourceUploader.kt
@@ -4,17 +4,26 @@ import io.runtime.mcumgr.McuMgrCallback
 import io.runtime.mcumgr.exception.McuMgrException
 import io.runtime.mcumgr.managers.SUITManager
 import io.runtime.mcumgr.response.suit.McuMgrUploadResponse
+import io.runtime.mcumgr.util.CBOR
 
 private const val OP_WRITE = 2
-private const val ID_ENVELOPE_UPLOAD = 2
+private const val ID_RESOURCE_UPLOAD = 4
 
-open class EnvelopeUploader(
+/**
+ * This uploader is using a [SUITManager] to upload the resource requested by the device during
+ * device firmware update.
+ *
+ * After sending a SUIT Envelope using [EnvelopeUploader], use [SUITManager.poll] to check if any
+ * resource is requested.
+ */
+open class ResourceUploader(
     private val suitManager: SUITManager,
-    envelope: ByteArray,
+    private val sessionId: Int,
+    data: ByteArray,
     windowCapacity: Int = 1,
     memoryAlignment: Int = 1,
 ) : Uploader(
-    envelope,
+    data,
     windowCapacity,
     memoryAlignment,
     suitManager.mtu,
@@ -23,13 +32,29 @@ open class EnvelopeUploader(
     override fun write(requestMap: Map<String, Any>, timeout: Long, callback: (UploadResult) -> Unit) {
         suitManager.uploadAsync(requestMap, timeout, callback)
     }
+
+    override fun getAdditionalData(
+        data: ByteArray,
+        offset: Int,
+        map: MutableMap<String, Any>
+    ) {
+        if (offset == 0) {
+            map["stream_session_id"] = sessionId
+        }
+    }
+
+    override fun getAdditionalSize(offset: Int): Int = when (offset) {
+        // "stream_session_id": 0x73747265616D5F73657373696F6E5F6964 (18 bytes) + session ID
+        0 -> 18 + CBOR.uintLength(sessionId)
+        else -> 0
+    }
 }
 
 private fun SUITManager.uploadAsync(
     requestMap: Map<String, Any>,
     timeout: Long,
     callback: (UploadResult) -> Unit
-) = send(OP_WRITE, ID_ENVELOPE_UPLOAD, requestMap, timeout, McuMgrUploadResponse::class.java,
+) = send(OP_WRITE, ID_RESOURCE_UPLOAD, requestMap, timeout, McuMgrUploadResponse::class.java,
     object : McuMgrCallback<McuMgrUploadResponse> {
         override fun onResponse(response: McuMgrUploadResponse) {
             callback(UploadResult.Response(response, response.returnCode))

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ResourceUploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ResourceUploader.kt
@@ -4,6 +4,7 @@ import io.runtime.mcumgr.McuMgrCallback
 import io.runtime.mcumgr.exception.McuMgrException
 import io.runtime.mcumgr.managers.SUITManager
 import io.runtime.mcumgr.response.suit.McuMgrUploadResponse
+import io.runtime.mcumgr.response.suit.McuMgrPollResponse
 import io.runtime.mcumgr.util.CBOR
 
 private const val OP_WRITE = 2
@@ -15,6 +16,15 @@ private const val ID_RESOURCE_UPLOAD = 4
  *
  * After sending a SUIT Envelope using [EnvelopeUploader], use [SUITManager.poll] to check if any
  * resource is requested.
+ *
+ * @property suitManager The SUIT Manager.
+ * @property sessionId The session ID received in [McuMgrPollResponse] using [SUITManager.poll].
+ * @param data The resource data, as bytes.
+ * @param windowCapacity Number of buffers available for sending data, defaults to 1. The more buffers
+ * are available, the more packets can be sent without awaiting notification with response, thus
+ * accelerating upload process.
+ * @param memoryAlignment The memory alignment of the device, defaults to 1. Some memory
+ * implementations may require bytes to be aligned to a certain value before saving them.
  */
 open class ResourceUploader(
     private val suitManager: SUITManager,

--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrManagerModule.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/module/McuMgrManagerModule.java
@@ -11,6 +11,7 @@ import dagger.Provides;
 import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
 import io.runtime.mcumgr.managers.BasicManager;
+import io.runtime.mcumgr.managers.SUITManager;
 import io.runtime.mcumgr.managers.SettingsManager;
 import io.runtime.mcumgr.managers.DefaultManager;
 import io.runtime.mcumgr.managers.FsManager;
@@ -75,5 +76,11 @@ public class McuMgrManagerModule {
     @McuMgrScope
     static FirmwareUpgradeManager provideFirmwareUpgradeManager(final McuMgrTransport transport) {
         return new FirmwareUpgradeManager(transport);
+    }
+
+    @Provides
+    @McuMgrScope
+    static SUITManager provideSUITManager(final McuMgrTransport transport) {
+        return new SUITManager(transport);
     }
 }


### PR DESCRIPTION
This PR adds implementation for the Mcu Manager's new SUIT group which allows updating firmware using SUIT (Software Update for Internet of Things).

The CBOR protocol isn't finalized and may be changed.

Supported operations:
1. Reading list of all manifest roles
2. Reading manifests by role
3. Uploading candidate SUIT envelope for processing
4. Polling for additional resources
5. Uploading requested resources

Up until now, updating devices with SUIT support was possible using the Image manager, where SUIT commands and parameters were mapped into previous API. However, as SUIT protocol allows the firmware binaries to be delivered outside of the envelope: downloaded (in case of Internet access) or requested from the client, the new API allows to poll the target for required resources and delivering them on demand. As the McuMgr protocol is based on request-response model, the target cannot notify the client when a resource is needed, instead polling mechanism is used.

This PR does not provide any UI for the new manager.