### PR TITLE
Ignoring unknown properties in CBOR

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrBootloaderInfoResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrBootloaderInfoResponse.java
@@ -7,11 +7,9 @@
 package io.runtime.mcumgr.response.dflt;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** @noinspection unused*/
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class McuMgrBootloaderInfoResponse extends McuMgrOsResponse {
     // MCUboot modes are explained here: https://docs.mcuboot.com/design.html#image-slots
 

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrMpStatResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrMpStatResponse.java
@@ -8,6 +8,7 @@ package io.runtime.mcumgr.response.dflt;
 
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
@@ -30,6 +31,7 @@ public class McuMgrMpStatResponse extends McuMgrOsResponse {
      * Information describing a memory pool, used to return OS information
      * to the management layer.
      */
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class MpStat {
         /** Size of the memory blocks in the pool. */
         @JsonProperty("blksiz")

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrTaskStatResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrTaskStatResponse.java
@@ -7,6 +7,7 @@
 package io.runtime.mcumgr.response.dflt;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
@@ -48,6 +49,7 @@ public class McuMgrTaskStatResponse extends McuMgrOsResponse {
     /**
      * Structure containing information about a running task.
      */
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class TaskStat {
         /** Task Priority. */
         @JsonProperty("prio")

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageSlotResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageSlotResponse.java
@@ -6,6 +6,7 @@
 package io.runtime.mcumgr.response.img;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.runtime.mcumgr.managers.ImageManager;
@@ -20,11 +21,13 @@ public class McuMgrImageSlotResponse extends McuMgrResponse implements ImageMana
     /**
      * The single image data structure.
      */
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Image {
 
         /**
          * The single slot data structure.
          */
+        @JsonIgnoreProperties(ignoreUnknown = true)
         public static class Slot {
             /** The slot number: 0 or 1. */
             @JsonProperty("slot")

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageStateResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/img/McuMgrImageStateResponse.java
@@ -6,6 +6,7 @@
 package io.runtime.mcumgr.response.img;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.runtime.mcumgr.managers.ImageManager;
@@ -35,6 +36,7 @@ public class McuMgrImageStateResponse extends McuMgrResponse implements ImageMan
     /**
      * The single image slot data structure.
      */
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ImageSlot {
         /**
          * The image number used for multi-core devices.

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/log/McuMgrLogResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/log/McuMgrLogResponse.java
@@ -32,9 +32,9 @@ public class McuMgrLogResponse extends McuMgrResponse {
     @JsonCreator
     public McuMgrLogResponse() {}
 
+    /** @noinspection unused*/
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class LogResult {
-
         public static final int LOG_TYPE_STREAM = 0;
         public static final int LOG_TYPE_MEMORY = 1;
         public static final int LOG_TYPE_STORAGE = 2;
@@ -62,9 +62,9 @@ public class McuMgrLogResponse extends McuMgrResponse {
         public LogResult() {}
     }
 
+    /** @noinspection unused*/
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Entry {
-
         public static final int LOG_LEVEL_DEBUG = 0;
         public static final int LOG_LEVEL_INFO = 1;
         public static final int LOG_LEVEL_WARN = 2;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrManifestListResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/suit/McuMgrManifestListResponse.java
@@ -7,6 +7,7 @@
 package io.runtime.mcumgr.response.suit;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.jetbrains.annotations.NotNull;
@@ -21,6 +22,7 @@ import io.runtime.mcumgr.response.McuMgrResponse;
 /** @noinspection unused*/
 public class McuMgrManifestListResponse extends McuMgrResponse {
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Manifest {
         /**
          * The manifest role.


### PR DESCRIPTION
Some types were crashing the app when a new property was added and sent over CBOR.
With these changes all "extra" fields are ignored.