### PR TITLE
Enable Factory Reset by default

### DIFF
--- a/sample/src/main/res/layout/fragment_card_image_erase_settings.xml
+++ b/sample/src/main/res/layout/fragment_card_image_erase_settings.xml
@@ -70,7 +70,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="16dp"
-            android:enabled="false"
             android:text="@string/image_settings_action_erase"
             android:textColor="@color/button_destructive"
             app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
For some reason, this button was getting enabled only when some other action was performed, like Read image state.