### PR TITLE
Catching disconnection due to insufficient authentication

### DIFF
--- a/mcumgr-ble/src/main/java/no/nordicsemi/android/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/no/nordicsemi/android/mcumgr/ble/McuMgrBleTransport.java
@@ -45,6 +45,7 @@ import no.nordicsemi.android.mcumgr.ble.callback.SmpTransaction;
 import no.nordicsemi.android.mcumgr.ble.callback.TransactionTimeoutException;
 import no.nordicsemi.android.mcumgr.ble.exception.McuMgrBluetoothDisabledException;
 import no.nordicsemi.android.mcumgr.ble.exception.McuMgrDisconnectedException;
+import no.nordicsemi.android.mcumgr.ble.exception.McuMgrInsufficientAuthenticationException;
 import no.nordicsemi.android.mcumgr.ble.exception.McuMgrNotSupportedException;
 import no.nordicsemi.android.mcumgr.ble.exception.McuMgrUnsupportedConfigurationException;
 import no.nordicsemi.android.mcumgr.ble.util.ResultCondition;
@@ -466,9 +467,12 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                             break;
                         }
                         default: {
-                            if (status == BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION)
+                            if (status == BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION) {
                                 log(Log.ERROR, "Unable to resume encryption, pairing removed from peer");
-                            callback.onError(new McuMgrException(GattError.parseConnectionError(status)));
+                                callback.onError(new McuMgrInsufficientAuthenticationException());
+                            } else {
+                                callback.onError(new McuMgrException(GattError.parseConnectionError(status)));
+                            }
                             break;
                         }                    }
                 })
@@ -532,6 +536,10 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
                         }
                         case FailCallback.REASON_BLUETOOTH_DISABLED: {
                             callback.onError(new McuMgrBluetoothDisabledException());
+                            break;
+                        }
+                        case BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION: {
+                            callback.onError(new McuMgrInsufficientAuthenticationException());
                             break;
                         }
                         default: {

--- a/mcumgr-ble/src/main/java/no/nordicsemi/android/mcumgr/ble/exception/McuMgrInsufficientAuthenticationException.java
+++ b/mcumgr-ble/src/main/java/no/nordicsemi/android/mcumgr/ble/exception/McuMgrInsufficientAuthenticationException.java
@@ -1,0 +1,10 @@
+package no.nordicsemi.android.mcumgr.ble.exception;
+
+import no.nordicsemi.android.mcumgr.exception.McuMgrException;
+
+/**
+ * This exception is thrown when the operation could not be performed because the
+ * authentication level of the connection is insufficient.
+ */
+public class McuMgrInsufficientAuthenticationException extends McuMgrException {
+}


### PR DESCRIPTION
When a pairing information gets removed from peer, but Android still has it, connection to that device may fail with status 5, which seems to be Insufficient Authentication. A new error type is returned in that case.