### PR TITLE
Connectivity improvements

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ room = "2.7.2"
 slf4j = "2.0.17"
 slf4j-timber = "1.2"
 
-nordic-ble = "2.10.2"
+nordic-ble = "2.11.0"
 nordic-blek = "2.0.0-alpha08"
 nordic-log = "2.5.0"
 nordic-scanner = "1.6.0"

--- a/mcumgr-ble/src/main/java/no/nordicsemi/android/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/no/nordicsemi/android/mcumgr/ble/McuMgrBleTransport.java
@@ -46,6 +46,7 @@ import no.nordicsemi.android.mcumgr.ble.callback.TransactionTimeoutException;
 import no.nordicsemi.android.mcumgr.ble.exception.McuMgrBluetoothDisabledException;
 import no.nordicsemi.android.mcumgr.ble.exception.McuMgrDisconnectedException;
 import no.nordicsemi.android.mcumgr.ble.exception.McuMgrNotSupportedException;
+import no.nordicsemi.android.mcumgr.ble.exception.McuMgrUnsupportedConfigurationException;
 import no.nordicsemi.android.mcumgr.ble.util.ResultCondition;
 import no.nordicsemi.android.mcumgr.exception.InsufficientMtuException;
 import no.nordicsemi.android.mcumgr.exception.McuMgrErrorException;
@@ -441,9 +442,14 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                         // This may also happen if service discovery ends with an error, which
                         // will trigger disconnection.
                         case FailCallback.REASON_REQUEST_FAILED:
-                            case FailCallback.REASON_DEVICE_DISCONNECTED:
-                        case     FailCallback.REASON_CANCELLED: {
+                        case FailCallback.REASON_DEVICE_DISCONNECTED:
+                        case FailCallback.REASON_CANCELLED: {
                             callback.onError(new McuMgrDisconnectedException());
+                            break;
+                        }
+                        case FailCallback.REASON_UNSUPPORTED_CONFIGURATION: {
+                            log(Log.ERROR, "Android device failed to reply to PHY request, disable PHY LE 2M on the peripheral.");
+                            callback.onError(new McuMgrUnsupportedConfigurationException());
                             break;
                         }
                         case FailCallback.REASON_DEVICE_NOT_SUPPORTED: {
@@ -460,6 +466,8 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                             break;
                         }
                         default: {
+                            if (status == BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION)
+                                log(Log.ERROR, "Unable to resume encryption, pairing removed from peer");
                             callback.onError(new McuMgrException(GattError.parseConnectionError(status)));
                             break;
                         }                    }
@@ -486,6 +494,14 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                     callback.onConnected();
                 })
                 .fail((device, status) -> {
+                    switch (status) {
+                        case FailCallback.REASON_UNSUPPORTED_CONFIGURATION:
+                            log(Log.ERROR, "Android device failed to reply to PHY request, disable PHY LE 2M on the peripheral.");
+                            break;
+                        case BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION:
+                            log(Log.ERROR, "Unable to resume encryption, pairing removed from peer");
+                            break;
+                    }
                     if (callback == null) {
                         return;
                     }
@@ -500,6 +516,10 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                         case FailCallback.REASON_DEVICE_DISCONNECTED:
                         case FailCallback.REASON_CANCELLED: {
                             callback.onError(new McuMgrDisconnectedException());
+                            break;
+                        }
+                        case FailCallback.REASON_UNSUPPORTED_CONFIGURATION: {
+                            callback.onError(new McuMgrUnsupportedConfigurationException());
                             break;
                         }
                         case FailCallback.REASON_DEVICE_NOT_SUPPORTED: {

--- a/mcumgr-ble/src/main/java/no/nordicsemi/android/mcumgr/ble/exception/McuMgrUnsupportedConfigurationException.java
+++ b/mcumgr-ble/src/main/java/no/nordicsemi/android/mcumgr/ble/exception/McuMgrUnsupportedConfigurationException.java
@@ -1,0 +1,11 @@
+package no.nordicsemi.android.mcumgr.ble.exception;
+
+import no.nordicsemi.android.mcumgr.exception.McuMgrException;
+
+/**
+ * This exception is thrown when the Android device fails to connect to the peripheral
+ * due to its internal issues. Most probably it cannot respond properly to PHY LE 2M
+ * update procedure, causing the remote device to terminate the connection.
+ */
+public class McuMgrUnsupportedConfigurationException extends McuMgrException {
+}

--- a/sample/src/main/java/no/nordicsemi/android/mcumgr/sample/observable/ObservableMcuMgrBleTransport.java
+++ b/sample/src/main/java/no/nordicsemi/android/mcumgr/sample/observable/ObservableMcuMgrBleTransport.java
@@ -199,6 +199,14 @@ public class ObservableMcuMgrBleTransport extends McuMgrBleTransport {
             AtomicReference<String> swType = new AtomicReference<>();
             AtomicReference<String> currentVersion = new AtomicReference<>();
             beginAtomicRequestQueue()
+                    .add(readCharacteristic(disSerialNumberCharacteristic)
+                            .with((device, data) -> serialNumber.set(data.getStringValue(0))))
+                    .add(readCharacteristic(disHwRevCharacteristic)
+                            .with((device, data) -> hwVersion.set(data.getStringValue(0))))
+                    .add(readCharacteristic(disFwRevCharacteristic)
+                            .with((device, data) -> currentVersion.set(data.getStringValue(0))))
+                    .add(readCharacteristic(disSwRevCharacteristic)
+                            .with((device, data) -> swType.set(data.getStringValue(0))))
                     .add(readCharacteristic(mdsAuthCharacteristic)
                             .with((device, data) -> {
                                 final String value = data.getStringValue(0);
@@ -210,14 +218,6 @@ public class ObservableMcuMgrBleTransport extends McuMgrBleTransport {
                                     }
                                 }
                             }))
-                    .add(readCharacteristic(disSerialNumberCharacteristic)
-                            .with(((device, data) -> serialNumber.set(data.getStringValue(0)))))
-                    .add(readCharacteristic(disHwRevCharacteristic)
-                            .with(((device, data) -> hwVersion.set(data.getStringValue(0)))))
-                    .add(readCharacteristic(disFwRevCharacteristic)
-                            .with(((device, data) -> currentVersion.set(data.getStringValue(0)))))
-                    .add(readCharacteristic(disSwRevCharacteristic)
-                            .with(((device, data) -> swType.set(data.getStringValue(0)))))
                     .done(device -> deviceInfo = new DeviceInfo(
                             serialNumber.get(),
                             hwVersion.get(),

--- a/sample/src/main/java/no/nordicsemi/android/mcumgr/sample/utils/StringUtils.java
+++ b/sample/src/main/java/no/nordicsemi/android/mcumgr/sample/utils/StringUtils.java
@@ -15,6 +15,7 @@ import no.nordicsemi.android.mcumgr.McuMgrErrorCode;
 import no.nordicsemi.android.mcumgr.ble.exception.McuMgrBluetoothDisabledException;
 import no.nordicsemi.android.mcumgr.ble.exception.McuMgrDisconnectedException;
 import no.nordicsemi.android.mcumgr.ble.exception.McuMgrNotSupportedException;
+import no.nordicsemi.android.mcumgr.ble.exception.McuMgrUnsupportedConfigurationException;
 import no.nordicsemi.android.mcumgr.exception.McuMgrErrorException;
 import no.nordicsemi.android.mcumgr.exception.McuMgrException;
 import no.nordicsemi.android.mcumgr.exception.McuMgrTimeoutException;
@@ -68,6 +69,8 @@ public class StringUtils {
             return context.getString(R.string.status_disconnected);
         } else if (error instanceof McuMgrNotSupportedException) {
             return context.getString(R.string.status_not_supported);
+        } else if (error instanceof McuMgrUnsupportedConfigurationException) {
+            return context.getString(R.string.status_unsupported_configuration);
         } else if (error instanceof McuMgrTimeoutException) {
             return context.getString(R.string.status_connection_timeout);
         }

--- a/sample/src/main/res/values/strings_device_status.xml
+++ b/sample/src/main/res/values/strings_device_status.xml
@@ -21,6 +21,7 @@
     <string name="status_disconnecting">Disconnecting…</string>
     <string name="status_disconnected">Disconnected</string>
     <string name="status_not_supported">Device not supported</string>
+    <string name="status_unsupported_configuration">Internal Bluetooth error: PHY LE 2M request failed. Disable PHY LE 2M on the peripheral side.</string>
     <string name="status_connection_failed">Connection failed</string>
     <string name="status_connection_timeout">Connection timed out</string>
 


### PR DESCRIPTION
This PR adds 2 connectivity improvements:

1. Forcing TX MTU = 23 on Samsung A8 Tab. This tablet (and perhaps other Android devices) has an internal issue with Bluetooth controller. When `requestMtu(x)` is called it sends `TX MTU = 23` and `RX MTU = x`, while both `TX MTU` and `RX MTU` should be equal and set to `x`. The consequence is that later, when it tries to send a longer packet, the peripheral disconnects (which is expected, according to spec). As a workaround, for that one `Build.HARDWARE`, the library will always send packets of at-most 20 bytes (ATT MTU = 23), while being able to receive longer ones. **Important:** This means, that *SMP Reassembly* is requried on the peripheral side, due to the minimum required packet size for DFU being 70 bytes.
2. Some phones fail to respond to a PHY request when the request is sent just after reconnection to a bonded device. In that case the new version of [Android BLE library](https://github.com/NordicSemiconductor/Android-BLE-Library) (2.11+) will return an error "Unsupported configuration". This PR migrates the `:mcumgr-ble` module to that version and handles that disconnection reason.