### PR TITLE
Add stream variants for download and upload in FsManager

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/StreamDownloadCallback.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/StreamDownloadCallback.java
@@ -1,0 +1,33 @@
+package io.runtime.mcumgr.transfer;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.runtime.mcumgr.exception.McuMgrException;
+
+public interface StreamDownloadCallback {
+    /**
+     * Called when a response has been received successfully.
+     *
+     * @param current   the number of bytes downloaded so far.
+     * @param total     the total size of the download in bytes.
+     * @param timestamp the timestamp of when the response was received.
+     */
+    void onDownloadProgressChanged(int current, int total, long timestamp);
+
+    /**
+     * Called when the download has failed.
+     *
+     * @param error the error. See the cause for more info.
+     */
+    void onDownloadFailed(@NotNull McuMgrException error);
+
+    /**
+     * Called when the download has been canceled.
+     */
+    void onDownloadCanceled();
+
+    /**
+     * Called when the download has finished successfully.
+     */
+    void onDownloadCompleted();
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/StreamTransfer.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/StreamTransfer.java
@@ -1,0 +1,33 @@
+package io.runtime.mcumgr.transfer;
+
+import org.jetbrains.annotations.Nullable;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public abstract class StreamTransfer extends Transfer {
+
+    StreamTransfer() {
+        this(0);
+    }
+
+    StreamTransfer(int offset) {
+        this(offset, -1);
+    }
+
+    StreamTransfer(int offset, int totalBytes) {
+        super(offset);
+        mDataLength = totalBytes;
+    }
+
+    @Override
+    @Deprecated
+    public byte @Nullable [] getData() {
+        throw new UnsupportedOperationException("StreamTransfer has no retrievable data.");
+    }
+
+    /**
+     * Returns true if transfer is complete.
+     */
+    public boolean isFinished() {
+        return mOffset == mDataLength;
+    }
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/StreamUpload.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/StreamUpload.java
@@ -1,0 +1,83 @@
+package io.runtime.mcumgr.transfer;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.InputStream;
+
+import io.runtime.mcumgr.McuMgrErrorCode;
+import io.runtime.mcumgr.exception.McuMgrErrorException;
+import io.runtime.mcumgr.exception.McuMgrException;
+import io.runtime.mcumgr.response.McuMgrResponse;
+import io.runtime.mcumgr.response.UploadResponse;
+
+@SuppressWarnings("unused")
+public abstract class StreamUpload extends StreamTransfer {
+
+    @NotNull
+    private final InputStream mDataInput;
+
+    private final UploadCallback mCallback;
+
+    protected StreamUpload(@NotNull InputStream data, int totalBytes) {
+        this(data, totalBytes, null);
+    }
+
+    protected StreamUpload(
+            @NotNull InputStream data,
+            int totalBytes,
+            @Nullable UploadCallback callback
+    ) {
+        super(0, totalBytes);
+        mDataInput = data;
+        mCallback = callback;
+    }
+
+    protected abstract UploadResponse write(@NotNull InputStream data, int offset, int totalBytes) throws McuMgrException;
+
+    @Override
+    public McuMgrResponse send(int offset) throws McuMgrException {
+        UploadResponse response = write(mDataInput, offset, mDataLength);
+        // Check for a McuManager error.
+        if (response.rc != 0) {
+            throw new McuMgrErrorException(McuMgrErrorCode.valueOf(response.rc));
+        }
+
+        mOffset = response.off;
+
+        return response;
+    }
+
+    @Override
+    public void reset() {
+        mOffset = 0;
+    }
+
+    @Override
+    public void onProgressChanged(int current, int total, long timestamp) {
+        if (mCallback != null) {
+            mCallback.onUploadProgressChanged(current, total, timestamp);
+        }
+    }
+
+    @Override
+    public void onFailed(@NotNull McuMgrException e) {
+        if (mCallback != null) {
+            mCallback.onUploadFailed(e);
+        }
+    }
+
+    @Override
+    public void onCompleted() {
+        if (mCallback != null) {
+            mCallback.onUploadCompleted();
+        }
+    }
+
+    @Override
+    public void onCanceled() {
+        if (mCallback != null) {
+            mCallback.onUploadCanceled();
+        }
+    }
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Transfer.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Transfer.java
@@ -11,23 +11,23 @@ public abstract class Transfer implements TransferCallback {
     byte @Nullable [] mData;
     int mOffset;
 
+    int mDataLength;
+
     Transfer() {
-        mData = null;
-        mOffset = 0;
+        this(null, 0);
     }
 
     Transfer(int offset) {
-        mData = null;
-        mOffset = offset;
+        this(null, offset);
     }
 
     Transfer(byte @Nullable [] data) {
-        mData = data;
-        mOffset = 0;
+        this(data, 0);
     }
 
     Transfer(byte @Nullable [] data, int offset) {
         mData = data;
+        mDataLength = data == null ? -1 : data.length;
         mOffset = offset;
     }
 

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/TransferCallable.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/TransferCallable.java
@@ -97,12 +97,8 @@ public class TransferCallable implements Callable<Transfer>, TransferController 
                     return mTransfer;
                 }
 
-                if (mTransfer.getData() == null) {
-                    throw new NullPointerException("Transfer data is null!");
-                }
-
                 // Call the progress callback.
-                mTransfer.onProgressChanged(mTransfer.getOffset(), mTransfer.getData().length,
+                mTransfer.onProgressChanged(mTransfer.getOffset(), mTransfer.mDataLength,
                         System.currentTimeMillis());
             }
         }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/TransferManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/TransferManager.java
@@ -37,6 +37,19 @@ public class TransferManager extends McuManager {
     }
 
     /**
+     * Start an upload.
+     * <p>
+     * If there is an active transfer being executed on this manager, the transfer will be queued.
+     *
+     * @param upload The upload to start.
+     * @return The controller used to pause, resume, or cancel the upload.
+     */
+    @NotNull
+    public TransferController startUpload(@NotNull StreamUpload upload) {
+        return startTransfer(upload);
+    }
+
+    /**
      * Start an download.
      * <p>
      * If there is an active transfer being executed on this manager, the download will be queued.
@@ -46,6 +59,19 @@ public class TransferManager extends McuManager {
      */
     @NotNull
     public TransferController startDownload(@NotNull Download download) {
+        return startTransfer(download);
+    }
+
+    /**
+     * Start an download.
+     * <p>
+     * If there is an active transfer being executed on this manager, the download will be queued.
+     *
+     * @param download The upload to start.
+     * @return The controller used to pause, resume, or cancel the download.
+     */
+    @NotNull
+    public TransferController startDownload(@NotNull StreamDownload download) {
         return startTransfer(download);
     }
 


### PR DESCRIPTION
Implementation to resolve #157

I added separate stream versions of transfer classes so that backwards compatibility is not affected. I did have to make a small addition to `Transfer` so that retrieving the total size of the transfer in `TransferCallable` does not depend on retrieving the data array to allow it to work with stream versions.