### PR TITLE
Fast Pair firmware update intent handling

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -39,6 +39,11 @@
 	 it is left here for readability.
 	-->
 	<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+	<!--
+	 This app may show a notification when a firmware is available for
+	 a Fast Pair device. It is registered as companion app.
+	-->
+	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 	<!-- Bluetooth LE is required. -->
 	<uses-feature
@@ -100,6 +105,18 @@
 			android:name=".MainActivity"
 			android:parentActivityName=".ScannerActivity"
 			android:windowSoftInputMode="adjustPan" />
+
+		<!--
+		 Register the Fast Pair firmware update receiver.
+		 See: https://developers.google.com/nearby/fast-pair/companion-apps#firmware_update_intent
+		-->
+		<receiver
+			android:name=".application.FastPairFirmwareUpdateReceiver"
+			android:exported="true">
+			<intent-filter>
+				<action android:name="com.google.android.gms.nearby.fastpair.ACTION_FIRMWARE_UPDATE_BROADCAST" />
+			</intent-filter>
+		</receiver>
 	</application>
 
 </manifest>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -65,7 +65,8 @@
 		android:supportsRtl="false"
 		android:theme="@style/AppTheme"
 		android:enableOnBackInvokedCallback="true"
-		tools:ignore="GoogleAppIndexingWarning">
+		tools:ignore="GoogleAppIndexingWarning"
+        tools:targetApi="33">
 
 		<activity
 			android:name=".ScannerActivity"

--- a/sample/src/main/java/io/runtime/mcumgr/sample/ScannerActivity.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/ScannerActivity.java
@@ -8,6 +8,7 @@ package io.runtime.mcumgr.sample;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
@@ -19,6 +20,7 @@ import androidx.activity.SystemBarStyle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.Insets;
 import androidx.core.splashscreen.SplashScreen;
@@ -140,6 +142,19 @@ public class ScannerActivity extends AppCompatActivity implements Injectable {
         } else {
             scannerFragment = getSupportFragmentManager().findFragmentByTag("scanner");
             savedFragment = getSupportFragmentManager().findFragmentByTag("saved");
+        }
+    }
+
+    @Override
+    protected void onRestart() {
+        super.onRestart();
+
+        // Request POST_NOTIFICATIONS permission if not granted.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ActivityCompat.checkSelfPermission(this, android.Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                ActivityCompat.requestPermissions(this,
+                        new String[] { android.Manifest.permission.POST_NOTIFICATIONS }, 0);
+            }
         }
     }
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/application/Dagger2Application.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/application/Dagger2Application.java
@@ -15,6 +15,8 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
+import androidx.core.app.NotificationChannelCompat;
+import androidx.core.app.NotificationManagerCompat;
 
 import javax.inject.Inject;
 
@@ -48,6 +50,9 @@ public class Dagger2Application extends Application implements HasAndroidInjecto
         // Hack based on: https://github.com/JakeWharton/timber/issues/484#issuecomment-2008724303
         //noinspection DataFlowIssue
         Timber.plant((Timber.Tree) (Object) new Timber.DebugTree());
+
+        // Register the notification channel for Fast Pair firmware updates.
+        registerNotificationChannels();
     }
 
     @Override
@@ -105,5 +110,23 @@ public class Dagger2Application extends Application implements HasAndroidInjecto
             builder.logSessionUri(logger.getSession().getSessionUri());
         }
         builder.build().update(this);
+    }
+
+    /**
+     * Registers Notifications Channels.
+     */
+    private void registerNotificationChannels() {
+        // https://developers.google.com/nearby/fast-pair/companion-apps#firmware_update_intent
+        final NotificationChannelCompat channel = new NotificationChannelCompat
+                .Builder(FastPairFirmwareUpdateReceiver.NOTIFICATION_CHANNEL_ID, NotificationManagerCompat.IMPORTANCE_LOW)
+                .setName("Fast Pair")
+                .setDescription("Notifications regarding Fast Pair firmware updates. These notifications will only show up when you have a Fast Pair accessory with the companion app set to nRF Connect Device Manager.")
+                .setLightsEnabled(true)
+                .setLightColor(0x0000FF)
+                .setShowBadge(false)
+                .build();
+
+        final NotificationManagerCompat notificationManager = NotificationManagerCompat.from(this);
+        notificationManager.createNotificationChannel(channel);
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/application/FastPairFirmwareUpdateReceiver.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/application/FastPairFirmwareUpdateReceiver.java
@@ -1,0 +1,69 @@
+package io.runtime.mcumgr.sample.application;
+
+import android.Manifest;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+
+import androidx.core.app.ActivityCompat;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+import androidx.core.app.PendingIntentCompat;
+
+import io.runtime.mcumgr.sample.R;
+import io.runtime.mcumgr.sample.ScannerActivity;
+import timber.log.Timber;
+
+/**
+ * A broadcast received to FastPair firmware update notifications.
+ * <p>
+ * Read more <a href="https://developers.google.com/nearby/fast-pair/companion-apps#firmware_update_intent">here</a>.
+ */
+public class FastPairFirmwareUpdateReceiver extends BroadcastReceiver {
+    public static final String ACTION = "com.google.android.gms.nearby.fastpair.ACTION_FIRMWARE_UPDATE_BROADCAST";
+    public static final String EXTRA_LOCAL_VERSION = "com.google.android.gms.nearby.fastpair.EXTRA_LOCAL_FIRMWARE_VERSION";
+    public static final String EXTRA_NOTIF_SHOWN = "com.google.android.gms.nearby.fastpair.EXTRA_UPDATE_NOTIFICATION_SHOWN";
+
+    public static final String NOTIFICATION_CHANNEL_ID = "fastpair_dfu";
+    public static final int NOTIFICATION_ID = 1;
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        final String localVersion = intent.getStringExtra(EXTRA_LOCAL_VERSION);
+        final boolean notificationShown = intent.getBooleanExtra(EXTRA_NOTIF_SHOWN, false);
+        Timber.tag("FastPair").w("An outdated FastPair accessory with version %s found (notification shown = %b)", localVersion, notificationShown);
+
+        // Note:
+        // Unfortunately, the current version of FastPair firmware update intents
+        // (https://developers.google.com/nearby/fast-pair/companion-apps#firmware_update_intent)
+        // doesn't give BluetoothDevice or any indication about the device.
+        // At this moment, the device is already disconnected, so it's not possible to
+        // narrow the list of possible targets to only connected ones.
+        // Also, some devices need special action to switch to DFU mode.
+        // The companion app should display an instruction how to make the device updatable.
+
+        if (ActivityCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
+            final PendingIntent openApp = PendingIntentCompat.getActivity(context, 0,
+                    new Intent(context, ScannerActivity.class)
+                            .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
+                    PendingIntent.FLAG_UPDATE_CURRENT,
+                    false
+            );
+
+            final NotificationCompat.Builder builder = new NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
+                    .setSmallIcon(R.drawable.ic_launcher_foreground)
+                    .setContentTitle("Update available")
+                    .setContentText("New version available for your Fast Pair accessory.")
+                    .setPriority(NotificationCompat.PRIORITY_LOW)
+                    .setCategory(NotificationCompat.CATEGORY_STATUS)
+                    .setOnlyAlertOnce(true)
+                    .setAutoCancel(true)
+                    .setContentIntent(openApp);
+
+            NotificationManagerCompat.from(context)
+                    .notify(NOTIFICATION_ID, builder.build());
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for Fast Pair intents sent to companion apps when a new firmware version is registered in the console.
Fast Pair service checks the current firmware version on devices approximately once per day. If the local version is lower than one obtained from the console, the service sends a broadcast to companion app registered on the console.

Read more: https://developers.google.com/nearby/fast-pair/companion-apps#firmware_update_intent