### PR TITLE
Disabling Erase App Settings by default

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
@@ -128,7 +128,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
         // Fill default values.
         if (savedInstanceState == null) {
             final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(requireContext());
-            binding.advancedEraseSettings.setChecked(preferences.getBoolean(PREF_ERASE_APP_SETTINGS, true));
+            binding.advancedEraseSettings.setChecked(preferences.getBoolean(PREF_ERASE_APP_SETTINGS, false));
             binding.advancedSwapTime.setText(getString(R.string.value_int, preferences.getInt(PREF_ESTIMATED_SWAP_TIME, 10)));
             binding.advancedWindowCapacity.setText(getString(R.string.value_int, preferences.getInt(PREF_WINDOW_CAPACITY, 4)));
             memoryAlignment = preferences.getInt(PREF_MEMORY_ALIGNMENT, 4);

--- a/sample/src/main/res/layout/fragment_card_image_upgrade.xml
+++ b/sample/src/main/res/layout/fragment_card_image_upgrade.xml
@@ -128,7 +128,7 @@
             android:id="@+id/advanced_erase_settings"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:checked="true"
+            android:checked="false"
             android:text="@string/image_upgrade_erase_storage"
             app:layout_constraintEnd_toStartOf="@+id/advanced_erase_settings_info"
             app:layout_constraintStart_toStartOf="@+id/file_name_label"

--- a/sample/src/main/res/values/strings_image_upgrade.xml
+++ b/sample/src/main/res/values/strings_image_upgrade.xml
@@ -33,7 +33,7 @@
 
     <string name="image_upgrade_error">The value is invalid.</string>
     <string name="image_upgrade_dialog_help_title">Help</string>
-    <string name="image_upgrade_erase_storage_info">Enabling this feature will cause the application settings to be erased after the new firmware has been sent successfully. This is equivalent of Factory Reset.\n\nEnable when switching applications or upgrading by a major version with incompatible settings structure.\n\nEnabled by default.</string>
+    <string name="image_upgrade_erase_storage_info">Enabling this feature will cause the application settings to be erased after the new firmware has been sent successfully. This is equivalent of Factory Reset.\n\nEnable when switching applications or upgrading by a major version with incompatible settings structure.</string>
     <string name="image_upgrade_swap_time_info">A time required by a device to swap the images. When used with Test &amp; Confirm, the app will delay reconnection given number of seconds to avoid timeouts on reconnection.\n\nBy default 10 seconds.</string>
     <string name="image_upgrade_pipeline_info">The number of net_bufs to allocate for mcumgr. Multiple buffers allow sending packets in parallel, without waiting for their responses, which improves the upload speed.\n\nThis is configured as MCUMGR_BUF_COUNT in KConfig in Zephyr and default equal to 4.</string>
     <string name="image_upgrade_memory_alignment_info">Enabling this will cause each packet to be truncated to fit the device\'s flash alignment. This is only relevant with pipelining, that is with Concurrent buffers count  greater than 1, and is ignored otherwise.\n\nIf a device uses internal flash buffering this can be disabled.</string>


### PR DESCRIPTION
This PR set the default value of the "Erase App Settings" switch to OFF. Users can still enable it and the last used value is saved and restored when the app is relaunched, so the new value only applies until it's changed for the first time.

On Image tab use the arrow to expand the Settings pane and enable the checkbox if needed:
![Screenshot_20240520_115334](https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/assets/6576580/ade72dc8-46b2-456f-847a-20fe60283470)
