### PR TITLE
Disallowing updating Room to 2.8.0+ due to minSdk set to 23

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,8 @@ material = "1.13.0"
 memfault-cloud = "2.0.5"
 preference = "1.2.1"
 recyclerview = "1.4.0"
-room = "2.8.0"
+#noinspection GradleDependency
+room = "2.7.2" # don't update, 2.8.0 increases minSdk to 23
 slf4j = "2.0.17"
 slf4j-timber = "1.2"
 

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,8 @@
     },
     {
       "matchPackageNames": [
-        "/com.fasterxml.jackson.*/"
+        "/com.fasterxml.jackson.*/",
+        "/androidx.room/"
       ],
       "enabled": false
     }


### PR DESCRIPTION
Current minSdk is 21 (Android 5).