### PR TITLE
Slot Info command

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
@@ -33,6 +33,7 @@ import io.runtime.mcumgr.response.McuMgrResponse;
 import io.runtime.mcumgr.response.UploadResponse;
 import io.runtime.mcumgr.response.img.McuMgrCoreLoadResponse;
 import io.runtime.mcumgr.response.img.McuMgrImageResponse;
+import io.runtime.mcumgr.response.img.McuMgrImageSlotResponse;
 import io.runtime.mcumgr.response.img.McuMgrImageStateResponse;
 import io.runtime.mcumgr.response.img.McuMgrImageUploadResponse;
 import io.runtime.mcumgr.transfer.Download;
@@ -208,7 +209,7 @@ public class ImageManager extends TransferManager {
     private final static int ID_CORELIST = 3;
     private final static int ID_CORELOAD = 4;
     private final static int ID_ERASE = 5;
-    private final static int ID_ERASE_STATE = 6;
+    private final static int ID_SLOT_INFO = 6;
 
     /**
      * Construct an image manager.
@@ -513,55 +514,23 @@ public class ImageManager extends TransferManager {
     }
 
     /**
-     * Erase the state of secondary slot of main image (asynchronous).
+     * Reads slot information (asynchronous).
      *
      * @param callback the asynchronous callback.
      */
-    public void eraseState(@NotNull McuMgrCallback<McuMgrImageResponse> callback) {
-        eraseState(0, callback);
+    public void slots(@NotNull McuMgrCallback<McuMgrImageSlotResponse> callback) {
+        send(OP_READ, ID_SLOT_INFO, null, SHORT_TIMEOUT, McuMgrImageSlotResponse.class, callback);
     }
 
     /**
-     * Erase the state of secondary slot of the main image (asynchronous).
-     *
-     * @param image    the image number, default is 0. Use 0 for core0, 1 for core1, etc.
-     * @param callback the asynchronous callback.
-     */
-    public void eraseState(int image, @NotNull McuMgrCallback<McuMgrImageResponse> callback) {
-        HashMap<String, Object> payloadMap = null;
-        if (image > 0) {
-            payloadMap = new HashMap<>();
-            payloadMap.put("image", image);
-        }
-        send(OP_WRITE, ID_ERASE_STATE, payloadMap, DEFAULT_TIMEOUT, McuMgrImageResponse.class, callback);
-    }
-
-    /**
-     * Erase the state of secondary slot of the main image (synchronous).
+     * Reads slot information (synchronous).
      *
      * @return The response.
      * @throws McuMgrException Transport error. See cause.
      */
     @NotNull
-    public McuMgrImageResponse eraseState() throws McuMgrException {
-        return eraseState(0);
-    }
-
-    /**
-     * Erase the state of secondary slot of given image (synchronous).
-     *
-     * @param image the image number, default is 0. Use 0 for core0, 1 for core1, etc.
-     * @return The response.
-     * @throws McuMgrException Transport error. See cause.
-     */
-    @NotNull
-    public McuMgrImageResponse eraseState(int image) throws McuMgrException {
-        HashMap<String, Object> payloadMap = null;
-        if (image > 0) {
-            payloadMap = new HashMap<>();
-            payloadMap.put("image", image);
-        }
-        return send(OP_WRITE, ID_ERASE_STATE, payloadMap, SHORT_TIMEOUT, McuMgrImageResponse.class);
+    public McuMgrImageSlotResponse slots() throws McuMgrException {
+        return send(OP_READ, ID_SLOT_INFO, null, SHORT_TIMEOUT, McuMgrImageSlotResponse.class);
     }
 
     /**

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageSlotResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageSlotResponse.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Intellinium SAS, 2014-present
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.runtime.mcumgr.response.img;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.runtime.mcumgr.managers.ImageManager;
+import io.runtime.mcumgr.response.McuMgrResponse;
+
+@SuppressWarnings("unused")
+public class McuMgrImageSlotResponse extends McuMgrResponse implements ImageManager.Response {
+    /** Slot information for each image (core). */
+    @JsonProperty("images")
+    public Image[] images;
+
+    /**
+     * The single image data structure.
+     */
+    public static class Image {
+
+        /**
+         * The single slot data structure.
+         */
+        public static class Slot {
+            /** The slot number: 0 or 1. */
+            @JsonProperty("slot")
+            public int slot;
+            /** The slot size in bytes. */
+            @JsonProperty("size")
+            public int size;
+            /**
+             * Optional field (only present if <code>CONFIG_MCUMGR_GRP_IMG_DIRECT_UPLOAD</code> is
+             * enabled to allow direct image uploads) which specifies the image ID that can be
+             * used by external tools to upload an image to that slot.
+             */
+            @JsonProperty("upload_image_id")
+            public Integer uploadImageId;
+
+            @JsonCreator
+            public Slot() {}
+        }
+
+        /**
+         * The image number used for multi-core devices.
+         * The main core image has index 0, second core image is 1, etc.
+         * E.g. nRF5340 has 2 cores: application core (0) and network core (1).
+         * For single core devices the value is 0 (default).
+         */
+        @JsonProperty("image")
+        public int image;
+        @JsonProperty("slots")
+        public Slot[] slots;
+        /**
+         * Optional field (only present if <code>CONFIG_MCUMGR_GRP_IMG_TOO_LARGE_SYSBUILD</code> or
+         * <code>CONFIG_MCUMGR_GRP_IMG_TOO_LARGE_BOOTLOADER_INFO</code> are enabled) which specifies the
+         * maximum size of an application that can be uploaded to that image number.
+         */
+        @JsonProperty("max_image_size")
+        public Integer maxImageSize;
+
+        @JsonCreator
+        public Image() {}
+    }
+
+    @JsonCreator
+    public McuMgrImageSlotResponse() {}
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageStateResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageStateResponse.java
@@ -63,10 +63,10 @@ public class McuMgrImageStateResponse extends McuMgrResponse implements ImageMan
          */
         @JsonProperty("pending")
         public boolean pending;
-        /** An image is confirmed when it managed to boot on slot 0. */
+        /** An image is confirmed when it managed to boot from and was confirmed. */
         @JsonProperty("confirmed")
         public boolean confirmed;
-        /** An image is active when it is running on slot 0. */
+        /** An image is active when it is running. */
         @JsonProperty("active")
         public boolean active;
         /** An image is permanent after it was confirmed using <i>confirm</i> command. */


### PR DESCRIPTION
This PR removes the "Erase slot" and replaces it with "Slot info".

This "Slot info" command is described here: https://docs.zephyrproject.org/latest/services/device_mgmt/smp_groups/smp_group_1.html#slot-info

I cannot find any reference to "Erase slot" command, neither in Zephyr or MyNewt. It was never working.