### PR TITLE
Migration to SLF4J 2.0.13

### DIFF
--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     api 'no.nordicsemi.android:ble:2.7.5'
 
     // Logging
-    implementation 'org.slf4j:slf4j-api:1.7.36' // don't update
+    implementation 'org.slf4j:slf4j-api:2.0.13'
 
     // Kotlin
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1'

--- a/mcumgr-core/build.gradle
+++ b/mcumgr-core/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation 'org.jetbrains:annotations:24.1.0'
 
     // Logging
-    implementation 'org.slf4j:slf4j-api:1.7.36' // don't update
+    implementation 'org.slf4j:slf4j-api:2.0.13'
 
     // Kotlin
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1'


### PR DESCRIPTION
This PR migrates logging system to SLF4J version 2.

This is possible thanks to [LionZXY/slf4j2-timber](https://github.com/LionZXY/slf4j2-timber) which created binding for [Timber](https://github.com/JakeWharton/timber) library.

> [!Note]
> The nRF Connect Device Manager library logs using [SLF4J](https://www.slf4j.org/index.html). The _:mcumgr-core_ module includes dependency to _org.slf4j:slf4j-api_ which requires a provider (before called a binding).
> 
> In the app add a provider, for example `implementation 'org.slf4j:slf4j-simple:2.0.13'` or `implementation 'org.slf4j:slf4j-noop:2.0.13'` for disabling logging. See https://mvnrepository.com/artifact/org.slf4j for more.