### PR TITLE
Android BLE Library updated to 2.10

### DIFF
--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     api project(':mcumgr-core')
 
     // Import the BLE Library
-    api 'no.nordicsemi.android:ble:2.9.0'
+    api 'no.nordicsemi.android:ble:2.10.0'
 
     // Logging
     implementation 'org.slf4j:slf4j-api:2.0.16'


### PR DESCRIPTION
This version adds support for the new [`GATT_CONNECTION_TIMEOUT`](https://developer.android.com/reference/android/bluetooth/BluetoothGatt#GATT_CONNECTION_TIMEOUT) error added in Android 15. 

This error is now thrown instead of error 133 around 30 seconds after a failed connection attenpt, when the target isn't reachable. Handling of this error is exactly like 133 on older Android versions.