### PR TITLE
Expose configurable MCUboot image magic numbers for OTA image parsing

### DIFF
--- a/mcumgr-core/src/main/java/no/nordicsemi/android/mcumgr/image/McuMgrImageConfig.java
+++ b/mcumgr-core/src/main/java/no/nordicsemi/android/mcumgr/image/McuMgrImageConfig.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package no.nordicsemi.android.mcumgr.image;
+
+import no.nordicsemi.android.mcumgr.image.tlv.McuMgrImageTlv;
+
+/**
+ * Global configuration for the magic numbers used when parsing McuBoot firmware image headers
+ * and TLV trailers.
+ * <p>
+ * The default values match the standard McuBoot specification. If a device uses custom magic
+ * numbers, call the appropriate setters <b>before</b> starting the SMP OTA upgrade.
+ * <p>
+ * Example usage:
+ * <pre>
+ *     // Set custom magic numbers before starting OTA
+ *     McuMgrImageConfig.setHeaderMagic(0xCustomMagic);
+ *     McuMgrImageConfig.setTlvInfoMagic(0xCustomTlvMagic);
+ *     McuMgrImageConfig.setTlvProtectedInfoMagic(0xCustomProtectedTlvMagic);
+ *
+ *     // Start the OTA upgrade ...
+ *
+ *     // Optionally restore defaults afterwards
+ *     McuMgrImageConfig.resetToDefaults();
+ * </pre>
+ */
+@SuppressWarnings("unused")
+public final class McuMgrImageConfig {
+
+    // Default magic number values (standard McuBoot specification).
+    private static final int DEFAULT_HEADER_MAGIC       = 0x96f3b83d;
+    private static final int DEFAULT_HEADER_MAGIC_V1    = 0x96f3b83c;
+    private static final int DEFAULT_TLV_INFO_MAGIC     = McuMgrImageTlv.IMG_TLV_INFO_MAGIC;
+    private static final int DEFAULT_TLV_PROTECTED_INFO_MAGIC = McuMgrImageTlv.IMG_TLV_PROTECTED_INFO_MAGIC;
+
+    // Volatile to ensure visibility across threads.
+    private static volatile int sHeaderMagic            = DEFAULT_HEADER_MAGIC;
+    private static volatile int sHeaderMagicV1          = DEFAULT_HEADER_MAGIC_V1;
+    private static volatile int sTlvInfoMagic           = DEFAULT_TLV_INFO_MAGIC;
+    private static volatile int sTlvProtectedInfoMagic  = DEFAULT_TLV_PROTECTED_INFO_MAGIC;
+
+    private McuMgrImageConfig() {
+        // Not instantiable.
+    }
+
+    // -------------------------------------------------------------------------
+    // Getters
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the expected magic number for the current McuBoot image header.
+     * Default: {@code 0x96f3b83d}
+     */
+    public static int getHeaderMagic() {
+        return sHeaderMagic;
+    }
+
+    /**
+     * Returns the expected magic number for the legacy (V1) McuBoot image header.
+     * Default: {@code 0x96f3b83c}
+     */
+    public static int getHeaderMagicV1() {
+        return sHeaderMagicV1;
+    }
+
+    /**
+     * Returns the expected magic number for the unprotected TLV info block.
+     * Default: {@code 0x6907}
+     */
+    public static int getTlvInfoMagic() {
+        return sTlvInfoMagic;
+    }
+
+    /**
+     * Returns the expected magic number for the protected TLV info block.
+     * Default: {@code 0x6908}
+     */
+    public static int getTlvProtectedInfoMagic() {
+        return sTlvProtectedInfoMagic;
+    }
+
+    // -------------------------------------------------------------------------
+    // Setters
+    // -------------------------------------------------------------------------
+
+    /**
+     * Sets a custom magic number for the current McuBoot image header.
+     * <p>
+     * Call this before starting the SMP OTA upgrade if the target device uses a non-standard
+     * header magic value.
+     *
+     * @param magic The expected 32-bit header magic number.
+     */
+    public static void setHeaderMagic(int magic) {
+        sHeaderMagic = magic;
+    }
+
+    /**
+     * Sets a custom magic number for the legacy (V1) McuBoot image header.
+     * <p>
+     * Call this before starting the SMP OTA upgrade if the target device uses a non-standard
+     * legacy header magic value.
+     *
+     * @param magic The expected 32-bit legacy header magic number.
+     */
+    public static void setHeaderMagicV1(int magic) {
+        sHeaderMagicV1 = magic;
+    }
+
+    /**
+     * Sets a custom magic number for the unprotected TLV info block.
+     * <p>
+     * Call this before starting the SMP OTA upgrade if the target device uses a non-standard
+     * TLV info magic value.
+     *
+     * @param magic The expected 16-bit TLV info magic number.
+     */
+    public static void setTlvInfoMagic(int magic) {
+        sTlvInfoMagic = magic;
+    }
+
+    /**
+     * Sets a custom magic number for the protected TLV info block.
+     * <p>
+     * Call this before starting the SMP OTA upgrade if the target device uses a non-standard
+     * protected TLV info magic value.
+     *
+     * @param magic The expected 16-bit protected TLV info magic number.
+     */
+    public static void setTlvProtectedInfoMagic(int magic) {
+        sTlvProtectedInfoMagic = magic;
+    }
+
+    // -------------------------------------------------------------------------
+    // Reset
+    // -------------------------------------------------------------------------
+
+    /**
+     * Resets all magic numbers to the standard McuBoot default values.
+     */
+    public static void resetToDefaults() {
+        sHeaderMagic           = DEFAULT_HEADER_MAGIC;
+        sHeaderMagicV1         = DEFAULT_HEADER_MAGIC_V1;
+        sTlvInfoMagic          = DEFAULT_TLV_INFO_MAGIC;
+        sTlvProtectedInfoMagic = DEFAULT_TLV_PROTECTED_INFO_MAGIC;
+    }
+}

--- a/mcumgr-core/src/main/java/no/nordicsemi/android/mcumgr/image/McuMgrImageHeader.java
+++ b/mcumgr-core/src/main/java/no/nordicsemi/android/mcumgr/image/McuMgrImageHeader.java
@@ -23,9 +23,6 @@ import no.nordicsemi.android.mcumgr.util.Endian;
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class McuMgrImageHeader {
 
-    private static final int IMG_HEADER_MAGIC      = 0x96f3b83d;
-    private static final int IMG_HEADER_MAGIC_V1   = 0x96f3b83c;
-
     private static final int HEADER_LENGTH = 24;
     private final int mMagic;
     private final int mLoadAddr;
@@ -62,8 +59,10 @@ public class McuMgrImageHeader {
 
         int magic = ByteUtil.byteArrayToUnsignedInt(b, offset, Endian.LITTLE, 4);
 
-        if (magic != IMG_HEADER_MAGIC && magic != IMG_HEADER_MAGIC_V1) {
-            throw new McuMgrException(String.format("Wrong magic number (found 0x%08X, expected 0x%08X or 0x%08X)", magic, IMG_HEADER_MAGIC, IMG_HEADER_MAGIC_V1));
+        int expectedMagic   = McuMgrImageConfig.getHeaderMagic();
+        int expectedMagicV1 = McuMgrImageConfig.getHeaderMagicV1();
+        if (magic != expectedMagic && magic != expectedMagicV1) {
+            throw new McuMgrException(String.format("Wrong magic number (found 0x%08X, expected 0x%08X or 0x%08X)", magic, expectedMagic, expectedMagicV1));
         }
 
         int loadAddr = ByteUtil.byteArrayToUnsignedInt(b, 4 + offset, Endian.LITTLE, 4);
@@ -105,6 +104,6 @@ public class McuMgrImageHeader {
     }
 
     public boolean isLegacy() {
-        return mMagic == IMG_HEADER_MAGIC_V1;
+        return mMagic == McuMgrImageConfig.getHeaderMagicV1();
     }
 }

--- a/mcumgr-core/src/main/java/no/nordicsemi/android/mcumgr/image/tlv/McuMgrImageTlvInfo.java
+++ b/mcumgr-core/src/main/java/no/nordicsemi/android/mcumgr/image/tlv/McuMgrImageTlvInfo.java
@@ -7,6 +7,7 @@
 package no.nordicsemi.android.mcumgr.image.tlv;
 
 import no.nordicsemi.android.mcumgr.exception.McuMgrException;
+import no.nordicsemi.android.mcumgr.image.McuMgrImageConfig;
 import no.nordicsemi.android.mcumgr.util.ByteUtil;
 import no.nordicsemi.android.mcumgr.util.Endian;
 
@@ -39,8 +40,8 @@ public class McuMgrImageTlvInfo {
         info.mMagic = (short) ByteUtil.byteArrayToUnsignedInt(b, offset, Endian.LITTLE, 2);
         info.mTotal = (short) ByteUtil.byteArrayToUnsignedInt(b, offset + 2, Endian.LITTLE, 2);
 
-        if (info.mMagic != McuMgrImageTlv.IMG_TLV_INFO_MAGIC &&
-                info.mMagic != McuMgrImageTlv.IMG_TLV_PROTECTED_INFO_MAGIC) {
+        if (info.mMagic != McuMgrImageConfig.getTlvInfoMagic() &&
+                info.mMagic != McuMgrImageConfig.getTlvProtectedInfoMagic()) {
             throw new McuMgrException("Wrong magic number, magic=" + info.mMagic);
         }
         return info;
@@ -59,6 +60,6 @@ public class McuMgrImageTlvInfo {
     }
 
     public boolean isProtected() {
-        return mMagic == McuMgrImageTlv.IMG_TLV_PROTECTED_INFO_MAGIC;
+        return mMagic == McuMgrImageConfig.getTlvProtectedInfoMagic();
     }
 }


### PR DESCRIPTION
## Description

This change adds a public configuration API that allows client applications to override the MCUboot image magic numbers used during image validation before starting SMP OTA.

By default, behavior is unchanged. If the client app does not set any custom values, the library continues using the existing standard magic numbers.

## What Changed

* Added a new config class: *McuMgrImageConfig.java*
* Exposed static setters/getters for:
   *  Header magic
   *  Legacy header magic
   *  TLV info magic
   *  Protected TLV info magic
* Added a reset method to restore the default MCUboot values
* Updated image header parsing to read magic numbers from config instead of hardcoded constants in *McuMgrImageHeader.java*
* Updated TLV info parsing to read magic numbers from config instead of hardcoded constants in *McuMgrImageTlvInfo.java*

## Why

Some client applications use non-default image magic numbers. Today those values are hardcoded in the library, which prevents reuse in those setups.

This change makes the magic numbers configurable while preserving the current default behavior for all existing clients.

## Behavior / Compatibility

No change for existing integrations unless the new config API is explicitly used.
Default MCUboot values remain the same.
Configuration is global and intended to be set before image parsing / OTA starts.