### PR TITLE
Feature: Adding support for pushing cache images for SUIT updates

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/mcuboot/model/ImageSet.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/mcuboot/model/ImageSet.java
@@ -3,16 +3,48 @@ package io.runtime.mcumgr.dfu.mcuboot.model;
 import android.util.Pair;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import io.runtime.mcumgr.dfu.suit.model.CacheImage;
 import io.runtime.mcumgr.exception.McuMgrException;
 
-/** @noinspection unused*/
+/**
+ * Represents a set of images to be sent to the device using teh Image group (manager).
+ * <p>
+ * The Image manager can be used to update devices with MCUboot and SUIT bootloaders.
+ * For SUIT bootloaders a dedicated SUIT manager should be used, but some devices support both
+ * or only Image manager (e.g. for recovery).
+ * @noinspection unused
+ */
 public class ImageSet {
+    /**
+     * List of target images to be sent to the device.
+     * <p>
+     * A device with MCUboot bootloader can have multiple images. Each image is identified by
+     * an image index. Images must be sent with the "image" parameter set to the image index.
+     * When all images are sent the client should send "test" or "confirm" command to confirm them
+     * and "reset" command to begin the update.
+     */
     @NotNull
     private final List<TargetImage> images;
+
+    /**
+     * Cache images are used to update devices supporting SUIT manifest. The cache images are
+     * sent after the SUIT manifest and contain parts of firmware that are not included in the
+     * manifest.
+     * <p>
+     * In case the cache images are not null, {@link #images} must contain a single SUIT file.
+     * <p>
+     * Flow:
+     * 1. Send .suit file ("image" is set to 0 (default))
+     * 2. Send cache images, each with "image" parameter set to the partition ID.
+     * 3. Send "confirm" command (without hash) to begin the update.
+     */
+    @Nullable
+    private List<CacheImage> cacheImages;
 
     /**
      * Creates an empty image set. Use {@link #add(TargetImage)} to add targets.
@@ -37,27 +69,52 @@ public class ImageSet {
         return images;
     }
 
+    @Nullable
+    public List<CacheImage> getCacheImages() {
+        return cacheImages;
+    }
+
+    @NotNull
     public ImageSet add(TargetImage binary) {
         images.add(binary);
         return this;
     }
 
+    @NotNull
+    public ImageSet add(CacheImage cacheImage) {
+        if (cacheImages == null) {
+            cacheImages = new ArrayList<>();
+        }
+        cacheImages.add(cacheImage);
+        return this;
+    }
+
+    @NotNull
+    public ImageSet set(List<CacheImage> cacheImages) {
+        this.cacheImages = cacheImages;
+        return this;
+    }
+
+    @NotNull
     public ImageSet add(byte[] image) throws McuMgrException {
         images.add(new TargetImage(image));
         return this;
     }
 
+    @NotNull
     public ImageSet add(Pair<Integer, byte[]> image) throws McuMgrException {
         images.add(new TargetImage(image.first, image.second));
         return this;
     }
 
+    @NotNull
     public ImageSet add(List<android.util.Pair<Integer, byte[]>> images) throws McuMgrException {
         for (Pair<Integer, byte[]> image : images)
             this.images.add(new TargetImage(image.first, image.second));
         return this;
     }
 
+    @NotNull
     public ImageSet removeImagesWithImageIndex(int imageIndex) {
         for (int i = 0; i < images.size(); i++) {
             if (images.get(i).imageIndex == imageIndex) {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/suit/SUITUpgradeManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/suit/SUITUpgradeManager.java
@@ -11,6 +11,7 @@ import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeCallback;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeController;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeSettings;
+import io.runtime.mcumgr.dfu.suit.model.CacheImageSet;
 
 /** @noinspection unused*/
 public class SUITUpgradeManager implements FirmwareUpgradeController {
@@ -142,9 +143,28 @@ public class SUITUpgradeManager implements FirmwareUpgradeController {
      * Start the upgrade.
      * <p>
      * This method should be used for SUIT candidate envelopes files.
+     *
+     * @param settings the firmware upgrade settings.
+     * @param envelope the SUIT candidate envelope.
      */
     public synchronized void start(@NotNull final FirmwareUpgradeSettings settings,
                                    final byte @NotNull [] envelope) {
+        start(settings, envelope, null);
+    }
+
+    /**
+     * Start the upgrade.
+     * <p>
+     * This method should be used for SUIT candidate envelopes files.
+     *
+     * @param settings the firmware upgrade settings.
+     * @param envelope the SUIT candidate envelope.
+     * @param cacheImages cache images to be uploaded together with the SUIT envelope before
+     *                    starting the update.
+     */
+    public synchronized void start(@NotNull final FirmwareUpgradeSettings settings,
+                                   final byte @NotNull [] envelope,
+                                   @Nullable final CacheImageSet cacheImages) {
         if (mPerformer.isBusy()) {
             LOG.info("Firmware upgrade is already in progress");
             return;
@@ -154,7 +174,8 @@ public class SUITUpgradeManager implements FirmwareUpgradeController {
         mInternalCallback.onUpgradeStarted(this);
         final SUITUpgradePerformer.Settings performerSettings =
                 new SUITUpgradePerformer.Settings(settings, mResourceCallback);
-        mPerformer.start(mTransport, performerSettings, envelope);
+
+        mPerformer.start(mTransport, performerSettings, envelope, cacheImages);
     }
 
     //******************************************************************

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/suit/SUITUpgradePerformer.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/suit/SUITUpgradePerformer.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeCallback;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeSettings;
+import io.runtime.mcumgr.dfu.suit.model.CacheImageSet;
 import io.runtime.mcumgr.dfu.suit.task.PerformDfu;
 import io.runtime.mcumgr.dfu.suit.task.SUITUpgradeTask;
 import io.runtime.mcumgr.exception.McuMgrException;
@@ -51,9 +52,10 @@ public class SUITUpgradePerformer extends TaskPerformer<SUITUpgradePerformer.Set
 
     void start(@NotNull final McuMgrTransport transport,
                @NotNull final Settings settings,
-               final byte @NotNull [] envelope) {
+               final byte @NotNull [] envelope,
+               @Nullable final CacheImageSet cacheImageSet) {
         LOG.trace("Starting SUIT upgrade");
-        super.start(transport, settings, new PerformDfu(envelope));
+        super.start(transport, settings, new PerformDfu(envelope, cacheImageSet));
     }
 
     @Override

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/suit/model/CacheImage.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/suit/model/CacheImage.java
@@ -1,0 +1,26 @@
+package io.runtime.mcumgr.dfu.suit.model;
+
+import org.jetbrains.annotations.NotNull;
+
+/** @noinspection unused*/
+public class CacheImage {
+
+    /** Target partition ID. */
+    public final int partitionId;
+
+    /**
+     * The image.
+     */
+    public final byte @NotNull [] image;
+
+    /**
+     * A wrapper for a partition cache raw image and the ID of the partition.
+     *
+     * @param partition the partition ID.
+     * @param data the signed binary to be sent.
+     */
+    public CacheImage(int partition, byte @NotNull [] data) {
+        this.partitionId = partition;
+        this.image = data;
+    }
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/suit/model/CacheImageSet.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/suit/model/CacheImageSet.java
@@ -7,8 +7,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.runtime.mcumgr.exception.McuMgrException;
-
 /** @noinspection unused*/
 public class CacheImageSet {
     @NotNull
@@ -37,22 +35,22 @@ public class CacheImageSet {
         return images;
     }
 
-    public CacheImageSet add(CacheImage image) throws McuMgrException {
+    public CacheImageSet add(CacheImage image) {
         images.add(image);
         return this;
     }
 
-    public CacheImageSet add(int partition, byte[] image) throws McuMgrException {
+    public CacheImageSet add(int partition, byte[] image) {
         images.add(new CacheImage(partition, image));
         return this;
     }
 
-    public CacheImageSet add(Pair<Integer, byte[]> image) throws McuMgrException {
+    public CacheImageSet add(Pair<Integer, byte[]> image) {
         images.add(new CacheImage(image.first, image.second));
         return this;
     }
 
-    public CacheImageSet add(List<Pair<Integer, byte[]>> images) throws McuMgrException {
+    public CacheImageSet add(List<Pair<Integer, byte[]>> images) {
         for (Pair<Integer, byte[]> image : images)
             this.images.add(new CacheImage(image.first, image.second));
         return this;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/suit/model/CacheImageSet.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/suit/model/CacheImageSet.java
@@ -1,0 +1,60 @@
+package io.runtime.mcumgr.dfu.suit.model;
+
+import android.util.Pair;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.runtime.mcumgr.exception.McuMgrException;
+
+/** @noinspection unused*/
+public class CacheImageSet {
+    @NotNull
+    private final List<CacheImage> images;
+
+    /**
+     * Creates an empty image set. Use {@link #add(CacheImage)} to add targets.
+     */
+    public CacheImageSet() {
+        this.images = new ArrayList<>(4);
+    }
+
+    /**
+     * Creates an image set with given targets.
+     * @param targets image targets.
+     */
+    public CacheImageSet(@NotNull final List<CacheImage> targets) {
+        this.images = targets;
+    }
+
+    /**
+     * Returns list of targets.
+     */
+    @NotNull
+    public List<CacheImage> getImages() {
+        return images;
+    }
+
+    public CacheImageSet add(CacheImage image) throws McuMgrException {
+        images.add(image);
+        return this;
+    }
+
+    public CacheImageSet add(int partition, byte[] image) throws McuMgrException {
+        images.add(new CacheImage(partition, image));
+        return this;
+    }
+
+    public CacheImageSet add(Pair<Integer, byte[]> image) throws McuMgrException {
+        images.add(new CacheImage(image.first, image.second));
+        return this;
+    }
+
+    public CacheImageSet add(List<Pair<Integer, byte[]>> images) throws McuMgrException {
+        for (Pair<Integer, byte[]> image : images)
+            this.images.add(new CacheImage(image.first, image.second));
+        return this;
+    }
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/suit/task/BeginInstall.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/suit/task/BeginInstall.java
@@ -1,0 +1,46 @@
+package io.runtime.mcumgr.dfu.suit.task;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.runtime.mcumgr.McuMgrCallback;
+import io.runtime.mcumgr.dfu.suit.SUITUpgradeManager;
+import io.runtime.mcumgr.dfu.suit.SUITUpgradePerformer;
+import io.runtime.mcumgr.exception.McuMgrException;
+import io.runtime.mcumgr.managers.SUITManager;
+import io.runtime.mcumgr.response.McuMgrResponse;
+import io.runtime.mcumgr.task.TaskManager;
+
+class BeginInstall extends SUITUpgradeTask {
+    private final static Logger LOG = LoggerFactory.getLogger(BeginInstall.class);
+
+    @Override
+    public int getPriority() {
+        return PRIORITY_PROCESS;
+    }
+
+    @Override
+    public @Nullable SUITUpgradeManager.State getState() {
+        return SUITUpgradeManager.State.UPLOADING_RESOURCE;
+    }
+
+    @Override
+    public void start(@NotNull TaskManager<SUITUpgradePerformer.Settings, SUITUpgradeManager.State> performer) {
+        LOG.trace("Starting deferred install");
+
+        final SUITManager manager = new SUITManager(performer.getTransport());
+        manager.beginDeferredInstall(new McuMgrCallback<>() {
+            @Override
+            public void onResponse(@NotNull McuMgrResponse response) {
+                performer.onTaskCompleted(BeginInstall.this);
+            }
+
+            @Override
+            public void onError(@NotNull McuMgrException error) {
+                performer.onTaskFailed(BeginInstall.this, error);
+            }
+        });
+    }
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/suit/task/PerformDfu.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/suit/task/PerformDfu.java
@@ -1,9 +1,14 @@
 package io.runtime.mcumgr.dfu.suit.task;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 import io.runtime.mcumgr.dfu.suit.SUITUpgradeManager;
 import io.runtime.mcumgr.dfu.suit.SUITUpgradePerformer;
+import io.runtime.mcumgr.dfu.suit.model.CacheImage;
+import io.runtime.mcumgr.dfu.suit.model.CacheImageSet;
 import io.runtime.mcumgr.task.TaskManager;
 
 /**
@@ -12,9 +17,27 @@ import io.runtime.mcumgr.task.TaskManager;
 public class PerformDfu extends SUITUpgradeTask {
 
 	private final byte @NotNull [] envelope;
+	private final CacheImageSet cacheImages;
 
+	/**
+	 * Create a new PerformDfu task.
+	 * @param envelope the SUIT candidate envelope.
+	 * @noinspection unused
+	 */
 	public PerformDfu(final byte @NotNull [] envelope) {
 		this.envelope = envelope;
+		this.cacheImages = null;
+	}
+
+	/**
+	 * Create a new PerformDfu task.
+	 * @param envelope the SUIT candidate envelope.
+	 * @param cacheImages cache images to be uploaded before starting the update.
+	 */
+	public PerformDfu(final byte @NotNull [] envelope,
+					  final @Nullable CacheImageSet cacheImages) {
+		this.envelope = envelope;
+		this.cacheImages = cacheImages;
 	}
 
 	@NotNull
@@ -30,7 +53,24 @@ public class PerformDfu extends SUITUpgradeTask {
 
 	@Override
 	public void start(final @NotNull TaskManager<SUITUpgradePerformer.Settings, SUITUpgradeManager.State> performer) {
-		performer.enqueue(new UploadEnvelope(envelope));
+		// Upload the candidate envelope.
+		performer.enqueue(new UploadEnvelope(envelope, cacheImages != null));
+
+		// Upload the cache images, if any.
+		if (cacheImages != null) {
+			final List<CacheImage> images = cacheImages.getImages();
+			for (CacheImage image : images) {
+				performer.enqueue(new UploadCache(image.partitionId, image.image));
+			}
+			// After the cache images are uploaded, begin the deferred install.
+			performer.enqueue(new BeginInstall());
+		}
+
+		// After the candidate envelope and cache images are uploaded, client should poll
+		// for more resources.
+		performer.enqueue(new PollTask());
+
+		// Enqueuing is done, notify the performer that this task is complete.
 		performer.onTaskCompleted(this);
 	}
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SUITManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SUITManager.java
@@ -13,10 +13,10 @@ import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.exception.InsufficientMtuException;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.response.McuMgrResponse;
-import io.runtime.mcumgr.response.suit.McuMgrUploadResponse;
 import io.runtime.mcumgr.response.suit.McuMgrManifestListResponse;
 import io.runtime.mcumgr.response.suit.McuMgrManifestStateResponse;
 import io.runtime.mcumgr.response.suit.McuMgrPollResponse;
+import io.runtime.mcumgr.response.suit.McuMgrUploadResponse;
 import io.runtime.mcumgr.transfer.EnvelopeUploader;
 import io.runtime.mcumgr.transfer.ResourceUploader;
 import io.runtime.mcumgr.transfer.UploadCallback;
@@ -31,6 +31,8 @@ import kotlinx.coroutines.CoroutineScope;
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class SUITManager extends McuManager {
     private final static Logger LOG = LoggerFactory.getLogger(SUITManager.class);
+
+    // Link to src: https://github.com/nrfconnect/sdk-nrf/blob/7b1f88d8009719d50fd389487257675246ff4a70/subsys/mgmt/suitfu/src/suitfu_mgmt_priv.h#L41-L50
 
     /**
      * Command allows to get information about roles of manifests supported by the device.
@@ -57,12 +59,12 @@ public class SUITManager extends McuManager {
      * requested image in chunks. Due to the fact that SMP is designed in clients-server pattern
      * and lack of server-sent notifications, implementation bases on polling.
      */
-    private final static int ID_POLL_IMAGE_STATE = 3;
+    private final static int ID_MISSING_IMAGE_STATE = 3;
 
     /**
      * Command delivers a packet of a resource requested by the target device.
      */
-    private final static int ID_RESOURCE_UPLOAD = 4;
+    private final static int ID_MISSING_IMAGE_UPLOAD = 4;
 
     /**
      * Construct a McuManager instance.
@@ -206,7 +208,7 @@ public class SUITManager extends McuManager {
      * @param callback the asynchronous callback.
      */
     public void poll(@NotNull McuMgrCallback<McuMgrPollResponse> callback) {
-        send(OP_READ, ID_POLL_IMAGE_STATE, null, SHORT_TIMEOUT, McuMgrPollResponse.class, callback);
+        send(OP_READ, ID_MISSING_IMAGE_STATE, null, SHORT_TIMEOUT, McuMgrPollResponse.class, callback);
     }
 
     /**
@@ -228,7 +230,7 @@ public class SUITManager extends McuManager {
      */
     @NotNull
     public McuMgrPollResponse poll() throws McuMgrException {
-        return send(OP_READ, ID_POLL_IMAGE_STATE, null, SHORT_TIMEOUT, McuMgrPollResponse.class);
+        return send(OP_READ, ID_MISSING_IMAGE_STATE, null, SHORT_TIMEOUT, McuMgrPollResponse.class);
     }
 
     /**
@@ -254,7 +256,7 @@ public class SUITManager extends McuManager {
         HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, sessionId);
         // Timeout for the initial chunk is long, as the device may need to erase the flash.
         final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
-        send(OP_WRITE, ID_RESOURCE_UPLOAD, payloadMap, timeout, McuMgrUploadResponse.class, callback);
+        send(OP_WRITE, ID_MISSING_IMAGE_UPLOAD, payloadMap, timeout, McuMgrUploadResponse.class, callback);
     }
 
     /**
@@ -281,7 +283,7 @@ public class SUITManager extends McuManager {
         HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, sessionId);
         // Timeout for the initial chunk is long, as the device may need to erase the flash.
         final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
-        return send(OP_WRITE, ID_RESOURCE_UPLOAD, payloadMap, timeout, McuMgrUploadResponse.class);
+        return send(OP_WRITE, ID_MISSING_IMAGE_UPLOAD, payloadMap, timeout, McuMgrUploadResponse.class);
     }
 
     /*

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SUITManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SUITManager.java
@@ -47,6 +47,8 @@ public class SUITManager extends McuManager {
 
     /**
      * Command delivers a packet of a SUIT envelope to the device.
+     * <p>
+     * When sent with len=0, the device will start processing the SUIT envelope.
      */
     private final static int ID_ENVELOPE_UPLOAD = 2;
 
@@ -65,6 +67,16 @@ public class SUITManager extends McuManager {
      * Command delivers a packet of a resource requested by the target device.
      */
     private final static int ID_MISSING_IMAGE_UPLOAD = 4;
+
+    /**
+     * Commands uploads a raw cache image.
+     */
+    private final static int ID_CACHE_RAW_UPLOAD = 5;
+
+    /**
+     * Command cleans up the SUIT cache and envelopes.
+     */
+    private final static int ID_CLEANUP = 6;
 
     /**
      * Construct a McuManager instance.
@@ -159,7 +171,7 @@ public class SUITManager extends McuManager {
      */
     public void upload(byte @NotNull [] data, int offset,
                        @NotNull McuMgrCallback<McuMgrUploadResponse> callback) {
-        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset);
+        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, false, -1, -1);
         // Timeout for the initial chunk is long, as the device may need to erase the flash.
         final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
         send(OP_WRITE, ID_ENVELOPE_UPLOAD, payloadMap, timeout, McuMgrUploadResponse.class, callback);
@@ -185,14 +197,109 @@ public class SUITManager extends McuManager {
     @NotNull
     public McuMgrUploadResponse upload(byte @NotNull [] data, int offset)
             throws McuMgrException {
-        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset);
+        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, false, -1, -1);
         // Timeout for the initial chunk is long, as the device may need to erase the flash.
         final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
         return send(OP_WRITE, ID_ENVELOPE_UPLOAD, payloadMap, timeout, McuMgrUploadResponse.class);
     }
 
     /**
-     * Poll for required image (asynchronous).
+     * Command delivers a part of SUIT envelope to the device (asynchronous).
+     * <p>
+     * When using deferred install, the device will not start the update process after the last
+     * chunk and will await the {@link #beginDeferredInstall()} command. This allows to send cache images
+     * using {@link #uploadCache(int, byte[], int)} before the actual update.
+     * <p>
+     * The chunk size is limited by the current MTU. If the current MTU set by
+     * {@link #setUploadMtu(int)} is too large, the {@link McuMgrCallback#onError(McuMgrException)}
+     * with {@link InsufficientMtuException} error will be returned.
+     * Use {@link InsufficientMtuException#getMtu()} to get the current MTU and
+     * pass it to {@link #setUploadMtu(int)} and try again.
+     * <p>
+     * Use {@link EnvelopeUploader#uploadAsync(UploadCallback)} to
+     * upload the whole envelope.
+     *
+     * @param data     image data.
+     * @param offset   the offset, from which the chunk will be sent.
+     * @param deferInstall if true, the device will not start the update process after the last chunk
+     *                     and will await the {@link #beginDeferredInstall()} command.
+     * @param callback the asynchronous callback.
+     */
+    public void upload(byte @NotNull [] data, int offset, boolean deferInstall,
+                       @NotNull McuMgrCallback<McuMgrUploadResponse> callback) {
+        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, deferInstall, -1, -1);
+        // Timeout for the initial chunk is long, as the device may need to erase the flash.
+        final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
+        send(OP_WRITE, ID_ENVELOPE_UPLOAD, payloadMap, timeout, McuMgrUploadResponse.class, callback);
+    }
+
+    /**
+     * Command delivers a part of SUIT envelope to the device (synchronous).
+     * <p>
+     * When using deferred install, the device will not start the update process after the last
+     * chunk and will await the {@link #beginDeferredInstall()} command. This allows to send cache images
+     * before the actual update.
+     * <p>
+     * The chunk size is limited by the current MTU. If the current MTU set by
+     * {@link #setUploadMtu(int)} is too large, the {@link InsufficientMtuException} error will be
+     * thrown. Use {@link InsufficientMtuException#getMtu()} to get the current MTU and
+     * pass it to {@link #setUploadMtu(int)} and try again.
+     * <p>
+     * Use {@link EnvelopeUploader#uploadAsync(UploadCallback, CoroutineScope)}
+     * to upload the whole envelope.
+     *
+     * @param data   image data.
+     * @param offset the offset, from which the chunk will be sent.
+     * @param deferInstall if true, the device will not start the update process after the last chunk
+     *                     and will await the {@link #beginDeferredInstall()} command.
+     * @return The upload response.
+     */
+    @NotNull
+    public McuMgrUploadResponse upload(byte @NotNull [] data, int offset, boolean deferInstall)
+            throws McuMgrException {
+        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, deferInstall, -1, -1);
+        // Timeout for the initial chunk is long, as the device may need to erase the flash.
+        final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
+        return send(OP_WRITE, ID_ENVELOPE_UPLOAD, payloadMap, timeout, McuMgrUploadResponse.class);
+    }
+
+    /**
+     * Begins the update process (asynchronous).
+     * <p>
+     * This method can be called after the SUIT envelope and cache partition images have been
+     * uploaded to the device.
+     *
+     * @param callback the asynchronous callback.
+     */
+    public void beginDeferredInstall(@NotNull McuMgrCallback<McuMgrResponse> callback) {
+        HashMap<String, Object> payloadMap = new HashMap<>();
+        payloadMap.put("len", 0);
+        payloadMap.put("off", 0);
+        // assuming defer_install is false by default, so not set
+        send(OP_WRITE, ID_ENVELOPE_UPLOAD, payloadMap, SHORT_TIMEOUT, McuMgrResponse.class, callback);
+    }
+
+    /**
+     * Begins the update process (synchronous).
+     * <p>
+     * This method can be called after the SUIT envelope and cache partition images have been
+     * uploaded to the device.
+     *
+     * @return The response.
+     */
+    @NotNull
+    public McuMgrResponse beginDeferredInstall() throws McuMgrException {
+        HashMap<String, Object> payloadMap = new HashMap<>();
+        payloadMap.put("len", 0);
+        payloadMap.put("off", 0);
+        // assuming defer_install is false by default, so not set
+        return send(OP_WRITE, ID_ENVELOPE_UPLOAD, payloadMap, SHORT_TIMEOUT, McuMgrResponse.class);
+    }
+
+    /**
+     * Poll for required image (asynchronous). This should be called after the install was started
+     * either by sending the Envelope without deferred install, or by calling
+     * {@link #beginDeferredInstall(McuMgrCallback)}.
      * <p>
      * SUIT command sequence has the ability of conditional execution of directives, i.e. based
      * on the digest of installed image. That opens scenario where SUIT candidate envelope contains
@@ -203,7 +310,8 @@ public class SUITManager extends McuManager {
      * and lack of server-sent notifications, implementation bases on polling.
      * <p>
      * After sending the Envelope, the client should periodically poll the device to check if an
-     * image is required.
+     * image is required. Use {{@link #uploadResource(int, byte[], int, McuMgrCallback)}} to 
+     * deliver the image.
      *
      * @param callback the asynchronous callback.
      */
@@ -212,7 +320,8 @@ public class SUITManager extends McuManager {
     }
 
     /**
-     * Poll for required image (synchronous).
+     * Poll for required image (synchronous). This should be called after the install was started
+     * either by sending the Envelope without deferred install, or by calling {@link #beginDeferredInstall()}.
      * <p>
      * SUIT command sequence has the ability of conditional execution of directives, i.e. based
      * on the digest of installed image. That opens scenario where SUIT candidate envelope contains
@@ -223,7 +332,7 @@ public class SUITManager extends McuManager {
      * and lack of server-sent notifications, implementation bases on polling.
      * <p>
      * After sending the Envelope, the client should periodically poll the device to check if an
-     * image is required.
+     * image is required. Use {{@link #uploadResource(int, byte[], int)}} to deliver the image.
      *
      * @return The response.
      * @throws McuMgrException Transport error. See cause.
@@ -253,7 +362,7 @@ public class SUITManager extends McuManager {
         if (sessionId <= 0) {
             throw new IllegalArgumentException("Session ID must be greater than 0");
         }
-        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, sessionId);
+        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, false, sessionId, -1);
         // Timeout for the initial chunk is long, as the device may need to erase the flash.
         final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
         send(OP_WRITE, ID_MISSING_IMAGE_UPLOAD, payloadMap, timeout, McuMgrUploadResponse.class, callback);
@@ -280,24 +389,75 @@ public class SUITManager extends McuManager {
         if (sessionId <= 0) {
             throw new IllegalArgumentException("Session ID must be greater than 0");
         }
-        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, sessionId);
+        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, false, sessionId, -1);
         // Timeout for the initial chunk is long, as the device may need to erase the flash.
         final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
         return send(OP_WRITE, ID_MISSING_IMAGE_UPLOAD, payloadMap, timeout, McuMgrUploadResponse.class);
     }
 
-    /*
-     * Build the upload payload.
+    /**
+     * Command delivers a part of a raw cache image to the device (asynchronous).
+     *
+     * @param partition the partition id (target id).
+     * @param data     raw cache data.
+     * @param offset   the offset, from which the chunk will be sent.
+     * @param callback the asynchronous callback.
+     */
+    public void uploadCache(int partition, byte @NotNull [] data, int offset,
+                               @NotNull McuMgrCallback<McuMgrUploadResponse> callback) {
+        if (partition <= 0) {
+            throw new IllegalArgumentException("Partition ID must be greater than 0");
+        }
+        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, false, -1, partition);
+        // Timeout for the initial chunk is long, as the device may need to erase the flash.
+        final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
+        send(OP_WRITE, ID_CACHE_RAW_UPLOAD, payloadMap, timeout, McuMgrUploadResponse.class, callback);
+    }
+
+    /**
+     * Command delivers a part of a raw cache image to the device (synchronous).
+     *
+     * @param partition the partition id (target id).
+     * @param data   raw cache data.
+     * @param offset the offset, from which the chunk will be sent.
+     * @return The upload response.
      */
     @NotNull
-    private HashMap<String, Object> buildUploadPayload(byte @NotNull [] data, int offset) {
-        return buildUploadPayload(data, offset, -1);
+    public McuMgrUploadResponse uploadCache(int partition, byte @NotNull [] data, int offset)
+            throws McuMgrException {
+        if (partition <= 0) {
+            throw new IllegalArgumentException("Partition ID must be greater than 0");
+        }
+        HashMap<String, Object> payloadMap = buildUploadPayload(data, offset, false, partition, -1);
+        // Timeout for the initial chunk is long, as the device may need to erase the flash.
+        final long timeout = offset == 0 ? DEFAULT_TIMEOUT : SHORT_TIMEOUT;
+        return send(OP_WRITE, ID_CACHE_RAW_UPLOAD, payloadMap, timeout, McuMgrUploadResponse.class);
+    }
+
+    /**
+     * Erases the SUIT candidate envelope and cache images stored on the device (asynchronous).
+     *
+     * @param callback the asynchronous callback.
+     */
+    public void cleanup(@NotNull McuMgrCallback<McuMgrResponse> callback) {
+        send(OP_WRITE, ID_CLEANUP, null, DEFAULT_TIMEOUT, McuMgrResponse.class, callback);
+    }
+
+    /**
+     * Erases the SUIT candidate envelope and cache images stored on the device (synchronous).
+     *
+     * @return The response.
+     * @throws McuMgrException Transport error. See cause.
+     */
+    @NotNull
+    public McuMgrResponse cleanup() throws McuMgrException {
+        return send(OP_WRITE, ID_CLEANUP, null, DEFAULT_TIMEOUT, McuMgrResponse.class);
     }
 
     @NotNull
-    private HashMap<String, Object> buildUploadPayload(byte @NotNull [] data, int offset, int sessionId) {
+    private HashMap<String, Object> buildUploadPayload(byte @NotNull [] data, int offset, boolean deferInstall, int sessionId, int partition) {
         // Get chunk of image data to send
-        int dataLength = Math.min(mMtu - calculatePacketOverhead(data, offset, sessionId), data.length - offset);
+        int dataLength = Math.min(mMtu - calculatePacketOverhead(data, offset, deferInstall, sessionId, partition), data.length - offset);
         byte[] sendBuffer = new byte[dataLength];
         System.arraycopy(data, offset, sendBuffer, 0, dataLength);
 
@@ -307,14 +467,20 @@ public class SUITManager extends McuManager {
         payloadMap.put("off", offset);
         if (offset == 0) {
             payloadMap.put("len", data.length);
+            if (deferInstall) {
+                payloadMap.put("defer_install", true);
+            }
             if (sessionId > 0) {
                 payloadMap.put("stream_session_id", sessionId);
+            }
+            if (partition > 0) {
+                payloadMap.put("target_id", partition);
             }
         }
         return payloadMap;
     }
 
-    private int calculatePacketOverhead(byte @NotNull [] data, int offset, int sessionId) {
+    private int calculatePacketOverhead(byte @NotNull [] data, int offset, boolean deferInstall, int sessionId, int partition) {
         try {
             if (getScheme().isCoap()) {
                 HashMap<String, Object> overheadTestMap = new HashMap<>();
@@ -322,8 +488,14 @@ public class SUITManager extends McuManager {
                 overheadTestMap.put("off", offset);
                 if (offset == 0) {
                     overheadTestMap.put("len", data.length);
+                    if (deferInstall) {
+                        overheadTestMap.put("defer_install", true);
+                    }
                     if (sessionId > 0) {
                         overheadTestMap.put("stream_session_id", sessionId);
+                    }
+                    if (partition > 0) {
+                        overheadTestMap.put("target_id", partition);
                     }
                 }
                 byte[] header = {0, 0, 0, 0, 0, 0, 0, 0};
@@ -339,8 +511,14 @@ public class SUITManager extends McuManager {
                 size += 4 + CBOR.uintLength(offset); // "off": 0x636F6666 + offset
                 if (offset == 0) {
                     size += 4 + 5; // "len": 0x636C656E + len as 32-bit positive integer
+                    if (deferInstall) {
+                        size += 15; // "defer_install": 0x6D64656665725F696E7374616C6C + 0xF5 (true)
+                    }
                     if (sessionId > 0) {
-                        size += 18 + CBOR.uintLength(sessionId); // "stream_session_id": 0x73747265616D5F73657373696F6E5F6964 + session ID
+                        size += 18 + CBOR.uintLength(sessionId); // "stream_session_id": 0x7173747265616D5F73657373696F6E5F6964 + session ID
+                    }
+                    if (partition > 0) {
+                        size += 10 + CBOR.uintLength(partition); // "target_id": 0x697461726765745F6964 + partition ID
                     }
                 }
                 return size + 8; // 8 additional bytes for the SMP header

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/CacheUploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/CacheUploader.kt
@@ -1,0 +1,73 @@
+package io.runtime.mcumgr.transfer
+
+import io.runtime.mcumgr.McuMgrCallback
+import io.runtime.mcumgr.exception.McuMgrException
+import io.runtime.mcumgr.managers.SUITManager
+import io.runtime.mcumgr.response.suit.McuMgrUploadResponse
+import io.runtime.mcumgr.util.CBOR
+
+private const val OP_WRITE = 2
+private const val ID_CACHE_RAW_UPLOAD = 4
+
+/**
+ * This uploader is using a [SUITManager] to upload the cache file during device firmware update.
+ *
+ * After sending a SUIT Envelope using [EnvelopeUploader] with _deferred install_, use this
+ * uploader to send the cache files.
+ *
+ * @property suitManager The SUIT Manager.
+ * @property partition The target partition ID.
+ * @param data The resource data, as bytes.
+ * @param windowCapacity Number of buffers available for sending data, defaults to 1. The more buffers
+ * are available, the more packets can be sent without awaiting notification with response, thus
+ * accelerating upload process.
+ * @param memoryAlignment The memory alignment of the device, defaults to 1. Some memory
+ * implementations may require bytes to be aligned to a certain value before saving them.
+ */
+open class CacheUploader(
+    private val suitManager: SUITManager,
+    private val partition: Int,
+    data: ByteArray,
+    windowCapacity: Int = 1,
+    memoryAlignment: Int = 1,
+) : Uploader(
+    data,
+    windowCapacity,
+    memoryAlignment,
+    suitManager.mtu,
+    suitManager.scheme
+) {
+    override fun write(requestMap: Map<String, Any>, timeout: Long, callback: (UploadResult) -> Unit) {
+        suitManager.uploadAsync(requestMap, timeout, callback)
+    }
+
+    override fun getAdditionalData(
+        data: ByteArray,
+        offset: Int,
+        map: MutableMap<String, Any>
+    ) {
+        if (offset == 0) {
+            map["target_id"] = partition
+        }
+    }
+
+    override fun getAdditionalSize(offset: Int): Int =
+        // "target_id": 0x697461726765745F6964 + partition ID
+        if (offset == 0) 18 + CBOR.uintLength(partition) else 0
+}
+
+private fun SUITManager.uploadAsync(
+    requestMap: Map<String, Any>,
+    timeout: Long,
+    callback: (UploadResult) -> Unit
+) = send(OP_WRITE, ID_CACHE_RAW_UPLOAD, requestMap, timeout, McuMgrUploadResponse::class.java,
+    object : McuMgrCallback<McuMgrUploadResponse> {
+        override fun onResponse(response: McuMgrUploadResponse) {
+            callback(UploadResult.Response(response, response.returnCode))
+        }
+
+        override fun onError(error: McuMgrException) {
+            callback(UploadResult.Failure(error))
+        }
+    }
+)

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/CacheUploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/CacheUploader.kt
@@ -7,7 +7,7 @@ import io.runtime.mcumgr.response.suit.McuMgrUploadResponse
 import io.runtime.mcumgr.util.CBOR
 
 private const val OP_WRITE = 2
-private const val ID_CACHE_RAW_UPLOAD = 4
+private const val ID_CACHE_RAW_UPLOAD = 5
 
 /**
  * This uploader is using a [SUITManager] to upload the cache file during device firmware update.

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/EnvelopeUploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/EnvelopeUploader.kt
@@ -32,6 +32,7 @@ open class EnvelopeUploader(
     envelope: ByteArray,
     windowCapacity: Int = 1,
     memoryAlignment: Int = 1,
+    private val deferInstall: Boolean = false,
 ) : Uploader(
     envelope,
     windowCapacity,
@@ -39,6 +40,16 @@ open class EnvelopeUploader(
     suitManager.mtu,
     suitManager.scheme
 ) {
+    override fun getAdditionalSize(offset: Int): Int =
+        // "defer_install": 0x6D64656665725F696E7374616C6C + 0xF5 (true)
+        if (offset == 0 && deferInstall) 15 else 0
+
+    override fun getAdditionalData(data: ByteArray, offset: Int, map: MutableMap<String, Any>) {
+        if (offset == 0 && deferInstall) {
+            map["defer_install"] = true
+        }
+    }
+
     override fun write(requestMap: Map<String, Any>, timeout: Long, callback: (UploadResult) -> Unit) {
         suitManager.uploadAsync(requestMap, timeout, callback)
     }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ResourceUploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ResourceUploader.kt
@@ -3,8 +3,8 @@ package io.runtime.mcumgr.transfer
 import io.runtime.mcumgr.McuMgrCallback
 import io.runtime.mcumgr.exception.McuMgrException
 import io.runtime.mcumgr.managers.SUITManager
-import io.runtime.mcumgr.response.suit.McuMgrUploadResponse
 import io.runtime.mcumgr.response.suit.McuMgrPollResponse
+import io.runtime.mcumgr.response.suit.McuMgrUploadResponse
 import io.runtime.mcumgr.util.CBOR
 
 private const val OP_WRITE = 2
@@ -48,10 +48,13 @@ open class ResourceUploader(
         offset: Int,
         map: MutableMap<String, Any>
     ) {
+        // Note: For some reason this has to be sent in each packet, not just when offset == 0
         map["stream_session_id"] = sessionId
     }
 
     override fun getAdditionalSize(offset: Int): Int =
+        // Note: For some reason this has to be sent in each packet, not just when offset == 0
+
         // "stream_session_id": 0x73747265616D5F73657373696F6E5F6964 (18 bytes) + session ID
         18 + CBOR.uintLength(sessionId)
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ResourceUploader.kt
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/ResourceUploader.kt
@@ -8,7 +8,7 @@ import io.runtime.mcumgr.response.suit.McuMgrPollResponse
 import io.runtime.mcumgr.util.CBOR
 
 private const val OP_WRITE = 2
-private const val ID_RESOURCE_UPLOAD = 4
+private const val ID_MISSING_IMAGE_UPLOAD = 4
 
 /**
  * This uploader is using a [SUITManager] to upload the resource requested by the device during
@@ -60,7 +60,7 @@ private fun SUITManager.uploadAsync(
     requestMap: Map<String, Any>,
     timeout: Long,
     callback: (UploadResult) -> Unit
-) = send(OP_WRITE, ID_RESOURCE_UPLOAD, requestMap, timeout, McuMgrUploadResponse::class.java,
+) = send(OP_WRITE, ID_MISSING_IMAGE_UPLOAD, requestMap, timeout, McuMgrUploadResponse::class.java,
     object : McuMgrCallback<McuMgrUploadResponse> {
         override fun onResponse(response: McuMgrUploadResponse) {
             callback(UploadResult.Response(response, response.returnCode))

--- a/moustache/README.mo
+++ b/moustache/README.mo
@@ -164,11 +164,6 @@ The different firmware upgrade modes are as follows:
 > [!Note]
 > Read about MCUboot modes [here](https://docs.mcuboot.com/design.html#image-slots).
 
-### Software Update for Internet of Things (SUIT)
-
-Starting from version 1.9, the library supports SUIT (Software Update for Internet of Things) files.
-In this case the selected mode is ignored. The process of upgrading is embedded in the SUIT file.
-
 ### Firmware Upgrade State
 
 `FirmwareUpgradeManager` acts as a simple, mostly linear state machine which is determined by the `Mode`.
@@ -182,6 +177,21 @@ device, the `State` will skip `UPLOAD` and move directly to `TEST` (or `CONFIRM`
 has been set). If the uploaded image is already active, and confirmed in slot 0, the upgrade will
 succeed immediately. The `VALIDATE` state makes it easy to reattempt an upgrade without needing to
 re-upload the image or manually determine where to start.
+
+### Software Update for Internet of Things (SUIT)
+
+Starting from version 1.9, the library supports SUIT (Software Update for Internet of Things) files.
+In this case the selected mode is ignored. The process of upgrading is embedded in the SUIT file.
+
+A new firmware can be delivered using:
+- single .suit file with SUIT Envelope
+- a ZIP file with .suit file, cache images and additional binary files.
+
+The update is always started by sending a SUIT Envelope. When cache images are present in the ZIP
+file, they are sent afterwards, each with a target partition ID. After sending a confirm command,
+the library will poll every few seconds for additional resources. If the device requests a new
+resource, it will be sent. The process is repeated until the device reboots, assuming successful
+upgrade.
 
 ## License
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUploadFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUploadFragment.java
@@ -185,25 +185,23 @@ public class ImageUploadFragment extends FileBrowserFragment implements Injectab
 
     @Override
     protected void onFileLoaded(@NonNull final byte[] data) {
+        binding.actionUpload.setEnabled(true);
+        binding.status.setText(R.string.image_upgrade_status_ready);
+        requiresImageSelection = true;
         try {
             final byte[] hash = McuMgrImage.getHash(data);
             binding.fileHash.setText(StringUtils.toHex(hash));
-            binding.actionUpload.setEnabled(true);
-            binding.status.setText(R.string.image_upgrade_status_ready);
-            requiresImageSelection = true;
         } catch (final McuMgrException e) {
             // Support for SUIT (Software Update for Internet of Things) format.
             try {
                 // Try parsing SUIT file.
                 final byte[] hash = SUITImage.getHash(data);
                 binding.fileHash.setText(StringUtils.toHex(hash));
-                binding.actionUpload.setEnabled(true);
-                binding.status.setText(R.string.image_upgrade_status_ready);
+                // A .suit file goes to the main dfu partition, no need to choose.
                 requiresImageSelection = false;
             } catch (final Exception e2) {
+                // Allow sending any file.
                 binding.fileHash.setText(null);
-                clearFileContent();
-                onFileLoadingFailed(R.string.image_error_file_not_valid);
             }
         }
     }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageControlViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageControlViewModel.java
@@ -285,6 +285,7 @@ public class ImageControlViewModel extends McuMgrViewModel {
                 suitManager.cleanup(new McuMgrCallback<>() {
                     @Override
                     public void onResponse(@NotNull McuMgrResponse response) {
+                        eraseAvailableLiveData.postValue(true);
                         postReady();
                     }
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -32,6 +32,7 @@ import io.runtime.mcumgr.dfu.FirmwareUpgradeSettings;
 import io.runtime.mcumgr.dfu.mcuboot.FirmwareUpgradeManager;
 import io.runtime.mcumgr.dfu.mcuboot.model.ImageSet;
 import io.runtime.mcumgr.dfu.suit.SUITUpgradeManager;
+import io.runtime.mcumgr.dfu.suit.model.CacheImageSet;
 import io.runtime.mcumgr.exception.McuMgrErrorException;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.image.SUITImage;
@@ -323,7 +324,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel {
                     // Ignore
                 }
             });
-            upgradeWithSUITManager(envelope, windowCapacity, memoryAlignment);
+            upgradeWithSUITManager(envelope, null, windowCapacity, memoryAlignment);
         } catch (final Exception e) {
             try {
                 // Try reading SUIT envelope from ZIP file.
@@ -332,6 +333,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel {
                 final byte[] envelope = zip.getSuitEnvelope();
                 if (envelope != null) {
                     final SUITImage suitImage = SUITImage.fromBytes(envelope);
+                    final CacheImageSet cacheImages = zip.getCacheBinaries();
                     // During the upload, SUIT manager may request additional resources.
                     // This callback will return the requested resource from the ZIP file.
                     suitManager.setResourceCallback(new SUITUpgradeManager.OnResourceRequiredCallback() {
@@ -354,7 +356,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel {
                             // Ignore
                         }
                     });
-                    upgradeWithSUITManager(suitImage, windowCapacity, memoryAlignment);
+                    upgradeWithSUITManager(suitImage, cacheImages, windowCapacity, memoryAlignment);
                     return;
                 }
                 throw new NullPointerException();
@@ -404,6 +406,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel {
 
     private void upgradeWithSUITManager(
             @NonNull final SUITImage envelope,
+            @Nullable final CacheImageSet cacheImages,
             final int windowCapacity,
             final int memoryAlignment
     ) {
@@ -413,7 +416,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel {
                 .setWindowCapacity(windowCapacity)
                 .setMemoryAlignment(memoryAlignment)
                 .build();
-        suitManager.start(settings, envelope.getData());
+        suitManager.start(settings, envelope.getData(), cacheImages);
     }
 
     public void pause() {

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -292,10 +292,14 @@ public class ImageUpgradeViewModel extends McuMgrViewModel {
                     final ZipPackage zip = new ZipPackage(data);
                     final byte[] envelope = zip.getSuitEnvelope();
                     if (envelope != null) {
-                        // SUIT envelope can also be sent using Image Manager.
+                        // SUIT envelope and cache images can also be sent using Image Manager.
                         // For example for device recovery.
-                        // Usually, a single file wouldn't be placed in a ZIP file, but let's try.
                         images = new ImageSet().add(envelope);
+                        // Check if the ZIP contains cache images.
+                        final CacheImageSet cacheImages = zip.getCacheBinaries();
+                        if (cacheImages != null) {
+                            images.set(cacheImages.getImages());
+                        }
                     } else {
                         images = zip.getBinaries();
                     }

--- a/sample/src/main/res/drawable/ic_help.xml
+++ b/sample/src/main/res/drawable/ic_help.xml
@@ -8,6 +8,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:tint="@color/colorOnSurface"
     android:viewportHeight="24.0"
     android:viewportWidth="24.0">
     <path

--- a/sample/src/main/res/values/strings_image_upload.xml
+++ b/sample/src/main/res/values/strings_image_upload.xml
@@ -17,10 +17,10 @@
 
     <string name="image_select_image">Select Image</string>
     <string-array name="image_select_images">
-        <item>Application Core (0)</item>
-        <item>Network Core (1)</item>
-        <item>Image 2 (2)</item>
-        <item>Image 3 (3)</item>
+        <item>Image 0 (main)</item>
+        <item>Image 1</item>
+        <item>Image 2</item>
+        <item>Image 3</item>
     </string-array>
 
     <string name="image_overwrite_title">Overwrite?</string>


### PR DESCRIPTION
This PR adds a new feature to DFU updates using [SUIT](https://datatracker.ietf.org/wg/suit/about.) bootloader.

### SUIT

In general, a SUIT (Software Update for Internet of Things) allows a _.suit_ file (an _Envelope_) to contain multiple firmware images or fetch them from different locations given with a URI. #160 added support for polling additional images from the phone. In some cases, a device with SUIT bootloader requires all images to be present before the update is started (e.g. to decrease required memory). For that, nRF Connect SDK 2.8 added support for _raw cache_ images. This PR is adding support for this feature in the Android library.

Changes:
1. SUIT group extended by 2 commands:
   1. _Upload raw cache image_ - uploads a cache image with a `target_id` parameter
   2. _Clean up_ - erases all images that were sent to the device before
2. A new parameter added to _Upload Envelope_ command: `defer_install`. When false (default) the update will start immediately after uploading the _.suit_ file (SUIT Envelope). When true, the device will wait for cache images and another call of _Upload Envelope_, this time with `len=0, off=0, defer_install=false`, which will initiate processing the Envelope.

> [!NOTE]
> This change should not break backward compatibility with previous devices with SUIT group, which don't support defering installation nor cache images.

### Image manager

Additionally, for slome  purposes, like device recovery, it is possible for a device to support SUIT update, but with Image manager instead of SUIT manager. The implementation will fall back to Image manager if a command sent to SUIT group will return an error, e.g. NOT SUPPORTED.

For that case, the Firmware Update Manager using Image manager was also modified:
1. Allowing to add cache images to `ImageSet`.
2. Uploading cache images after the Envelope.
3. Sending `confirm` command with `confirm=true` parameter, but without `hash` to begin the update. Note, that the reply to this command does not contain image details, like it does in MCUboot variant. The device reboots immediately after receiving a `confirm` command (it may validate the Envelope before doing so).

### Changes in the sample app

1. Added support for ZIP files containing SUIT update with cache images.
2. Option to send ANY file using Image tab / Advanced / Firmware Upload - as cache images aren't signed
3. Option to call _Erase_ on Image tab / Advanced / Images section after reading the images details
4. Option to send _Confirm_ command on Image tab / Advanced / Images section.

It is possible to:
1. Update a device with cache images using SUIT group
2. Fallback to Image group to update a device when SUIT group is not supported
3. Manually upload _.suit_ envelope and cache images in Advanced view
4. Manually confirm update (begin update after uploading required files
5. Manually clean up the device (_Clean up_ command from SUIT group)