### PR TITLE
Bug fix: set BLE target just once

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/MainActivity.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/MainActivity.java
@@ -76,7 +76,10 @@ public class MainActivity extends AppCompatActivity
         // Otherwise, Dagger2 will fail to inflate this Activity.
         // The target has to be set here, otherwise restoring the state will fail had the
         // Activity been destroyed and recreated.
-        ((Dagger2Application) getApplication()).setTarget(device);
+        // Is should only be done once, when the Activity is created for the first time.
+        if (savedInstanceState == null) {
+            ((Dagger2Application) getApplication()).setTarget(device);
+        }
 
         super.onCreate(savedInstanceState);
         final ActivityMainBinding binding = ActivityMainBinding.inflate(getLayoutInflater());


### PR DESCRIPTION
This PR fixes a bug, causing recreating logger each time the phone change orientation. There might have also been some memory leaks related to this.

Now, the target is set once, so both the logger, and the Dagger component are created only once after a device is selected.