### PR TITLE
Error messages for downgrade prevention improved

### DIFF
--- a/mcumgr-core/src/main/java/no/nordicsemi/android/mcumgr/dfu/mcuboot/task/Confirm.java
+++ b/mcumgr-core/src/main/java/no/nordicsemi/android/mcumgr/dfu/mcuboot/task/Confirm.java
@@ -62,11 +62,14 @@ class Confirm extends FirmwareUpgradeTask {
 							if (slot.permanent || slot.confirmed) {
 								performer.onTaskCompleted(Confirm.this);
 							} else {
-								performer.onTaskFailed(Confirm.this, new McuMgrException("Image not confirmed."));
+								LOG.warn("Permanent flag of slot {} of image {} not set. Possible reason: downgrade prevention enabled", slot.slot, slot.image);
+								performer.onTaskFailed(Confirm.this, new McuMgrException("Downgrade forbidden"));
 							}
 							return;
 						}
 					}
+					performer.onTaskFailed(Confirm.this, new McuMgrException("Confirmed image not found"));
+					return;
 				}
 				// SUIT implementation of Image manager does not return images from Confirm command.
 				// Instead, the device will reset and the new image will be booted.

--- a/mcumgr-core/src/main/java/no/nordicsemi/android/mcumgr/dfu/mcuboot/task/Test.java
+++ b/mcumgr-core/src/main/java/no/nordicsemi/android/mcumgr/dfu/mcuboot/task/Test.java
@@ -53,7 +53,8 @@ class Test extends FirmwareUpgradeTask {
 						if (slot.pending) {
 							performer.onTaskCompleted(Test.this);
 						} else {
-							performer.onTaskFailed(Test.this, new McuMgrException("Tested image is not in a pending state."));
+							LOG.warn("Pending flag of slot {} of image {} not set. Possible reason: downgrade prevention enabled", slot.slot, slot.image);
+							performer.onTaskFailed(Test.this, new McuMgrException("Downgrade forbidden"));
 						}
 						return;
 					}


### PR DESCRIPTION
This PR changes the way how specific error is reported to the user.
When a *Test* of *Confirm* command is sent to a slot its flags should change:
* Test -> *Pending* flag set
* Confirm -> * Pending* and *Permanent* flag set, or *Confirmed* flag set if the image was already *Active*

If despite sending *Test* or *Confirm* commands the flags don't change it means that the image cannot be applied and the most common reason (only one?) is an attempt to downgrade the firmware with downgrade prevention enabled.

## Before

The error was reported as "Image not confirmed."

## After

More meaningful text: "Downgrade forbidden".