### PR TITLE
Fixed sending non-suit image files

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -357,11 +357,10 @@ public class ImageUpgradeViewModel extends McuMgrViewModel {
                     upgradeWithSUITManager(suitImage, windowCapacity, memoryAlignment);
                     return;
                 }
+                throw new NullPointerException();
+            } catch (final Exception e2) {
                 // Fallback to Image Manager.
                 onSuitNotSupported.run();
-            } catch (final Exception e2) {
-                Timber.e(e, "Invalid image file");
-                errorLiveData.setValue(new McuMgrException("Invalid image file."));
             }
         }
     }


### PR DESCRIPTION
Previously, the implementation was reporting an error prematurely.