### PR TITLE
[1.10.0-sw] Save McuManager downloaded file to phone and fix crash with large files

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -16,7 +16,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 34
         versionCode getVersionCodeFromTags()
-        versionName getVersionNameFromTags()
+        versionName "1.10.0-sw"
         resourceConfigurations += ['en']
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -40,6 +40,9 @@
 	-->
 	<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
 	<!-- Bluetooth LE is required. -->
 	<uses-feature
 		android:name="android.hardware.bluetooth_le"

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FileDownloadManager.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FileDownloadManager.java
@@ -1,0 +1,34 @@
+package io.runtime.mcumgr.sample.fragment.mcumgr;
+
+import static android.os.Environment.DIRECTORY_DOWNLOADS;
+
+import android.content.Context;
+import android.os.Environment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class FileDownloadManager {
+    private final static Logger LOG = LoggerFactory.getLogger(FileDownloadManager.class);
+
+    public boolean save(byte[] data, String fileName) {
+        File file = new File(Environment.getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS), fileName);
+        String path = file.getAbsolutePath();
+        LOG.debug("Saving file to {}", path);
+
+        try {
+            FileOutputStream fos = new FileOutputStream(file);
+            fos.write(data);
+            fos.close();
+            LOG.debug("Saved file to {}", path);
+            return true;
+        } catch (IOException e) {
+            LOG.error(String.format("Failed to save file to %s; size=%d", path, data.length), e);
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Save McuManager downloaded file to phone and fix crash with large files. 
Downloaded file name will have timestamp appended in Internal Storage > Download directory. Fix crash where large files can't display in app. Only display last 10KB of large files in app.

Forked off of parent:7c6f9a455 version 1.10.0-alpha02
