### PR TITLE
Dependencies updated

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -71,7 +71,7 @@ dependencyResolutionManagement {
         create("libs") {
             // Note: Freeze at 2.11, 2.12+ increased minSdk to 23:
             // https://github.com/NordicSemiconductor/Android-Gradle-Plugins/releases/tag/2.12-2
-            from("no.nordicsemi.android.gradle:version-catalog:2.11")
+            from("no.nordicsemi.android.gradle:version-catalog:2.11-1")
         }
         // Fixed versions for Nordic libraries.
         create("nordic") {


### PR DESCRIPTION
This PR updates the Nordicv Gradle Version Catalog to [2.11-1](https://github.com/NordicSemiconductor/Android-Gradle-Plugins/releases).
Versions 2.11-x have `minSdk` set to 21. Above that the min Android version is increased to 23 (Marshmallow).