### PR TITLE
[Breaking] Validating packet length to skip horribly bad headers

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/McuMgrResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/McuMgrResponse.java
@@ -394,8 +394,12 @@ public class McuMgrResponse implements HasReturnCode {
             if (bytes.length < McuMgrHeader.HEADER_LENGTH) {
                 throw new IOException("Invalid McuMgrHeader");
             }
-            byte[] headerBytes = Arrays.copyOf(bytes, McuMgrHeader.HEADER_LENGTH);
-            McuMgrHeader header = McuMgrHeader.fromBytes(headerBytes);
+            McuMgrHeader header = McuMgrHeader.fromBytes(bytes);
+            // In theory, the packet length is 16-bit long, but in practice, it should not exceed
+            // 2475 bytes minus 8-byte header. Let's say 2500 bytes.
+            if (header.getLen() > 2500) {
+                throw new IOException("Invalid McuMgrHeader");
+            }
             return header.getLen() + McuMgrHeader.HEADER_LENGTH;
         }
     }


### PR DESCRIPTION
This PR fixes #163.

To help ignoring corrupted responses this change adds some validation on the header fields.

> [!WARNING]
> This does not guarantee, that a corrupted header will be ignored, but increases changes. 
> **Also, it limits the length of an SMP packet to 2500 bytes + header.**

If your implementation uses longer packets, please let us know. The default length with SMP segmentation and reassembly is set to 2475 bytes, which is sufficient in all known situations.