### PR TITLE
Android BLE library updated to 2.2.0-beta03

### DIFF
--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     api project(':mcumgr-core')
 
     // Import the BLE Library
-    api 'no.nordicsemi.android:ble:2.9.0-beta02'
+    api 'no.nordicsemi.android:ble:2.9.0-beta03'
 
     // Logging
     implementation 'org.slf4j:slf4j-api:2.0.16'


### PR DESCRIPTION
The new version contains the following fixes:
* Dependency to `androidx.core:core` downgraded 1.13.1 -> 1.12.0 due to `minSdkVersion` increment 18->19 in version 1.13.
* Fixed issues when bonding is cancelled

 More: https://github.com/NordicSemiconductor/Android-BLE-Library/releases/tag/2.9.0-beta03