### PR TITLE
Support for DFU with Firmware Loader

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrBootloaderInfoResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/dflt/McuMgrBootloaderInfoResponse.java
@@ -29,6 +29,8 @@ public class McuMgrBootloaderInfoResponse extends McuMgrOsResponse {
     public static final int MODE_DIRECT_XIP_WITH_REVERT	= 5;
     /** MCUboot is in RAM loader mode. */
     public static final int MODE_RAM_LOADER = 6;
+    /** MCUboot is in Firmware Loader mode. */
+    public static final int MODE_FIRMWARE_LOADER = 7;
 
     // Note: other modes may be added in the future.
 

--- a/sample/src/main/res/values/strings_device_status.xml
+++ b/sample/src/main/res/values/strings_device_status.xml
@@ -41,6 +41,7 @@
         <item>Direct XIP Without Revert (4)</item>
         <item>Direct XIP With Revert (5)</item>
         <item>RAM Loader (6)</item>
+        <item>Firmware Loader (7)</item>
     </string-array>
 
     <string-array name="b0_slots">


### PR DESCRIPTION
This PR adds support for the Firmware Loader mode of MCUBoot.

In that mode, the application and firmware loader (FL) are separated into two apps, where the FL is only responsible for updating the firmware. The device needs to be reboot into the FL mode, either using a button, or over the air.
In that mode the application is not running. The FL uses a different MAC address, so that any exisint cache or bond information on the client are not in use.

When in FL mode the slots are used so the slot 0 (primary) is used for the application and slot 1 (secondary) for the firmware loader itselt. The secondary slot is ACTIVE, while the primary slot is CONFIRMED, just like in test mode when TEST_AND_CONFIRM update mode is used. Despite the CONFIRM flag being set, starting an upload to the primary slot will erase the existing application (single bank DFU). In case of a upload failure, the device will remain in the FL mode allowing the operation to be repeated. It is possible to update the firmware loader by uploading a special appliaction, an installer, which will upadte the firmware loader.

As the default _target slot_ for a binary is `SLOT_SECONDARY` (because the new image used to be sent to a secondary slot and then swapped), the FL mode forces the _target slot_ to `SLOT_PRIMARY_. It also makes sure that no Reset command is sent due to the CONFIRMED flag set.