### PR TITLE
Bugfix: Checking if the connection is initialized

### DIFF
--- a/mcumgr-ble/src/main/java/no/nordicsemi/android/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/no/nordicsemi/android/mcumgr/ble/McuMgrBleTransport.java
@@ -482,7 +482,7 @@ public class McuMgrBleTransport extends BleManager implements McuMgrTransport {
 
     @Override
     public void connect(@Nullable final ConnectionCallback callback) {
-        if (isConnected()) {
+        if (isReady()) {
             if (callback != null) {
                 callback.onConnected();
             }


### PR DESCRIPTION
The `ConnectionObserver` is called when the device is "ready" (initialized), not just connected.
This callback was called too early.