### PR TITLE
Setting default DFU mode to `CONFIRM_ONLY`

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/dialog/FirmwareUpgradeModeDialogFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/dialog/FirmwareUpgradeModeDialogFragment.java
@@ -35,7 +35,7 @@ public class FirmwareUpgradeModeDialogFragment extends DialogFragment {
         if (savedInstanceState != null) {
             selectedItem = savedInstanceState.getInt(SIS_ITEM);
         } else {
-            selectedItem = 0;
+            selectedItem = 2; // CONFIRM_ONLY
         }
 
         return new MaterialAlertDialogBuilder(requireContext())
@@ -57,16 +57,11 @@ public class FirmwareUpgradeModeDialogFragment extends DialogFragment {
     }
 
     private FirmwareUpgradeManager.Mode getMode() {
-        switch (selectedItem) {
-            case 3:
-                return FirmwareUpgradeManager.Mode.NONE;
-            case 2:
-                return FirmwareUpgradeManager.Mode.CONFIRM_ONLY;
-            case 1:
-                return FirmwareUpgradeManager.Mode.TEST_ONLY;
-            case 0:
-            default:
-                return FirmwareUpgradeManager.Mode.TEST_AND_CONFIRM;
-        }
+        return switch (selectedItem) {
+            case 3 -> FirmwareUpgradeManager.Mode.NONE;
+            case 2 -> FirmwareUpgradeManager.Mode.CONFIRM_ONLY;
+            case 1 -> FirmwareUpgradeManager.Mode.TEST_ONLY;
+            default -> FirmwareUpgradeManager.Mode.TEST_AND_CONFIRM;
+        };
     }
 }


### PR DESCRIPTION
Although `TEST_AND_CONFIRM` allow to check if the image gets booted properly before confirming it, in most cases users just select `CONFIRM_ONLY`. This is also the only supported mode for some devices, like nRF53, which don't allow recovery on netcore, or with Direct Xip Without Revert mode.