### PR TITLE
Allowing reuploading images

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/dialog/YesNoDialogFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/dialog/YesNoDialogFragment.java
@@ -1,0 +1,55 @@
+package io.runtime.mcumgr.sample.dialog;
+
+import android.app.Dialog;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+
+public class YesNoDialogFragment extends DialogFragment {
+	private static final String ARG_REQUEST_ID = "requestId";
+	private static final String ARG_TITLE_ID = "titleId";
+	private static final String ARG_QUESTION_ID = "questionId";
+
+	public interface Listener {
+		void onAnswer(final int requestId, final boolean yes);
+	}
+
+	public static DialogFragment getInstance(final int requestId,
+											 @StringRes final int titleId, @StringRes final int questionId) {
+		final DialogFragment fragment = new YesNoDialogFragment();
+
+		final Bundle args = new Bundle();
+		args.putInt(ARG_REQUEST_ID, requestId);
+		args.putInt(ARG_TITLE_ID, titleId);
+		args.putInt(ARG_QUESTION_ID, questionId);
+		fragment.setArguments(args);
+
+		return fragment;
+	}
+
+	@NonNull
+	@Override
+	public Dialog onCreateDialog(@Nullable final Bundle savedInstanceState) {
+		final Bundle args = requireArguments();
+		final int requestId = args.getInt(ARG_REQUEST_ID);
+
+		return new AlertDialog.Builder(requireContext())
+				.setTitle(args.getInt(ARG_TITLE_ID))
+				.setMessage(args.getInt(ARG_QUESTION_ID))
+				.setPositiveButton(android.R.string.yes, (dialog, which) -> {
+					final Listener listener = (Listener) getParentFragment();
+					if (listener != null)
+						listener.onAnswer(requestId, true);
+				})
+				.setNegativeButton(android.R.string.cancel, (dialog, which) -> {
+					final Listener listener = (Listener) getParentFragment();
+					if (listener != null)
+						listener.onAnswer(requestId, false);
+				})
+				.create();
+	}
+}

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUploadViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUploadViewModel.java
@@ -231,16 +231,14 @@ public class ImageUploadViewModel extends McuMgrViewModel implements UploadCallb
 
     private void requestHighConnectionPriority() {
         final McuMgrTransport transporter = manager.getTransporter();
-        if (transporter instanceof McuMgrBleTransport) {
-            final McuMgrBleTransport bleTransporter = (McuMgrBleTransport) transporter;
+        if (transporter instanceof McuMgrBleTransport bleTransporter) {
             bleTransporter.requestConnPriority(ConnectionPriorityRequest.CONNECTION_PRIORITY_HIGH);
         }
     }
 
     private void setLoggingEnabled(final boolean enabled) {
         final McuMgrTransport transporter = manager.getTransporter();
-        if (transporter instanceof McuMgrBleTransport) {
-            final McuMgrBleTransport bleTransporter = (McuMgrBleTransport) transporter;
+        if (transporter instanceof McuMgrBleTransport bleTransporter) {
             bleTransporter.setLoggingEnabled(enabled);
         }
     }

--- a/sample/src/main/res/values/strings_image_upload.xml
+++ b/sample/src/main/res/values/strings_image_upload.xml
@@ -23,6 +23,10 @@
         <item>Image 3 (3)</item>
     </string-array>
 
+    <string name="image_overwrite_title">Overwrite?</string>
+    <string name="image_overwrite_message">The selected image is already on the device. Do you want to send it again?</string>
+    <string name="image_overwrite_active_message">The selected image is already active. Do you want to send it again?</string>
+
     <string name="image_upload_status_ready">READY</string>
     <string name="image_upload_status_validating">VALIDATING…</string>
     <string name="image_upload_status_uploading">UPLOADING…</string>


### PR DESCRIPTION
This PR adds an option to re-upload the same image again onto the device to the available slot.
When during a validation phase the hash of the selected image is already found on the device a popup will show up asking should it be sent again, or not. Before the change the upload was stopped with a message, that the image is already on the device.

For now, this only only apples to the Advanced pane of Image tab.