### PR TITLE
Feature: MCUboot update

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/DefaultManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/DefaultManager.java
@@ -363,11 +363,19 @@ public class DefaultManager extends McuManager {
      * When used as query in {@link #bootloaderInfo(String)} command, returns string representing
      * bootloader name.
      */
-    public static String BOOTLOADER_INFO_QUERY_BOOTLOADER = null;
+    public static final String BOOTLOADER_INFO_QUERY_BOOTLOADER = null;
     /**
      * For bootloader with name "MCUboot" returns the bootloader mode.
      */
-    public static String BOOTLOADER_INFO_MCUBOOT_QUERY_MODE = "mode";
+    public static final String BOOTLOADER_INFO_MCUBOOT_QUERY_MODE = "mode";
+    /**
+     * For bootloader with name "MCUboot" returns the id of a b0 slot with higher version.
+     * <p>
+     * The b0 is a bootloader that boots MCUboot and is used to upgrade MCUboot itself. It has 2
+     * slots: primary (0) and secondary (1) and can boot from either of them.
+     * @see <a href="https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/bootloader/README.html">nRF Secure Immutable Bootloader B0</a>
+     */
+    public static final String BOOTLOADER_INFO_QUERY_ACTIVE_B0_SLOT = "active_b0_slot";
 
     /**
      * Reads the Bootloader info (asynchronous).
@@ -378,6 +386,7 @@ public class DefaultManager extends McuManager {
      * 	            For bootloader named "MCUboot" use {@link #BOOTLOADER_INFO_MCUBOOT_QUERY_MODE} to get
      * 	            the bootloader mode. If query yields no answer, the response will contain
      * 	            an {@link ReturnCode#QUERY_YIELDS_NO_ANSWER} error.
+     * 	            Use {@link #BOOTLOADER_INFO_QUERY_ACTIVE_B0_SLOT} to get the ID of an active B0 slot.
      * @param callback the asynchronous callback.
      */
     public void bootloaderInfo(@Nullable String query, @NotNull McuMgrCallback<McuMgrBootloaderInfoResponse> callback) {
@@ -398,6 +407,7 @@ public class DefaultManager extends McuManager {
      * 	            For bootloader named "MCUboot" use {@link #BOOTLOADER_INFO_MCUBOOT_QUERY_MODE} to get
      * 	            the bootloader mode. If query yields no answer, the response will contain
      * 	            an {@link ReturnCode#QUERY_YIELDS_NO_ANSWER} error.
+     * 	            Use {@link #BOOTLOADER_INFO_QUERY_ACTIVE_B0_SLOT} to get the ID of an active B0 slot.
      * @return The response.
      * @throws McuMgrException Transport error. See cause.
      */

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrBootloaderInfoResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrBootloaderInfoResponse.java
@@ -50,6 +50,18 @@ public class McuMgrBootloaderInfoResponse extends McuMgrOsResponse {
     @JsonProperty("bootloader")
     public String bootloader;
 
+    /** The active slot number is unknown. */
+    public static final int UNKNOWN_SLOT = -1;
+
+    /**
+     * The id of the active B0 slot. It can be either 0 (primary) or
+     * 1 (secondary). This is set only when the request was made with
+     * {@link io.runtime.mcumgr.managers.DefaultManager#BOOTLOADER_INFO_QUERY_ACTIVE_B0_SLOT}
+     * parameter, otherwise set to {@value #UNKNOWN_SLOT}.
+     */
+    @JsonProperty("active")
+    public int activeB0Slot = UNKNOWN_SLOT;
+
     @JsonCreator
     public McuMgrBootloaderInfoResponse() {}
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/dialog/SelectBinaryDialogFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/dialog/SelectBinaryDialogFragment.java
@@ -1,0 +1,67 @@
+package io.runtime.mcumgr.sample.dialog;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.widget.ArrayAdapter;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import io.runtime.mcumgr.sample.R;
+import io.runtime.mcumgr.sample.databinding.DialogSelectImageBinding;
+
+public class SelectBinaryDialogFragment extends DialogFragment {
+	private static final String ARG_REQUEST_ID = "requestId";
+	private int position = 0;
+
+	public interface OnBinarySelectedListener {
+		void onBinarySelected(final int requestId, final int index);
+		void onSelectingBinaryCancelled();
+	}
+
+	public static DialogFragment getInstance(final int requestId) {
+		final DialogFragment fragment = new SelectBinaryDialogFragment();
+
+		final Bundle args = new Bundle();
+		args.putInt(ARG_REQUEST_ID, requestId);
+		fragment.setArguments(args);
+
+		return fragment;
+	}
+
+	@NonNull
+	@Override
+	public Dialog onCreateDialog(@Nullable final Bundle savedInstanceState) {
+		final Bundle args = requireArguments();
+		final int requestId = args.getInt(ARG_REQUEST_ID);
+		final String[] slots = getResources().getStringArray(R.array.image_upgrade_slot);
+		final DialogSelectImageBinding binding = DialogSelectImageBinding.inflate(getLayoutInflater());
+		binding.image.setAdapter(new ArrayAdapter<>(requireContext(), R.layout.drop_down_item, slots));
+		binding.image.setOnItemClickListener((parent, view, position, id) -> this.position = position);
+
+		return new MaterialAlertDialogBuilder(requireContext())
+				.setTitle(R.string.image_upgrade_slot)
+				.setView(binding.getRoot())
+				// Setting the positive button listener here would cause the dialog to dismiss.
+				// We have to validate the value before.
+				.setPositiveButton(android.R.string.ok, (dialog, which) -> {
+					final OnBinarySelectedListener listener = (OnBinarySelectedListener) getParentFragment();
+					if (listener != null)
+						listener.onBinarySelected(requestId, position);
+				})
+				.setNegativeButton(android.R.string.cancel, (dialog, button) -> onCancel(dialog))
+				.create();
+	}
+
+	@Override
+	public void onCancel(@NonNull DialogInterface dialog) {
+		super.onCancel(dialog);
+		final OnBinarySelectedListener listener = (OnBinarySelectedListener) getParentFragment();
+		if (listener != null)
+			listener.onSelectingBinaryCancelled();
+	}
+}

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/DeviceStatusFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/DeviceStatusFragment.java
@@ -13,6 +13,7 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
@@ -21,6 +22,7 @@ import javax.inject.Inject;
 import io.runtime.mcumgr.sample.R;
 import io.runtime.mcumgr.sample.databinding.FragmentCardDeviceStatusBinding;
 import io.runtime.mcumgr.sample.di.Injectable;
+import io.runtime.mcumgr.sample.dialog.HelpDialogFragment;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.DeviceStatusViewModel;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.McuMgrViewModelFactory;
 
@@ -46,6 +48,17 @@ public class DeviceStatusFragment extends Fragment implements Injectable {
                              @Nullable final ViewGroup container,
                              @Nullable final Bundle savedInstanceState) {
         binding = FragmentCardDeviceStatusBinding.inflate(inflater, container, false);
+        binding.toolbar.inflateMenu(R.menu.help);
+        binding.toolbar.setOnMenuItemClickListener(item -> {
+            if (item.getItemId() == R.id.action_help) {
+                final DialogFragment dialog = HelpDialogFragment.getInstance(
+                        R.string.status_dialog_help_title,
+                        R.string.status_dialog_help_message);
+                dialog.show(getChildFragmentManager(), null);
+                return true;
+            }
+            return false;
+        });
         return binding.getRoot();
     }
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/DeviceStatusFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/DeviceStatusFragment.java
@@ -118,6 +118,18 @@ public class DeviceStatusFragment extends Fragment implements Injectable {
                 binding.bootloaderMode.setText(R.string.status_unknown);
             }
         });
+        viewModel.getActiveB0Slot().observe(getViewLifecycleOwner(), slot -> {
+            if (slot != null) {
+                final CharSequence[] slots = getResources().getTextArray(R.array.b0_slots);
+                if (slot >= 0 && slot < slots.length) {
+                    binding.activeB0Slot.setText(slots[slot]);
+                } else {
+                    binding.bootloaderMode.setText(getString(R.string.status_unknown_value, slot));
+                }
+            } else {
+                binding.activeB0Slot.setText(R.string.status_unknown);
+            }
+        });
         viewModel.getAppInfo().observe(getViewLifecycleOwner(), kernel -> {
             if (kernel != null) {
                 binding.kernel.setText(kernel);

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/FileBrowserViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/FileBrowserViewModel.java
@@ -1,10 +1,10 @@
 package io.runtime.mcumgr.sample.viewmodel;
 
-import javax.inject.Inject;
-
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
+
+import javax.inject.Inject;
 
 public class FileBrowserViewModel extends ViewModel {
 	private final MutableLiveData<byte[]> fileContent = new MutableLiveData<>();
@@ -15,7 +15,7 @@ public class FileBrowserViewModel extends ViewModel {
 	}
 
 	public void setFileContent(final byte[] fileContent) {
-		this.fileContent.setValue(fileContent);
+		this.fileContent.postValue(fileContent);
 	}
 
 	public LiveData<byte[]> getFileContent() {

--- a/sample/src/main/res/layout/dialog_select_binary.xml
+++ b/sample/src/main/res/layout/dialog_select_binary.xml
@@ -13,11 +13,6 @@
     android:paddingTop="16dp"
     android:orientation="vertical">
 
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/image_upgrade_slot_descr" />
-
     <com.google.android.material.textfield.TextInputLayout
         style="?textInputOutlinedExposedDropdownMenuStyle"
         android:layout_width="match_parent"

--- a/sample/src/main/res/layout/fragment_card_device_status.xml
+++ b/sample/src/main/res/layout/fragment_card_device_status.xml
@@ -139,6 +139,26 @@
             app:layout_constraintTop_toBottomOf="@+id/bootloader_name_label"/>
 
         <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/active_b0_slot_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:layout_marginStart="16dp"
+            android:text="@string/status_active_b0_slot_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/bootloader_mode_label"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/active_b0_slot"
+            android:layout_width="wrap_content"
+            android:layout_height="21dp"
+            android:layout_marginStart="8dp"
+            android:text="@string/status_unknown"
+            android:textStyle="bold"
+            app:layout_constraintStart_toEndOf="@+id/connection_status_label"
+            app:layout_constraintTop_toBottomOf="@+id/bootloader_mode_label"/>
+
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/kernel_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -147,7 +167,7 @@
             android:text="@string/status_kernel"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/bootloader_mode_label"/>
+            app:layout_constraintTop_toBottomOf="@+id/active_b0_slot_label"/>
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/kernel"
@@ -157,7 +177,7 @@
             android:text="@string/status_unknown"
             android:textStyle="bold"
             app:layout_constraintStart_toEndOf="@+id/connection_status_label"
-            app:layout_constraintTop_toBottomOf="@+id/bootloader_mode_label"/>
+            app:layout_constraintTop_toBottomOf="@+id/active_b0_slot_label"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/sample/src/main/res/values/strings_device_status.xml
+++ b/sample/src/main/res/values/strings_device_status.xml
@@ -12,6 +12,7 @@
     <string name="status_mcumgr_buffer_size_label">Buffer details:</string>
     <string name="status_bootloader_name_label">Bootloader name:</string>
     <string name="status_bootloader_mode_label">Bootloader mode:</string>
+    <string name="status_active_b0_slot_label">Active B0 slot:</string>
     <string name="status_kernel">Kernel:</string>
 
     <string name="status_not_connected">Not connected</string>
@@ -33,12 +34,17 @@
     <string name="status_mcumgr_buffer_size">%d x %d bytes</string>
 
     <string-array name="bootloader_modes">
-        <item>Single App</item>
-        <item>Swap Scratch</item>
-        <item>Overwrite-only</item>
-        <item>Swap Without Scratch</item>
-        <item>Direct XIP Without Revert</item>
-        <item>Direct XIP With Revert</item>
-        <item>RAM Loader</item>
+        <item>Single App (0)</item>
+        <item>Swap Scratch (1)</item>
+        <item>Overwrite-only (2)</item>
+        <item>Swap Without Scratch (3)</item>
+        <item>Direct XIP Without Revert (4)</item>
+        <item>Direct XIP With Revert (5)</item>
+        <item>RAM Loader (6)</item>
+    </string-array>
+
+    <string-array name="b0_slots">
+        <item>Primary (0)</item>
+        <item>Secondary (1)</item>
     </string-array>
 </resources>

--- a/sample/src/main/res/values/strings_device_status.xml
+++ b/sample/src/main/res/values/strings_device_status.xml
@@ -47,4 +47,12 @@
         <item>Primary (0)</item>
         <item>Secondary (1)</item>
     </string-array>
+
+    <string name="status_dialog_help_title">Help</string>
+    <string name="status_dialog_help_message"><b>Buffer details</b> - number of mcumgr buffers and their size,
+        requires MCU Mgr Parameters command in OS Group.
+        \n<b>Bootloader name</b> - name of the bootloader, requires Bootloader Info command in OS Group.
+        \n<b>Bootloader mode</b> - mode of the MCUboot, requires MCUboot bootloader.
+        \n<b>Active B0 slot</b> - slot from which the nRF Secure Immutable Bootloader (NSIB), known also as B0, booted the application.
+        \n<b>Kernel</b> - kernel name and version, requires Application Info command in OS Group.</string>
 </resources>

--- a/sample/src/main/res/values/strings_image_upgrade.xml
+++ b/sample/src/main/res/values/strings_image_upgrade.xml
@@ -49,6 +49,18 @@
         <item>No Revert</item>
     </string-array>
 
+    <string name="image_upgrade_slot">MCUboot update</string>
+    <string name="image_upgrade_slot_descr">Select the MCUboot image to upload.
+        Each image targets a different B0 slot: Primary or Secondary. The selected image should target
+        the opposite slot to the active one.\n\nThe active B0 slot, if known, is displayed on the
+        Device Status pane.\n\nIf you are unsure which image to select, try the one for the Secondary slot.
+        If you select a wrong image the image will be ignored, try the other one next time.</string>
+    <string name="image_upgrade_slot_hint">Select image</string>
+    <string-array name="image_upgrade_slot">
+        <item>Image for the Primary slot</item>
+        <item>Image for the Secondary slot</item>
+    </string-array>
+
     <string name="image_upgrade_status_ready">READY</string>
     <string name="image_upgrade_status_validating">VALIDATING…</string>
     <string name="image_upgrade_status_uploading">UPLOADING…</string>


### PR DESCRIPTION
This PR adds a new feature which allows updating MCUboot bootloader using nRF Secure Immutable Bootloeder.

Read more here: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/bootloader/README.html

The B0 bootloader has 2 slots: primary and secondary. It can run MCUboot from either of them.
It is possible to send a MCUboot update using normal DFU. Upon reboot, MCUboot will notice, that the update is for MCUboot region and will copy the image to the non-used slot of B0 and perform a reset again. After reset B0 will verify the new image and will run the new version from its slot.

As the B0 bootloader isn't swapping images the binaries must be compiled for the correct memory region (so for primary or secondary slot). User needs to select which file to send. As a hint, the Active B0 Slot is shown on Device Status pane for supported devices.

After a successful MCUboot update the Active B0 Slot should change to the other slot.