### PR TITLE
Dimming "No name" on scanner screen for devices without a name

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/MainActivity.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/MainActivity.java
@@ -6,19 +6,23 @@
 
 package io.runtime.mcumgr.sample;
 
+import android.Manifest;
 import android.bluetooth.BluetoothDevice;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.app.ActivityCompat;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentTransaction;
+import androidx.lifecycle.ViewModelProvider;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 import javax.inject.Inject;
 
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentTransaction;
-import androidx.lifecycle.ViewModelProvider;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasAndroidInjector;
@@ -58,7 +62,13 @@ public class MainActivity extends AppCompatActivity
         setContentView(R.layout.activity_main);
 
         final BluetoothDevice device = getIntent().getParcelableExtra(EXTRA_DEVICE);
-        final String deviceName = device.getName();
+        String deviceName = getString(R.string.unknown_device);
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED) {
+            final String name = device.getName();
+            if (name != null && !name.isEmpty()) {
+                deviceName = name;
+            }
+        }
         final String deviceAddress = device.getAddress();
 
         new ViewModelProvider(this, viewModelFactory)

--- a/sample/src/main/java/io/runtime/mcumgr/sample/adapter/DevicesAdapter.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/adapter/DevicesAdapter.java
@@ -72,6 +72,7 @@ public class DevicesAdapter extends RecyclerView.Adapter<DevicesAdapter.ViewHold
 
         if (!TextUtils.isEmpty(deviceName)) {
             holder.binding.deviceName.setText(deviceName);
+            holder.binding.deviceName.setEnabled(true);
             // Set device icon. This is just guessing, based on the device name.
             if (deviceName.toLowerCase(Locale.US).contains("zephyr"))
                 holder.binding.icon.setImageResource(R.drawable.ic_device_zephyr);
@@ -81,6 +82,7 @@ public class DevicesAdapter extends RecyclerView.Adapter<DevicesAdapter.ViewHold
                 holder.binding.icon.setImageResource(R.drawable.ic_device_other);
         } else {
             holder.binding.deviceName.setText(R.string.unknown_device);
+            holder.binding.deviceName.setEnabled(false);
             holder.binding.icon.setImageResource(R.drawable.ic_device_other);
         }
         holder.binding.deviceAddress.setText(device.getAddress());

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
 	<string name="action_settings">Settings</string>
 	<string name="action_enable">Enable</string>
 
-	<string name="unknown_device">Unknown Device</string>
+	<string name="unknown_device">No name</string>
 	<string name="value_int">%d</string>
 
 	<string name="location_permission_title">LOCATION PERMISSION REQUIRED</string>


### PR DESCRIPTION
## Before

Devices that don't advertise a name were shown as "Unknown Device". The text was using primary color.

## After

Such devices are shown as "No name" and the text is disabled (dimmed). This is to distinguish from devices that have name "No name". I'm sure there's at least one. Also, the "No name" is added to title of the Main Activity instead of nothing.