### PR TITLE
Fixed incorrect command ID sent on SettingsManager.commit()

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SettingsManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SettingsManager.java
@@ -230,7 +230,7 @@ public class SettingsManager extends McuManager {
      * @param callback the asynchronous callback.
      */
     public void commit(@NotNull McuMgrCallback<McuMgrResponse> callback) {
-        send(OP_WRITE, ID_DELETE, null, SHORT_TIMEOUT, McuMgrResponse.class, callback);
+        send(OP_WRITE, ID_COMMIT, null, SHORT_TIMEOUT, McuMgrResponse.class, callback);
     }
 
     /**
@@ -241,7 +241,7 @@ public class SettingsManager extends McuManager {
      */
     @NotNull
     public McuMgrResponse commit() throws McuMgrException {
-        return send(OP_WRITE, ID_DELETE, null, SHORT_TIMEOUT, McuMgrResponse.class);
+        return send(OP_WRITE, ID_COMMIT, null, SHORT_TIMEOUT, McuMgrResponse.class);
     }
 
     /**


### PR DESCRIPTION
# Fixed
- Switched out incorrect command IDs for SettingsManager.commit requests. Referenced from https://docs.zephyrproject.org/latest/services/device_mgmt/smp_groups/smp_group_3.html#commit-settings-request