### PR TITLE
Enhance error dialog on OTA request HTTP error

### DIFF
--- a/sample/src/main/java/no/nordicsemi/android/mcumgr/sample/dialog/WarningDialogFragment.java
+++ b/sample/src/main/java/no/nordicsemi/android/mcumgr/sample/dialog/WarningDialogFragment.java
@@ -22,6 +22,8 @@ import no.nordicsemi.android.mcumgr.sample.R;
 public class WarningDialogFragment extends AppCompatDialogFragment {
     private static final String ARG_TITLE_RES_ID = "titleResId";
     private static final String ARG_MESSAGE_RES_ID = "messageResId";
+    private static final String ARG_TITLE_STRING = "titleString";
+    private static final String ARG_MESSAGE_STRING = "messageString";
 
 
     @NonNull
@@ -38,6 +40,32 @@ public class WarningDialogFragment extends AppCompatDialogFragment {
     }
 
     @NonNull
+    public static DialogFragment getInstance(@StringRes final int titleResId,
+                                             @NonNull final String message) {
+        final DialogFragment fragment = new WarningDialogFragment();
+
+        final Bundle args = new Bundle();
+        args.putInt(ARG_TITLE_RES_ID, titleResId);
+        args.putString(ARG_MESSAGE_STRING, message);
+        fragment.setArguments(args);
+
+        return fragment;
+    }
+
+    @NonNull
+    public static DialogFragment getInstance(@NonNull final String title,
+                                             @NonNull final String message) {
+        final DialogFragment fragment = new WarningDialogFragment();
+
+        final Bundle args = new Bundle();
+        args.putString(ARG_TITLE_STRING, title);
+        args.putString(ARG_MESSAGE_STRING, message);
+        fragment.setArguments(args);
+
+        return fragment;
+    }
+
+    @NonNull
     @Override
     public Dialog onCreateDialog(@Nullable final Bundle savedInstanceState) {
         final Bundle args = getArguments();
@@ -45,14 +73,28 @@ public class WarningDialogFragment extends AppCompatDialogFragment {
             throw new UnsupportedOperationException("WarningDialogFragment created without arguments");
         }
 
-        final int titleResId = getArguments().getInt(ARG_TITLE_RES_ID);
-        final int messageResId = getArguments().getInt(ARG_MESSAGE_RES_ID);
-
         final MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(requireContext())
                 .setIcon(R.drawable.ic_warning)
-                .setTitle(titleResId)
-                .setMessage(messageResId)
                 .setPositiveButton(android.R.string.ok, null);
+
+        // Handle title - prefer string over resource ID
+        final String titleString = args.getString(ARG_TITLE_STRING);
+        if (titleString != null) {
+            builder.setTitle(titleString);
+        } else {
+            final int titleResId = args.getInt(ARG_TITLE_RES_ID);
+            builder.setTitle(titleResId);
+        }
+
+        // Handle message - prefer string over resource ID
+        final String messageString = args.getString(ARG_MESSAGE_STRING);
+        if (messageString != null) {
+            builder.setMessage(messageString);
+        } else {
+            final int messageResId = args.getInt(ARG_MESSAGE_RES_ID);
+            builder.setMessage(messageResId);
+        }
+
         return builder.create();
     }
 }

--- a/sample/src/main/res/values/strings_image_upgrade.xml
+++ b/sample/src/main/res/values/strings_image_upgrade.xml
@@ -85,4 +85,6 @@
     <string name="ota_network_unavailable_title">Network Unavailable</string>
     <string name="ota_network_unavailable_message">A network connection is required to check for
         updates. Please check your internet connection and try again.</string>
+
+    <string name="ota_http_error_title">Server Error</string>
 </resources>


### PR DESCRIPTION
This patch attempts to improve the error dialog when an OTA request HTTP error is encountered- prior to this change, the dialog incorrectly reports a network connectivity issue, when the issue is in fact an HTTP error.

It's possible to test this by flashing an nRF54L15-DK with a test image that contains an invalid `hardware_version` identifier- follow the workflow here but _don't_ update the config value for `CONFIG_BT_DIS_HW_REV_STR`, leave it as
`CONFIG_BT_DIS_HW_REV_STR="nrf5340dk"`, and build for the nrf54l15dk:

```bash
❯ west build --sysbuild --pristine=always --board nrf54l15dk/nrf54l15/cpuapp nrf/samples/bluetooth/peripheral_mds
```

Issuing a "Check for Update" request will result in an invalid HTTP request, + error response, curl example below:

```bash
❯ curl -X GET 'https://device.memfault.com/api/v0/releases/latest/url?device_serial=mfltqs1&hardware_version=nrf5340dk&software_type=main&current_version=0.0.1' \
--header "Memfault-Project-Key: ${MEMFAULT_PROJECT_KEY}"
{"error":{"message":"Hardware version 'nrf5340dk' not found in project","http_code":400,"type":"InvalidUsageError","code":1000}}
```

I couldn't figure out how to get the HTTP response body into the dialog, but at least it now shows that the error is not a network issue, but an HTTP error:
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/9259de0f-9475-427d-87fe-30b24604f12e" />