### PR TITLE
Filter by UUID changed to Filter by Name

### DIFF
--- a/sample/src/main/java/no/nordicsemi/android/mcumgr/sample/adapter/DiscoveredBluetoothDevice.java
+++ b/sample/src/main/java/no/nordicsemi/android/mcumgr/sample/adapter/DiscoveredBluetoothDevice.java
@@ -18,6 +18,14 @@ public class DiscoveredBluetoothDevice implements Parcelable {
     private int rssi;
     private int previousRssi;
     private int highestRssi = -128;
+    /**
+     * A flag indicating that the device advertised Local Name at least once.
+     * <p>
+     * Some devices advertise with multiple different advertising packets, some with and some
+     * without names. To avoid flickering with "Only named" filter enabled this will show
+     * devices that have or HAD local name in their advertising packet.
+     */
+    private boolean hadName;
 
     public DiscoveredBluetoothDevice(final ScanResult scanResult) {
         device = scanResult.getDevice();
@@ -35,6 +43,7 @@ public class DiscoveredBluetoothDevice implements Parcelable {
         this.rssi = -128;
         this.highestRssi = -128;
         this.previousRssi = -128;
+        this.hadName = this.name != null && !this.name.isEmpty();
     }
 
     public BluetoothDevice getDevice() {
@@ -49,12 +58,19 @@ public class DiscoveredBluetoothDevice implements Parcelable {
         return name;
     }
 
-    public int getRssi() {
-        return rssi;
+    /**
+     * A flag indicating that the device advertised Local Name at least once.
+     * <p>
+     * Some devices advertise with multiple different advertising packets, some with and some
+     * without names. To avoid flickering with "Only named" filter enabled this will show
+     * devices that have or HAD local name in their advertising packet.
+     */
+    public boolean hadName() {
+        return hadName;
     }
 
-    public ScanResult getScanResult() {
-        return lastScanResult;
+    public int getRssi() {
+        return rssi;
     }
 
     /**
@@ -101,6 +117,8 @@ public class DiscoveredBluetoothDevice implements Parcelable {
         lastScanResult = scanResult;
         name = scanResult.getScanRecord() != null ?
                 scanResult.getScanRecord().getDeviceName() : null;
+        if (!hadName)
+            hadName = name != null && !name.isEmpty();
         previousRssi = rssi;
         rssi = scanResult.getRssi();
         if (highestRssi < rssi)
@@ -133,6 +151,7 @@ public class DiscoveredBluetoothDevice implements Parcelable {
         rssi = in.readInt();
         previousRssi = in.readInt();
         highestRssi = in.readInt();
+        hadName = in.readInt() == 1;
     }
 
     @Override
@@ -143,6 +162,7 @@ public class DiscoveredBluetoothDevice implements Parcelable {
         parcel.writeInt(rssi);
         parcel.writeInt(previousRssi);
         parcel.writeInt(highestRssi);
+        parcel.writeInt(hadName ? 1 : 0);
     }
 
     @Override

--- a/sample/src/main/java/no/nordicsemi/android/mcumgr/sample/fragment/scanner/ScannerFragment.java
+++ b/sample/src/main/java/no/nordicsemi/android/mcumgr/sample/fragment/scanner/ScannerFragment.java
@@ -140,9 +140,9 @@ public class ScannerFragment extends Fragment implements Injectable, DevicesAdap
 
         requireActivity().addMenuProvider(new MenuProvider() {
             @Override
-            public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
+            public void onCreateMenu(@NonNull final Menu menu, @NonNull final MenuInflater menuInflater) {
                 menuInflater.inflate(R.menu.filter, menu);
-                menu.findItem(R.id.filter_uuid).setChecked(scannerViewModel.isUuidFilterEnabled());
+                menu.findItem(R.id.filter_names).setChecked(scannerViewModel.isNameFilterEnabled());
                 menu.findItem(R.id.filter_nearby).setChecked(scannerViewModel.isNearbyFilterEnabled());
             }
 
@@ -152,11 +152,11 @@ public class ScannerFragment extends Fragment implements Injectable, DevicesAdap
             }
 
             @Override
-            public boolean onMenuItemSelected(@NonNull MenuItem item) {
+            public boolean onMenuItemSelected(@NonNull final MenuItem item) {
                 final int itemId = item.getItemId();
-                if (itemId == R.id.filter_uuid) {
+                if (itemId == R.id.filter_names) {
                     item.setChecked(!item.isChecked());
-                    scannerViewModel.filterByUuid(item.isChecked());
+                    scannerViewModel.filterByName(item.isChecked());
                     return true;
                 }
                 if (itemId == R.id.filter_nearby) {

--- a/sample/src/main/java/no/nordicsemi/android/mcumgr/sample/viewmodel/scanner/ScannerViewModel.java
+++ b/sample/src/main/java/no/nordicsemi/android/mcumgr/sample/viewmodel/scanner/ScannerViewModel.java
@@ -32,7 +32,7 @@ import no.nordicsemi.android.support.v18.scanner.ScanSettings;
 import timber.log.Timber;
 
 public class ScannerViewModel extends AndroidViewModel {
-    private static final String PREFS_FILTER_UUID_REQUIRED = "filter_uuid";
+    private static final String PREFS_FILTER_NAMED_ONLY = "filter_names";
     private static final String PREFS_FILTER_NEARBY_ONLY = "filter_nearby";
 
     /** MutableLiveData containing the list of devices. */
@@ -56,14 +56,14 @@ public class ScannerViewModel extends AndroidViewModel {
         super(application);
         this.preferences = preferences;
 
-        final boolean filterUuidRequired = isUuidFilterEnabled();
+        final boolean filterNamedOnly = isNameFilterEnabled();
         final boolean filerNearbyOnly = isNearbyFilterEnabled();
 
         scannerStateLiveData = new ScannerStateLiveData(
                 Utils.isBleEnabled(),
                 Utils.isLocationEnabled(application)
         );
-        devicesLiveData = new DevicesLiveData(filterUuidRequired, filerNearbyOnly);
+        devicesLiveData = new DevicesLiveData(filterNamedOnly, filerNearbyOnly);
         registerBroadcastReceivers(application);
     }
 
@@ -73,8 +73,8 @@ public class ScannerViewModel extends AndroidViewModel {
         unregisterBroadcastReceivers(getApplication());
     }
 
-    public boolean isUuidFilterEnabled() {
-        return preferences.getBoolean(PREFS_FILTER_UUID_REQUIRED, true);
+    public boolean isNameFilterEnabled() {
+        return preferences.getBoolean(PREFS_FILTER_NAMED_ONLY, true);
     }
 
     public boolean isNearbyFilterEnabled() {
@@ -103,12 +103,12 @@ public class ScannerViewModel extends AndroidViewModel {
      * even if they move away from the phone, or change the advertising packet. This is to
      * avoid removing devices from the list.
      *
-     * @param uuidRequired if true, the list will display only devices with SMP UUID
+     * @param nameRequired if true, the list will display only devices Local Name
      *                     in the advertising packet.
      */
-    public void filterByUuid(final boolean uuidRequired) {
-        preferences.edit().putBoolean(PREFS_FILTER_UUID_REQUIRED, uuidRequired).apply();
-        if (devicesLiveData.filterByUuid(uuidRequired))
+    public void filterByName(final boolean nameRequired) {
+        preferences.edit().putBoolean(PREFS_FILTER_NAMED_ONLY, nameRequired).apply();
+        if (devicesLiveData.filterByName(nameRequired))
             scannerStateLiveData.recordFound();
         else
             scannerStateLiveData.clearRecords();

--- a/sample/src/main/res/menu/filter.xml
+++ b/sample/src/main/res/menu/filter.xml
@@ -16,10 +16,10 @@
 
         <menu>
             <item
-                android:id="@+id/filter_uuid"
+                android:id="@+id/filter_names"
                 android:checkable="true"
                 android:checked="true"
-                android:title="@string/menu_filter_uuid"/>
+                android:title="@string/menu_filter_names"/>
 
             <item
                 android:id="@+id/filter_nearby"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -15,8 +15,8 @@
 	<string name="menu_collapse">Collapse</string>
 	<string name="menu_settings">Settings</string>
 	<string name="menu_filter">Filter</string>
-	<string name="menu_filter_uuid">Only devices advertising SMP UUID</string>
-	<string name="menu_filter_nearby">Only nearby devices</string>
+	<string name="menu_filter_names">Show only with names</string>
+	<string name="menu_filter_nearby">Show only nearby</string>
 
 	<string name="action_grant_permission">Grant permission</string>
 	<string name="action_settings">Settings</string>


### PR DESCRIPTION
The app was created when the only sample with SMP Service was the [SMP Server](https://docs.zephyrproject.org/latest/samples/subsys/mgmt/mcumgr/smp_svr/README.html), which used to advertise the SMP Service UUID. Then it made sense to filter for this UUID by default.

Fast forward to now, the SMP Service is used for updating tons of devices, most of which advertise their services, not the service used for device management. Almost 100% os users had to disable the filter just upon installing the app to see their devices.
The "Show only advertising SMP Service UUID" was replaced with a filter to only show devices advertising Local Name, which makes much more sense.