### PR TITLE
Displaying "SUIT envelope" next to Size for SUIT files

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/ImageUpgradeFragment.java
@@ -408,7 +408,7 @@ public class ImageUpgradeFragment extends FileBrowserFragment implements Injecta
         try {
             final byte[] hash = SUITImage.getHash(data);
             binding.fileHash.setText(StringUtils.toHex(hash));
-            binding.fileSize.setText(getString(R.string.image_upgrade_size_value, data.length));
+            binding.fileSize.setText(getString(R.string.image_upgrade_size_value_suit, data.length));
             binding.actionStart.setEnabled(true);
             binding.status.setText(R.string.image_upgrade_status_ready);
             requiresModeSelection = false;

--- a/sample/src/main/res/values/strings_image_upgrade.xml
+++ b/sample/src/main/res/values/strings_image_upgrade.xml
@@ -10,6 +10,7 @@
     <string name="image_upgrade_file_name">Name:</string>
     <string name="image_upgrade_size">Size:</string>
     <string name="image_upgrade_size_value">%d bytes</string>
+    <string name="image_upgrade_size_value_suit">%d bytes (SUIT envelope)</string>
     <string name="image_upgrade_hash">Hash:</string>
     <string name="image_upgrade_status">State:</string>
     <string name="image_upgrade_speed">%.1f kB/s</string>


### PR DESCRIPTION
Before, the "Image Upgrade" pane showed: name, size and hash. For SUIT files or ZIP files, the size was set for the SUIT envelope, not the whole ZIP file. That might have been not that clear. Adding "SUIT envelope" after the size makes it more clear.