### PR TITLE
Migration to AGP 9.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin.android) apply false
 
     // This plugin is used to generate Dokka documentation.
     alias(libs.plugins.kotlin.dokka) apply false

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -319,7 +319,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel {
             // HTTP(S) transport is currently not supported.
             suitManager.setResourceCallback(new SUITUpgradeManager.OnResourceRequiredCallback() {
                 @Override
-                public void onResourceRequired(@NotNull URI uri, SUITUpgradeManager.@NotNull ResourceCallback callback) {
+                public void onResourceRequired(@NotNull URI uri, @NonNull SUITUpgradeManager.ResourceCallback callback) {
                     callback.error(new UnsupportedOperationException("Resource required callback not supported."));
                 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -69,7 +69,9 @@ dependencyResolutionManagement {
         // Use Nordic Gradle Version Catalog with common external libraries versions.
         // Link: https://github.com/NordicSemiconductor/Android-Gradle-Plugins
         create("libs") {
-            from("no.nordicsemi.android.gradle:version-catalog:2.10-4")
+            // Note: Freeze at 2.11, 2.12+ increased minSdk to 23:
+            // https://github.com/NordicSemiconductor/Android-Gradle-Plugins/releases/tag/2.12-2
+            from("no.nordicsemi.android.gradle:version-catalog:2.11.3-1")
         }
         // Fixed versions for Nordic libraries.
         create("nordic") {


### PR DESCRIPTION
This PR updates dependencies, including:
* Android Gradle Plugin 9.0
* Kotlin 2.3.10