### PR TITLE
Fixed upload when device isn't ready

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/mcuboot/task/FirmwareUpgradeTask.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/mcuboot/task/FirmwareUpgradeTask.java
@@ -5,8 +5,8 @@ import io.runtime.mcumgr.dfu.mcuboot.FirmwareUpgradeManager.State;
 import io.runtime.mcumgr.task.Task;
 
 public abstract class FirmwareUpgradeTask extends Task<Settings, State> {
-	final static int PRIORITY_VALIDATE = 0;
-	final static int PRIORITY_RESET_INITIAL = 1;
+	final static int PRIORITY_RESET_INITIAL = 0;
+	final static int PRIORITY_VALIDATE = 1;
 	final static int PRIORITY_UPLOAD = 2;
 	final static int PRIORITY_ERASE_SETTINGS = PRIORITY_UPLOAD + 1;
 	final static int PRIORITY_TEST_AFTER_UPLOAD = PRIORITY_ERASE_SETTINGS + 1;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/mcuboot/task/Validate.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/mcuboot/task/Validate.java
@@ -158,7 +158,6 @@ class Validate extends FirmwareUpgradeTask {
 
 				// The flag indicates whether a reset operation should be performed during the process.
 				boolean resetRequired = false;
-				boolean initialResetRequired = false;
 
 				// For each image that is to be sent, check if the same image has already been sent.
 				for (final TargetImage image : images.getImages()) {
@@ -194,39 +193,70 @@ class Validate extends FirmwareUpgradeTask {
 							}
 							break;
 						} else {
+							// The `image.slot` determines to which slot the image will be uploaded.
+							// If the target slot of the image matches the slot number it means that
+							// a Direct XIP mode is used. In that case the firmware comes in two
+							// versions, one for each slot. We need to determine which one to send.
 							if (slot.slot == image.slot) {
-								// The `image.slot` determines to which slot the image will be uploaded.
-								// If the image on the target slot is active, we cannot send there
-								// anything, so we skip this image. It will not be uploaded.
+								// There are 5 cases the slots can be in:
+								//
+								// In "Swap" mode slots A and B are primary and secondary slots.
+								// In "Direct XIP" mode, slot A is the confirmed one, and slot B is the
+								// other one, but any of them can be primary.
+								//
+								// ----------------------------|--------|-----------|-----------------------|---------------------|
+								//                    | Normal | Tested | Confirmed | Test Mode Unconfirmed | Test Mode Confirmed |
+								// ----------------------------|--------|-----------|-----------------------|---------------------|
+								// Slot A | active    |   *    |   *    |    *      |                       |                     |
+								//        | confirmed |   *    |   *    |    *      |           *           |         *           |
+								//        | pending   |        |        |           |                       |                     |
+								//        | permanent |        |        |           |                       |                     |
+								// ----------------------------|--------|-----------|-----------------------|---------------------|
+								// Slot B | active    |        |        |           |           *           |         *           |
+								//        | confirmed |        |        |           |                       |                     |
+								//		  | pending   |        |   *    |    *      |                       |         *           |
+								//		  | permanent |        |        |    *      |                       |         *           |
+								// ----------------------------|--------|-----------|-----------------------|---------------------|
+								//
+								// Update can only be made in the Normal state, where the "other" slot is
+								// empty or has "pending" flag clear (the existing firmware will get
+								// erased automatically if needed).
+								// Sending Reset command will have the following effect:
+								// - Confirmed             -> Normal
+								// - Tested                -> Test Mode Unconfirmed
+								// - Test Mode Unconfirmed -> Normal
+								// - Test Mode Confirmed   -> Normal
+
+								// If the slot is pending or the device is in test mode (one slot
+								// is confirmed and the other active), we need to reset
+								// the device before uploading the image. Both slots in that case
+								// are in use and cannot be erased.
+								//
+								// Reset will cause MCUboot to boot the other slot and change flags,
+								// so we need to Validate again.
+								// Note:
+								//    It may happen that initial reset will be done two times.
+								//    If the image on the secondary slot has been marked as pending
+								//    (using Test command), the reset will switch the device to Test
+								//    mode. In that case, the image on the primary slot will be marked
+								//    as confirmed, and the one on the secondary slot as active.
+								//    Again, neither can be erased. Second reset will switch the device
+								//    back to the primary slot, and the secondary image will be erased
+								//    automatically.
+								if (slot.pending || slot.confirmed != slot.active) {
+									// Both slots are in use, we need to reset the device.
+									performer.enqueue(new ResetBeforeUpload(noSwap));
+									// And schedule the validation again.
+									performer.enqueue(new Validate(mode, images));
+									performer.onTaskCompleted(Validate.this);
+									return;
+								}
+								// If the image on the target slot is confirmed we cannot send
+								// there anything, so we skip this image. It will not be uploaded.
 								// This can happen on the primary slot or, when Direct XIP feature
 								// is enabled, also on the secondary slot.
-								if (slot.active) {
-									skip = true;
-									continue;
-								}
-								// A different image in the secondary slot of required image may be found
-								// in 3 cases:
-
-								// 1. All flags are clear -> a previous update has taken place.
-								//    The slot will be overridden automatically. Nothing needs to be done.
-								if (!slot.pending && !slot.confirmed) {
-									continue;
-								}
-
-								// 2. The confirmed flag is set -> the device is in test mode.
-								//    In that case we need to reset the device to restore the original
-								//    image. We could also confirm the image-under-test, but that's more
-								//    risky.
 								if (slot.confirmed) {
-									initialResetRequired = true;
-								}
-
-								// 3. The pending or permanent flags are set -> the test or confirm
-								//    command have been sent before, but reset was not performed.
-								//    In that case we have to reset before uploading, as pending
-								//    slot cannot be overwritten (NO MEMORY error would be returned).
-								if (slot.pending || slot.permanent) {
-									initialResetRequired = true;
+									skip = true;
 								}
 							}
 						}
@@ -304,9 +334,6 @@ class Validate extends FirmwareUpgradeTask {
 				}
 
 				// To make sure the reset command are added just once, they're added based on flags.
-				if (initialResetRequired) {
-					performer.enqueue(new ResetBeforeUpload(noSwap));
-				}
 				if (resetRequired) {
 					if (settings.eraseAppSettings)
 						performer.enqueue(new EraseStorage());


### PR DESCRIPTION
This PR fixes DFU when the device isn't ready to receive an image. This can happen in 2 situations:
1. A firmware was sent before and _Test_ or _Confirm_ command was sent, but the device wasn't reset - in that case the secondary slot cannot be erased as 'pending` flag is set.
> [!Note]
> It could be erased with `CONFIG_MCUMGR_GRP_IMG_ALLOW_ERASE_PENDING` flag enabled, but in general it cannot.
2. The device is in test mode, that means a _Test_ command was sent followed by a _Reset_ - in that case one slot is `confirmed` and the other is `active`, neither can be erased unless restarted again, which will restore the original firmware, or _Confirm_, command will be sent, which will mark the `active` slot as `confirmed` as well.

Before, in some cases the library would try to upload a wrong file, and an error was returned from the device.
This PR adds a _Reset_ command whenever a `pending` slot is found, or `confirmed != active` (which means test mode). After the reset a _Validate_ step will be scheduled again. In case the device was in a state that a _Test_ command was sent, but the device wasn't restarted, the reset will have to be sent twice.

Other approach would be to send a _Confirm_ command, or report no slot available error to the user, like the iOS library does.